### PR TITLE
polish: Horizontal overflow for v1 sims

### DIFF
--- a/assets/css/screenplay-container.scss
+++ b/assets/css/screenplay-container.scss
@@ -9,6 +9,7 @@
     flex-direction: column;
     height: 100%;
     overflow-y: scroll;
+    overflow-x: hidden;
 
     .page-content__header {
       font-weight: 700;


### PR DESCRIPTION
**Asana task**: [V1 Bus e-ink bug: opening 1624 Blue Hill Ave @ Mattapan Sq makes a horizontal scrollbar](https://app.asana.com/0/0/1202842194729176/f)

Not 100% sure where the extra width was coming from, but hiding the overflow prevents it from appearing. All of our content is contained in the viewport anyway, so no actual content should be cut off.
