### PR TITLE
fix: Line select all checkbox checks itself when clicked

### DIFF
--- a/assets/js/components/AlertWizard/StationColumn.tsx
+++ b/assets/js/components/AlertWizard/StationColumn.tsx
@@ -17,9 +17,10 @@ const StationColumn = (props: StationColumnProps): JSX.Element => {
         line={props.line}
         checked={stationsByLine[props.line]
           // Ignore disabled stations when determining whether the whole line is selected
-          .filter(({landscape, portrait}) => landscape || portrait)
-          .every((lineStation) => props.selectedStations.some((x) => x.name === lineStation.name))
-        }
+          .filter(({ landscape, portrait }) => landscape || portrait)
+          .every((lineStation) =>
+            props.selectedStations.some((x) => x.name === lineStation.name)
+          )}
         checkLine={props.checkLine}
       />
       {stationsByLine[props.line].map((station) => {


### PR DESCRIPTION
**Asana task**: [[Emergency Takeover]  Fix "select line" checkbox](https://app.asana.com/0/1185117109217413/1201643279264935/f)

Disabled stations were throwing off the filter when checking if the line should be checked. Changed it so those stations are not counted.