### PR TITLE
feat: Mattapan filter

### DIFF
--- a/assets/css/place-row.scss
+++ b/assets/css/place-row.scss
@@ -45,7 +45,8 @@
   &__Green-B,
   &__Green-C,
   &__Green-D,
-  &__Green-E {
+  &__Green-E,
+  &__Mattapan {
     width: 44px;
   }
 

--- a/assets/js/components/Dashboard/Dashboard.tsx
+++ b/assets/js/components/Dashboard/Dashboard.tsx
@@ -147,7 +147,10 @@ const Dashboard = (props: { page: string }): JSX.Element => {
   };
 
   const getFilteredLine = () => {
-    if (modeLineFilterValue.label.includes("Line")) {
+    if (
+      modeLineFilterValue.label.includes("Line") ||
+      modeLineFilterValue.label === "Mattapan"
+    ) {
       return modeLineFilterValue.label === "Green Line"
         ? "Green"
         : modeLineFilterValue.ids[0];

--- a/assets/js/components/Dashboard/Dashboard.tsx
+++ b/assets/js/components/Dashboard/Dashboard.tsx
@@ -91,7 +91,8 @@ const Dashboard = (props: { page: string }): JSX.Element => {
       // This catches on Silver Line, which we haven't really discussed how it should be treated.
       // Right now, the places list for SL is empty because its screens are all getting listed as buses.
       // It should probably treated as a bus route, but still a question for Adam.
-      modeLineFilterValue.label.includes("Line")
+      modeLineFilterValue.label.includes("Line") ||
+      modeLineFilterValue.label === "Mattapan"
     ) {
       return sortByStationOrder(places, sortDirection === 1);
     }

--- a/assets/js/components/Dashboard/Dashboard.tsx
+++ b/assets/js/components/Dashboard/Dashboard.tsx
@@ -88,9 +88,6 @@ const Dashboard = (props: { page: string }): JSX.Element => {
         ? places.sort((a: Place, b: Place) => (a.name > b.name ? 1 : -1))
         : places.sort((a: Place, b: Place) => (a.name < b.name ? 1 : -1));
     } else if (
-      // This catches on Silver Line, which we haven't really discussed how it should be treated.
-      // Right now, the places list for SL is empty because its screens are all getting listed as buses.
-      // It should probably treated as a bus route, but still a question for Adam.
       modeLineFilterValue.label.includes("Line") ||
       modeLineFilterValue.label === "Mattapan"
     ) {
@@ -117,7 +114,6 @@ const Dashboard = (props: { page: string }): JSX.Element => {
         );
       });
     }
-    // Can add additional filtering in if statements here.
 
     return filteredPlaces;
   };

--- a/assets/js/constants/constants.ts
+++ b/assets/js/constants/constants.ts
@@ -25,6 +25,7 @@ export const SORT_LABELS_BY_LINE: Record<string, [string, string]> = {
   Green: ["WESTBOUND", "EASTBOUND"],
   Orange: ["SOUTHBOUND", "NORTHBOUND"],
   Red: ["SOUTHBOUND", "NORTHBOUND"],
+  Mattapan: ["OUTBOUND", "INBOUND"],
 };
 
 export const SCREEN_TYPES = [

--- a/assets/js/constants/constants.ts
+++ b/assets/js/constants/constants.ts
@@ -12,6 +12,7 @@ export const MODES_AND_LINES = [
   { label: "Green Line D", ids: ["Green-D"], color: "#00843D" },
   { label: "Green Line E", ids: ["Green-E"], color: "#00843D" },
   { label: "Blue Line", ids: ["Blue"], color: "#003DA5" },
+  { label: "Mattapan", ids: ["Mattapan"], color: "#DA291C" },
   { label: "Silver Line", ids: ["Silver"], color: "#7C878E" },
   { label: "Bus", ids: ["Bus"], color: "#FFC72C" },
   { label: "Commuter Rail", ids: ["CR"], color: "#80276C" },

--- a/assets/js/constants/stationOrder.ts
+++ b/assets/js/constants/stationOrder.ts
@@ -850,6 +850,40 @@ const STATION_ORDER_BY_LINE: StationsByLine = {
       inlineMap: "Green-E-Trunk-Bottom",
     },
   ],
+  mattapan: [
+    {
+      name: "Ashmont",
+      inlineMap: "Red-Trunk-Top",
+    },
+    {
+      name: "Cedar Grove",
+      inlineMap: "Red-Trunk-Middle",
+    },
+    {
+      name: "Butler",
+      inlineMap: "Red-Trunk-Middle",
+    },
+    {
+      name: "Milton",
+      inlineMap: "Red-Trunk-Middle",
+    },
+    {
+      name: "Central Avenue",
+      inlineMap: "Red-Trunk-Middle",
+    },
+    {
+      name: "Valley Road",
+      inlineMap: "Red-Trunk-Middle",
+    },
+    {
+      name: "Capen Street",
+      inlineMap: "Red-Trunk-Middle",
+    },
+    {
+      name: "Mattapan",
+      inlineMap: "Red-Trunk-Middle",
+    }
+  ],
 };
 
 export default STATION_ORDER_BY_LINE;

--- a/assets/js/constants/stationOrder.ts
+++ b/assets/js/constants/stationOrder.ts
@@ -882,7 +882,7 @@ const STATION_ORDER_BY_LINE: StationsByLine = {
     {
       name: "Mattapan",
       inlineMap: "Red-Trunk-Bottom",
-    }
+    },
   ],
 };
 

--- a/assets/js/constants/stationOrder.ts
+++ b/assets/js/constants/stationOrder.ts
@@ -881,7 +881,7 @@ const STATION_ORDER_BY_LINE: StationsByLine = {
     },
     {
       name: "Mattapan",
-      inlineMap: "Red-Trunk-Middle",
+      inlineMap: "Red-Trunk-Bottom",
     }
   ],
 };


### PR DESCRIPTION
**Asana task**: [📺▶️ : 🇵🇱 | Add Mattapan Line filter](https://app.asana.com/0/1185117109217413/1202773104374781/f)

This PR adds a filter for Mattapan on the places list. When filtered, the stops are in order and a map segment is displayed.
