### PR TITLE
Column text styling

### DIFF
--- a/assets/css/place-row.scss
+++ b/assets/css/place-row.scss
@@ -82,7 +82,7 @@
 
   .place-row__screen-types,
   .place-row__status {
-    font-weight: 500;
+    font-weight: 400;
     font-size: 16px;
     line-height: 24px;
     .spacer {

--- a/assets/css/place-row.scss
+++ b/assets/css/place-row.scss
@@ -85,6 +85,9 @@
     font-weight: 500;
     font-size: 16px;
     line-height: 24px;
+    .spacer {
+      padding: 0 8px;
+    }
   }
 
   .place-row__mode-line-icon:not(:last-child) {

--- a/assets/js/components/Dashboard/PlaceRow.tsx
+++ b/assets/js/components/Dashboard/PlaceRow.tsx
@@ -36,26 +36,18 @@ const PlaceRow = (props: PlaceRowProps): JSX.Element => {
   const hasScreens =
     screens.length > 0 && screens.filter((screen) => !screen.hidden).length > 0;
 
-  const formatScreenTypes = () => {
-    if (!hasScreens) {
-      return "no screens";
-    }
 
-    const typeMap: Record<string, string> = {
-      pa_ess: "PA",
-      bus_shelter_v2: "Bus Shelter",
-      pre_fare_v2: "Prefare",
-      dup: "DUP",
-      gl_eink_single: "GL E-Ink",
-      gl_eink_double: "GL E-Ink",
-      gl_eink_v2: "GL E-Ink",
-      bus_eink: "Bus E-Ink",
-      bus_eink_v2: "Bus E-Ink",
-      solari: "Solari",
-    };
-
-    const types = new Set(sortScreens().map((screen) => typeMap[screen.type]));
-    return Array.from(types).join(" · ");
+  const typeMap: Record<string, string> = {
+    pa_ess: "PA",
+    bus_shelter_v2: "Bus Shelter",
+    pre_fare_v2: "Prefare",
+    dup: "DUP",
+    gl_eink_single: "GL E-Ink",
+    gl_eink_double: "GL E-Ink",
+    gl_eink_v2: "GL E-Ink",
+    bus_eink: "Bus E-Ink",
+    bus_eink_v2: "Bus E-Ink",
+    solari: "Solari",
   };
 
   const sortScreens = (screenList: Screen[] = screens) => {
@@ -78,6 +70,8 @@ const PlaceRow = (props: PlaceRowProps): JSX.Element => {
         : -1
     );
   };
+  
+  const screenTypes = !hasScreens ? ["no screens"] : Array.from(new Set(sortScreens().map((screen) => typeMap[screen.type])))
 
   const filterAndGroupScreens = (screens: Screen[]) => {
     const visibleScreens = screens.filter((screen) => !screen.hidden);
@@ -205,7 +199,9 @@ const PlaceRow = (props: PlaceRowProps): JSX.Element => {
             className="place-row__screen-types pe-3"
             data-testid="place-screen-types"
           >
-            {formatScreenTypes()}
+            {screenTypes.map((type, index) => index < (screenTypes.length - 1)
+              ? <span key={index}>{type}<span className="spacer">·</span></span>
+              : type)}
           </Col>
           <Col lg={3} className="place-row__status" data-testid="place-status">
             {hasScreens ? "Auto" : "—"}

--- a/assets/js/components/Dashboard/PlaceRow.tsx
+++ b/assets/js/components/Dashboard/PlaceRow.tsx
@@ -36,7 +36,6 @@ const PlaceRow = (props: PlaceRowProps): JSX.Element => {
   const hasScreens =
     screens.length > 0 && screens.filter((screen) => !screen.hidden).length > 0;
 
-
   const typeMap: Record<string, string> = {
     pa_ess: "PA",
     bus_shelter_v2: "Bus Shelter",
@@ -70,8 +69,10 @@ const PlaceRow = (props: PlaceRowProps): JSX.Element => {
         : -1
     );
   };
-  
-  const screenTypes = !hasScreens ? ["no screens"] : Array.from(new Set(sortScreens().map((screen) => typeMap[screen.type])))
+
+  const screenTypes = !hasScreens
+    ? ["no screens"]
+    : Array.from(new Set(sortScreens().map((screen) => typeMap[screen.type])));
 
   const filterAndGroupScreens = (screens: Screen[]) => {
     const visibleScreens = screens.filter((screen) => !screen.hidden);
@@ -199,9 +200,16 @@ const PlaceRow = (props: PlaceRowProps): JSX.Element => {
             className="place-row__screen-types pe-3"
             data-testid="place-screen-types"
           >
-            {screenTypes.map((type, index) => index < (screenTypes.length - 1)
-              ? <span key={index}>{type}<span className="spacer">·</span></span>
-              : type)}
+            {screenTypes.map((type, index) =>
+              index < screenTypes.length - 1 ? (
+                <span key={index}>
+                  {type}
+                  <span className="spacer">·</span>
+                </span>
+              ) : (
+                type
+              )
+            )}
           </Col>
           <Col lg={3} className="place-row__status" data-testid="place-status">
             {hasScreens ? "Auto" : "—"}

--- a/assets/tests/components/placeRow.test.tsx
+++ b/assets/tests/components/placeRow.test.tsx
@@ -42,7 +42,7 @@ describe("PlaceRow", () => {
     fireEvent.click(getByTestId("place-row"));
     expect(getByTestId("place-row").className).toBe("place-row open");
     expect(getByTestId("place-screen-types").textContent).toBe(
-      "DUP · Bus Shelter · Solari"
+      "DUP·Bus Shelter·Solari"
     );
     expect(getByTestId("place-status").textContent).toBe("Auto");
     expect(getByAltText("Green-B")).toBeInTheDocument();

--- a/lib/screenplay_web/templates/unauthorized/index.html.heex
+++ b/lib/screenplay_web/templates/unauthorized/index.html.heex
@@ -1,1 +1,1 @@
-You are not authorized. If you believe you should have access, contact phandorff@mbta.com.
+You are not authorized. If you believe you should have access, contact hpurcell@mbta.com.


### PR DESCRIPTION
[Polish task](https://www.notion.so/mbta-downtown-crossing/c879496a39fd4e62969fe1d0eecdfa01?v=f7ad0a8b40784aaebb1aaac3d417bb39&p=dff514270aa64b34b98d4e69f4072de8&pm=s). 

Convert screen-types spacer from text to element to add classname + padding. 
Reduced font-weight for screens / status text.
Changed "unauthorized" message to have my email instead of Paul's.

