### PR TITLE
Skip deleting image files which don't exist

### DIFF
--- a/lib/screenplay/outfront/sftp.ex
+++ b/lib/screenplay/outfront/sftp.ex
@@ -151,8 +151,15 @@ defmodule Screenplay.Outfront.SFTP do
       :ok ->
         :ok
 
-      {:error, msg} ->
-        _ = Logger.info("Delete image failed with: #{msg}")
+      {:error, %SFTPClient.OperationError{reason: :no_such_file}} ->
+        _ =
+          Logger.info(
+            "Skipping deleting #{orientation} image for #{station} as file does not exist"
+          )
+
+        :ok
+
+      _ ->
         delete_image(conn, station, orientation, retry - 1)
     end
   end


### PR DESCRIPTION
Rather than checking which files exist and only deleting those, try deleting all of them and catch and log any deletion operations which fail because the files don't exist.

I _think_ this is preferable because:
1. We only have to do one remote operation instead of two.
2. It plays nicer with the `FakeSFTPClient` module (since it doesn't have to report any names of files which are supposed to exist).

These shouldn't happen in the first place (except for `ZZZ_TEST_STATION`) though, so I'm logging when these happen.