### PR TITLE
Add frontend ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
           cache-dependency-path: './assets'
       - run: npm --prefix assets ci
       - run: npm --prefix assets run deploy
+      - run: npm --prefix assets run format:check
       # TODO: previous steps will cover build errors, but no tests currently in project.
       # - run: npm --prefix assets test
 

--- a/assets/package.json
+++ b/assets/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "deploy": "webpack --mode production",
     "watch": "webpack --mode development --watch",
-    "format": "prettier --write \"{.,**}/*.{js,json,ts,tsx,css,scss}\""
+    "format": "prettier --write \"{.,**}/*.{js,json,ts,tsx,css,scss}\"",
+    "format:check": "prettier --check \"{.,**}/*.{js,json,ts,tsx,css,scss}\""
   },
   "dependencies": {
     "@heroicons/react": "^1.0.4",


### PR DESCRIPTION
Add npm build commands to github action to catch build errors in PR stage instead of at build/deploy time.

pre merge of #65 
![image](https://user-images.githubusercontent.com/526017/141534403-bf3e830f-1e1e-4034-989c-dff11cba4d35.png)
after:
![image](https://user-images.githubusercontent.com/526017/141534473-340638e7-2a35-4fd4-a8ab-65df27c1ad47.png)
