### PR TITLE
feat: Support locations for screens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@ npm-debug.log
 # Local storage of takeover messages
 /priv/alerts.json
 /priv/places_and_screens.json
+/priv/screen_locations.json
 
 .envrc

--- a/assets/js/components/Dashboard/ScreenDetail.tsx
+++ b/assets/js/components/Dashboard/ScreenDetail.tsx
@@ -13,11 +13,14 @@ const ScreenDetail = (props: ScreenDetailProps): JSX.Element => {
       ?.label;
   };
 
+  const getScreenLocation = () =>
+    props.screens[0].location ? `/ ${props.screens[0].location}` : "";
+
   return (
     <div className="screen-detail__container">
       <div className="screen-detail__header">
         <div className="screen-detail__screen-type-location">
-          {translateScreenType()} / Location
+          {translateScreenType()} {getScreenLocation()}
         </div>
         <div className="screen-detail__report-a-problem-button">
           <ReportAProblemButton />

--- a/assets/js/models/screen.ts
+++ b/assets/js/models/screen.ts
@@ -4,4 +4,5 @@ export interface Screen {
   type: string;
   zone?: string;
   disabled: boolean;
+  location?: string;
 }

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -77,7 +77,8 @@ config :screenplay,
   local_alerts_path_spec: {:priv, "alerts.json"},
   sftp_client_module: Screenplay.Outfront.FakeSFTPClient,
   config_fetcher: Screenplay.Config.LocalFetch,
-  local_config_file_spec: {:priv, "places_and_screens.json"}
+  local_config_file_spec: {:priv, "places_and_screens.json"},
+  local_locations_file_spec: {:priv, "screen_locations.json"}
 
 config :ueberauth, Ueberauth,
   providers: [

--- a/lib/screenplay/config/local_fetch.ex
+++ b/lib/screenplay/config/local_fetch.ex
@@ -4,15 +4,19 @@ defmodule Screenplay.Config.LocalFetch do
   @behaviour Screenplay.Config.Fetch
 
   def get_config do
-    case do_get() do
-      {:ok, file_contents} -> Jason.decode(file_contents)
+    with {:ok, config_contents} <- do_get(:local_config_file_spec),
+         {:ok, location_contents} <- do_get(:local_locations_file_spec),
+         {:ok, config_json} <- Jason.decode(config_contents),
+         {:ok, location_json} <- Jason.decode(location_contents) do
+      {:ok, config_json, location_json}
+    else
       _ -> :error
     end
   end
 
   # sobelow_skip ["Traversal.FileModule"]
-  defp do_get do
-    path = local_config_path()
+  defp do_get(file_spec) do
+    path = local_path(file_spec)
 
     case File.read(path) do
       {:ok, contents} -> {:ok, contents}
@@ -20,8 +24,8 @@ defmodule Screenplay.Config.LocalFetch do
     end
   end
 
-  defp local_config_path do
-    case Application.get_env(:screenplay, :local_config_file_spec) do
+  defp local_path(file_spec) do
+    case Application.get_env(:screenplay, file_spec) do
       {:priv, file_name} -> Path.join(:code.priv_dir(:screenplay), file_name)
       {:test, file_name} -> Path.join(~w[#{File.cwd!()} test fixtures #{file_name}])
     end

--- a/lib/screenplay_web/controllers/dashboard_api_controller.ex
+++ b/lib/screenplay_web/controllers/dashboard_api_controller.ex
@@ -4,7 +4,23 @@ defmodule ScreenplayWeb.DashboardApiController do
   @config_fetcher Application.compile_env(:screenplay, :config_fetcher)
 
   def index(conn, _params) do
-    {:ok, config} = @config_fetcher.get_config()
-    json(conn, config)
+    {:ok, config, locations} = @config_fetcher.get_config()
+    json(conn, update_config_with_locations(config, locations))
+  end
+
+  defp update_config_with_locations(config, locations) do
+    Enum.reduce(locations, config, fn %{"id" => id, "location" => location}, acc ->
+      update_in(
+        acc,
+        [
+          Access.filter(fn %{"screens" => screens} ->
+            Enum.find(screens, &match?(%{"id" => ^id}, &1))
+          end),
+          "screens",
+          Access.filter(&match?(%{"id" => ^id}, &1))
+        ],
+        &Map.put(&1, "location", location)
+      )
+    end)
   end
 end


### PR DESCRIPTION
**Asana task**: [[Screenplay] Indicate location on screen name](https://app.asana.com/0/1185117109217413/1202505849835058/f)

A new file needs to be created for this feature to work as expected. That file (`screen_locations.json`) will live in the same directory as `places_and_screens.json`. The contents are a list of objects with the shape `{ "id": "1", "location": "Test" }`. Each object will map to screens with the same id in `places_and_screens.json`. The frontend will then render the location in the accordion panel. If no location exists for a screen, only the screen type is displayed. 

No locations are needed for the config to work. `screen_locations.json` can be an empty list and each screen will render only the screen type. 
