### PR TITLE
fix: Map segment orientation when sorting

### DIFF
--- a/assets/css/place-row.scss
+++ b/assets/css/place-row.scss
@@ -53,6 +53,10 @@
   &__Blue {
     width: 20px;
   }
+
+  &__flipped {
+    transform: scaleY(-1);
+  }
 }
 
 .map-segment {

--- a/assets/js/components/Dashboard/Dashboard.tsx
+++ b/assets/js/components/Dashboard/Dashboard.tsx
@@ -204,6 +204,7 @@ const Dashboard = (props: { page: string }): JSX.Element => {
                 filteredLine={
                   isOnlyFilteredByRoute() ? getFilteredLine() : null
                 }
+                defaultSort={sortDirection === 0}
               />
             ))}
           </Accordion>

--- a/assets/js/components/Dashboard/PlaceRow.tsx
+++ b/assets/js/components/Dashboard/PlaceRow.tsx
@@ -18,6 +18,7 @@ interface PlaceRowProps {
   place: Place;
   eventKey: string;
   filteredLine?: string | null;
+  defaultSort: boolean;
 }
 
 /**
@@ -147,7 +148,9 @@ const PlaceRow = (props: PlaceRowProps): JSX.Element => {
           {props.filteredLine && (
             <Col
               lg="auto"
-              className={`map-segment-container map-segment-container__${props.filteredLine}`}
+              className={`map-segment-container map-segment-container__${
+                props.filteredLine
+              } ${!props.defaultSort ? "map-segment-container__flipped" : ""}`}
             >
               <img
                 className="map-segment"

--- a/assets/js/components/Dashboard/PlaceRow.tsx
+++ b/assets/js/components/Dashboard/PlaceRow.tsx
@@ -148,9 +148,11 @@ const PlaceRow = (props: PlaceRowProps): JSX.Element => {
           {props.filteredLine && (
             <Col
               lg="auto"
-              className={`map-segment-container map-segment-container__${
-                props.filteredLine
-              } ${!props.defaultSort ? "map-segment-container__flipped" : ""}`}
+              className={classNames(
+                "map-segment-container",
+                `map-segment-container__${props.filteredLine}`,
+                { "map-segment-container__flipped": !props.defaultSort }
+              )}
             >
               <img
                 className="map-segment"

--- a/assets/tests/components/placeRow.test.tsx
+++ b/assets/tests/components/placeRow.test.tsx
@@ -20,7 +20,7 @@ describe("PlaceRow", () => {
 
     const { getByTestId, getByAltText, queryByAltText } = render(
       <Accordion>
-        <PlaceRow place={place} eventKey="0" />
+        <PlaceRow place={place} eventKey="0" defaultSort />
       </Accordion>
     );
 
@@ -46,7 +46,7 @@ describe("PlaceRow", () => {
 
     const { getByTestId, getByAltText, queryByAltText } = render(
       <Accordion>
-        <PlaceRow place={place} eventKey="0" />
+        <PlaceRow place={place} eventKey="0" defaultSort />
       </Accordion>
     );
 


### PR DESCRIPTION
**Asana task**: ad-hoc

I noticed that flipping the sort order causes the map segments to be facing the wrong direction for some stations. Added a CSS class to flip the image if the sort order is flipped.
