### PR TITLE
fix: Aligned label text with station cards on confirmation page

### DIFF
--- a/assets/css/stacked-stations.scss
+++ b/assets/css/stacked-stations.scss
@@ -22,6 +22,9 @@
       color: $gray-800;
       font-weight: 600;
     }
+    &:first-child {
+      padding-top: 0;
+    }
   }
   &.published-alert {
     background-color: unset;


### PR DESCRIPTION
**Asana task**: [[Polish] Confirm stage](https://app.asana.com/0/1185117109217413/1200958889814525/f)

<img width="998" alt="Screen Shot 2021-11-09 at 8 56 21 AM" src="https://user-images.githubusercontent.com/10713153/140937073-98754e58-b722-4c56-b0c1-6bfdccd0ecd4.png">

<img width="1007" alt="Screen Shot 2021-11-09 at 8 55 59 AM" src="https://user-images.githubusercontent.com/10713153/140937095-08f44e05-bdd2-4c91-9ca4-be130be9fca8.png">