### PR TITLE
Fix s3 bucket and path in prod config

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -16,7 +16,9 @@ config :screenplay, ScreenplayWeb.Endpoint,
   cache_static_manifest: "priv/static/cache_manifest.json"
 
 config :screenplay,
-  alerts_fetch_module: Screenplay.Alerts.S3Fetch
+  alerts_fetch_module: Screenplay.Alerts.S3Fetch,
+  alerts_s3_bucket: "mbta-ctd-config",
+  alerts_s3_path: "screenplay/screenplay-dev.json"
 
 # Do not print debug messages in production
 config :logger, level: :info


### PR DESCRIPTION
Temporarily always use `screenplay-dev.json`. A future PR will use the correct file based on the environment.