### PR TITLE
Update Signs UI URLs

### DIFF
--- a/assets/js/components/Dashboard/PaessScreenDetail.tsx
+++ b/assets/js/components/Dashboard/PaessScreenDetail.tsx
@@ -11,8 +11,8 @@ const PaessScreenDetail = (props: PaessScreenDetailProps): JSX.Element => {
     // @ts-ignore Suppressing "object could be null" warning
     const { environmentName } = document.getElementById("app").dataset;
     return environmentName === "dev" || environmentName === "dev-green"
-      ? `http://signs-dev.mbtace.com/${props.stationCode}/${props.zone}`
-      : `http://signs.mbta.com/${props.stationCode}/${props.zone}`;
+      ? `https://signs-dev.mbtace.com/${props.stationCode}/${props.zone}`
+      : `https://signs.mbta.com/${props.stationCode}/${props.zone}`;
   };
 
   function getZoneLabel(zone: string) {


### PR DESCRIPTION
These urls should use https anyway, but Firefox was also not allowing the URLs to be loaded because it doesn't let you load http URLs within an https URL. I tested this in dev by editing the url directly in the html and the signs then loaded properly.

For some reason, this causes a local instance of Screenplay to not be able to load the https signs UI urls even though Firefox apparently allows loading of mixed content when loading localhost but it's more important that dev works correctly and we can work out the local version later. Or one can simply temporarily change the URLs if they wanted to view the renderings locally.