### PR TITLE
[Screenplay Polish] - Missing subtle dimension on rows

### DIFF
--- a/assets/css/place-row.scss
+++ b/assets/css/place-row.scss
@@ -108,7 +108,3 @@
   margin: 0 12px 0 12px;
   border-radius: 8px;
 }
-
-.place-row::after {
-  border-radius: 8px;
-}

--- a/assets/css/place-row.scss
+++ b/assets/css/place-row.scss
@@ -1,5 +1,4 @@
 .place-row {
-  border: 1px transparent;
   border-radius: 8px;
   background-image: linear-gradient(
     180deg,

--- a/assets/css/place-row.scss
+++ b/assets/css/place-row.scss
@@ -1,7 +1,14 @@
 .place-row {
+  border: 1px transparent;
+  border-radius: 8px;
+  background-image: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.2) 0,
+    rgba(255, 255, 255, 0) 1px
+  );
+
   background-color: $cool-gray-30;
   box-shadow: 0px 4px 32px rgba(0, 0, 0, 0.25);
-  border-radius: 8px;
   margin-bottom: 2px;
   border-bottom: 0px;
 
@@ -99,5 +106,9 @@
 .place-row__screen-preview-container {
   background-color: $cool-gray-20;
   margin: 0 12px 0 12px;
+  border-radius: 8px;
+}
+
+.place-row::after {
   border-radius: 8px;
 }


### PR DESCRIPTION
[Task in Notion](https://www.notion.so/mbta-downtown-crossing/Missing-subtle-dimension-on-rows-7e189e6ff11447648f1075044e3bacfa)

Evidently `border-radius`, `border-image-source`, and `linear-gradient` don't play too nicely together. The current solution works but is missing the gradient on the sides and only shows it along the top of a row.

![Screen Shot 2022-09-20 at 4 43 13 PM](https://user-images.githubusercontent.com/16074540/191360656-8bc52eff-aaf7-4060-bf12-006fd039c9a2.png)
