### PR TITLE
tweak: Omit hidden-from-screenplay screens when generating places_and_screens.json

### DIFF
--- a/scripts/fetch_places_and_screens.exs
+++ b/scripts/fetch_places_and_screens.exs
@@ -1,6 +1,6 @@
 # Script to gather screenplay places and screens.
 #
-# Example usage: API_V3_KEY=<your_key_here> mix run scripts/places_and_screens.exs --environment prod
+# Example usage: API_V3_KEY=<your_key_here> mix run scripts/fetch_places_and_screens.exs --environment prod
 
 {opts, _, _} =
   System.argv()
@@ -76,6 +76,9 @@ parsed = Jason.decode!(file)
 
 formatted_screens =
   parsed["screens"]
+  # Certain screens (test screens, ones we've configured for non-MBTA locations) are intentionally not included in Screenplay,
+  # and marked as such with the `hidden_from_screenplay` boolean field.
+  |> Enum.reject(&match?({_id, %{"hidden_from_screenplay" => true}}, &1))
   # This reduce allows us to split out a single config into multiple places.
   # Only splits out DUPs, but can be modified to work with other screen types.
   |> Enum.reduce(

--- a/scripts/fetch_places_and_screens.exs
+++ b/scripts/fetch_places_and_screens.exs
@@ -79,10 +79,9 @@ formatted_screens =
   # Certain screens (test screens, ones we've configured for non-MBTA locations) are intentionally not included in Screenplay,
   # and marked as such with the `hidden_from_screenplay` boolean field.
   |> Enum.reject(&match?({_id, %{"hidden_from_screenplay" => true}}, &1))
-  # This reduce allows us to split out a single config into multiple places.
+  # This flat_map allows us to split out a single config into multiple places.
   # Only splits out DUPs, but can be modified to work with other screen types.
-  |> Enum.reduce(
-    [],
+  |> Enum.flat_map(
     fn
       {id,
        %{
@@ -91,14 +90,13 @@ formatted_screens =
            "primary" => %{"sections" => [%{"stop_ids" => primary_stop_ids} | _]},
            "secondary" => %{"sections" => []}
          }
-       } = stuff},
-      acc ->
+       } = stuff} ->
         primary =
           Enum.map(primary_stop_ids, fn stop_id ->
             {id, Map.put(stuff, "stop", stop_id)}
           end)
 
-        acc ++ primary
+        primary
 
       {id,
        %{
@@ -107,8 +105,7 @@ formatted_screens =
            "primary" => %{"sections" => [%{"stop_ids" => primary_stop_ids} | _]},
            "secondary" => %{"sections" => [%{"stop_ids" => secondary_stop_ids} | _]}
          }
-       } = stuff},
-      acc ->
+       } = stuff} ->
         primary =
           Enum.map(primary_stop_ids, fn stop_id ->
             {id, Map.put(stuff, "stop", stop_id)}
@@ -119,7 +116,7 @@ formatted_screens =
             {id, Map.put(stuff, "stop", stop_id)}
           end)
 
-        acc ++ primary ++ secondary
+        primary ++ secondary
 
       {id,
        %{
@@ -127,8 +124,7 @@ formatted_screens =
          "app_params" => %{
            "sections" => sections
          }
-       } = stuff},
-      acc ->
+       } = stuff} ->
         stops =
           Enum.flat_map(sections, fn %{"query" => %{"params" => %{"stop_ids" => stop_ids}}} ->
             stop_ids
@@ -137,10 +133,10 @@ formatted_screens =
             {id, Map.put(stuff, "stop", stop_id)}
           end)
 
-        acc ++ stops
+        stops
 
-      screen, acc ->
-        acc ++ [screen]
+      screen ->
+        [screen]
     end
   )
 


### PR DESCRIPTION
**Asana task**: ad hoc / pre-launch polish

This adds a line to the script that generates places_and_screens.json, making it respect the new `hidden_from_screenplay` config field when fetching screens config.

Plus one small refactor to the script: replaced an `Enum.reduce` with an `Enum.flat_map` that does the same thing.

Tested informally by hiding 2 screens in screens-dev admin and running the script pointed at dev with some debug lines:
```
$ mix run scripts/fetch_places_and_screens.exs --environment dev
BEFORE screen count: 206
AFTER screen count: 204
```
