### PR TITLE
Stations by line with placeholder values for screens

### DIFF
--- a/assets/js/components/constants/stations_by_line.js
+++ b/assets/js/components/constants/stations_by_line.js
@@ -1,0 +1,337 @@
+const STATIONS_BY_LINE = {
+    red: [
+        {
+            name: "Alewife",
+            portrait: true,
+            landscape: true
+        },
+        {
+            name: "Davis",
+            portrait: true,
+            landscape: true
+        },
+        {
+            name: "Porter",
+            portrait: true,
+            landscape: true
+        },
+        {
+            name: "Harvard",
+            portrait: true,
+            landscape: true
+        },
+        {
+            name: "Central",
+            portrait: true,
+            landscape: true
+        },
+        {
+            name: "Kendall/MIT",
+            portrait: true,
+            landscape: true
+        },
+        {
+            name: "Charles/MGH",
+            portrait: true,
+            landscape: true
+        },
+        {
+            name: "Park Street",
+            portrait: true,
+            landscape: true
+        },
+        {
+            name: "Downtown Crossing",
+            portrait: true,
+            landscape: true
+        },
+        {
+            name: "South Station",
+            portrait: true,
+            landscape: true
+        },
+        {
+            name: "Broadway",
+            portrait: true,
+            landscape: true
+        },
+        {
+            name: "Andrew",
+            portrait: true,
+            landscape: true
+        },
+        {
+            name: "JFK/UMass",
+            portrait: true,
+            landscape: true
+        },
+        {
+            name: "Savin Hill",
+            portrait: true,
+            landscape: true
+        },
+        {
+            name: "Fields Corner",
+            portrait: true,
+            landscape: true
+        },
+        {
+            name: "Shawmut",
+            portrait: true,
+            landscape: true
+        },
+        {
+            name: "Ashmont",
+            portrait: true,
+            landscape: true
+        },
+        {
+            name: "North Quincy",
+            portrait: true,
+            landscape: true
+        },
+        {
+            name: "Wollaston",
+            portrait: true,
+            landscape: true
+        },
+        {
+            name: "Quincy Center",
+            portrait: true,
+            landscape: true
+        },
+        {
+            name: "Quincy Adams",
+            portrait: true,
+            landscape: true
+        },
+        {
+            name: "Braintree",
+            portrait: true,
+            landscape: true
+        }
+    ],
+    orange: [
+        {
+            name: "Oak Grove",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Malden Center",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Wellington",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Assembly",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Sullivan Square",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Community College",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "North Station",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Haymarket",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "State",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Downtown Crossing",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Chinatown",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Tufts Medical Center",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Back Bay",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Massachusetts Avenue",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Ruggles",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Roxbury Crossing",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Jackson Square",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Stony Brook",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Green Street",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Forest Hills",
+            portrait: true,
+            landscape: false
+        }
+    ],
+    blue: [
+        {
+            name: "Bowdoin",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Government Center",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "State",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Aquarium",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Maverick",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Airport",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Wood Island",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Orient Heights",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Suffolk Downs",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Beachmont",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Revere Beach",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Wonderland",
+            portrait: true,
+            landscape: false
+        }
+    ],
+    green: [
+        {
+            name: "North Station",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Haymarket",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Government Center",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Park Street",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Boylston",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Arlington",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Copley",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Hynes Convention Center",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Kenmore",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Prudential",
+            portrait: true,
+            landscape: false
+        },
+        {
+            name: "Symphony",
+            portrait: true,
+            landscape: false
+        }
+    ]
+}
+
+export default STATIONS_BY_LINE;


### PR DESCRIPTION
The stations should all be present; the values for `portrait` and `landscape` are dummy values, which I'll replace in a future PR.