### PR TITLE
polish: Prevent row collapse when ScreenDetail card is clicked.

### DIFF
--- a/assets/js/components/Dashboard/ScreenDetail.tsx
+++ b/assets/js/components/Dashboard/ScreenDetail.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { SyntheticEvent } from "react";
 import { Screen } from "../../models/screen";
 import ReportAProblemButton from "./ReportAProblemButton";
 import { SCREEN_TYPES } from "../../constants/constants";
@@ -82,6 +82,7 @@ const ScreenDetail = (props: ScreenDetailProps): JSX.Element => {
         [`screen-detail__container--paess screen-detail__container--paess-${getPaessRouteLetter()}`]:
           isPaess,
       })}
+      onClick={(e: SyntheticEvent) => e.stopPropagation()}
     >
       <div className="screen-detail__header">
         <div


### PR DESCRIPTION
**Asana task**: [Places list: Prevent expanded place row from closing when simulation panels are clicked](https://app.asana.com/0/0/1202839698975983/f)

At the moment, nothing should happen when the ScreenDetail card or simulation is clicked. Adding `stopPropagation` keeps the row from collapsing.