### PR TITLE
Add special layout for Solari for screen cards

### DIFF
--- a/assets/css/place-row.scss
+++ b/assets/css/place-row.scss
@@ -32,10 +32,6 @@
     &:last-child {
       border-radius: 0 0 8px 8px;
     }
-
-    &.open {
-      border-radius: 8px;
-    }
   }
 
   .place-row__toggle {
@@ -103,4 +99,8 @@
   background-color: $cool-gray-20;
   margin: 0 12px 0 12px;
   border-radius: 8px;
+
+  > :not(:last-child) {
+    margin-bottom: 4px;
+  }
 }

--- a/assets/css/screen-detail.scss
+++ b/assets/css/screen-detail.scss
@@ -14,7 +14,7 @@
       margin-right: 4px;
     }
   }
-  
+
   &--paess {
     padding: 0px 0px 16px;
   }

--- a/assets/css/screen-detail.scss
+++ b/assets/css/screen-detail.scss
@@ -1,8 +1,20 @@
+.screen-detail__solari-layout {
+  display: flex;
+  justify-content: space-between;
+}
+
 .screen-detail__container {
   background-color: $cool-gray-40;
   border-radius: 8px;
   padding: 24px 16px;
 
+  &--solari {
+    flex-grow: 1;
+    &:not(:last-child) {
+      margin-right: 4px;
+    }
+  }
+  
   &--paess {
     padding: 0px 0px 16px;
   }
@@ -37,10 +49,6 @@
 
   &--paess-s {
     background: linear-gradient(to bottom, $mbta-bus 40px, $cool-gray-40 40px);
-  }
-
-  &:not(:last-child) {
-    margin-bottom: 4px;
   }
 }
 

--- a/assets/js/components/Dashboard/PlaceRow.tsx
+++ b/assets/js/components/Dashboard/PlaceRow.tsx
@@ -87,8 +87,8 @@ const PlaceRow = (props: PlaceRowProps): JSX.Element => {
       .filter((screen) => screen.type !== "solari" && screen.type !== "pa_ess")
       .map((screen) => [screen]);
 
-    groupedScreens.push(solariScreens)
-    
+    groupedScreens.push(solariScreens);
+
     if (paEssScreens.length > 0) {
       groupPaEssScreensbyRoute(paEssScreens, groupedScreens);
     }

--- a/assets/js/components/Dashboard/PlaceRow.tsx
+++ b/assets/js/components/Dashboard/PlaceRow.tsx
@@ -77,13 +77,18 @@ const PlaceRow = (props: PlaceRowProps): JSX.Element => {
 
   const filterAndGroupScreens = (screens: Screen[]) => {
     const visibleScreens = screens.filter((screen) => !screen.hidden);
+    const solariScreens = visibleScreens.filter(
+      (screen) => screen.type === "solari"
+    );
     const paEssScreens = visibleScreens.filter(
       (screen) => screen.type === "pa_ess"
     );
     const groupedScreens = visibleScreens
-      .filter((screen) => screen.type !== "pa_ess")
+      .filter((screen) => screen.type !== "solari" && screen.type !== "pa_ess")
       .map((screen) => [screen]);
 
+    groupedScreens.push(solariScreens)
+    
     if (paEssScreens.length > 0) {
       groupPaEssScreensbyRoute(paEssScreens, groupedScreens);
     }

--- a/assets/js/components/Dashboard/ScreenDetail.tsx
+++ b/assets/js/components/Dashboard/ScreenDetail.tsx
@@ -13,28 +13,28 @@ interface ScreenDetailProps {
 const ScreenDetail = (props: ScreenDetailProps): JSX.Element => {
   const isSolari = props.screens.every((screen) => screen.type === "solari");
 
-  return (
-    isSolari
-    ? <div className="screen-detail__solari-layout">
+  return isSolari ? (
+    <div className="screen-detail__solari-layout">
       {props.screens.map((screens, index) => (
-        <ScreenCard
-          {...props}
-          key={index}
-          screens={[screens]}
-        />
+        <ScreenCard {...props} key={index} screens={[screens]} />
       ))}
     </div>
-    : <ScreenCard {...props}/>
+  ) : (
+    <ScreenCard {...props} />
   );
 };
 
 const ScreenCard = (props: ScreenDetailProps) => {
-  const {screens, isOpen} = props
+  const { screens, isOpen } = props;
   const isPaess = screens.every((screen) => screen.type === "pa_ess");
   const isSolari = screens.every((screen) => screen.type === "solari");
-  const paessRouteLetter = screens[0].station_code ? screens[0].station_code.charAt(0).toLowerCase() : "";
+  const paessRouteLetter = screens[0].station_code
+    ? screens[0].station_code.charAt(0).toLowerCase()
+    : "";
 
-  const translateScreenType = SCREEN_TYPES.find(({ ids }) => ids.includes(screens[0].type))?.label;
+  const translateScreenType = SCREEN_TYPES.find(({ ids }) =>
+    ids.includes(screens[0].type)
+  )?.label;
 
   const getPaessRoute = (routeLetter: string) => {
     switch (routeLetter) {
@@ -53,7 +53,11 @@ const ScreenCard = (props: ScreenDetailProps) => {
     }
   };
 
-  const getScreenLocation = isPaess ? `/ ${getPaessRoute(paessRouteLetter)}` : screens[0].location ? `/ ${screens[0].location}` : ""
+  const getScreenLocation = isPaess
+    ? `/ ${getPaessRoute(paessRouteLetter)}`
+    : screens[0].location
+    ? `/ ${screens[0].location}`
+    : "";
 
   const generateSource = (screen: Screen) => {
     const { id, type } = screen;
@@ -89,8 +93,7 @@ const ScreenCard = (props: ScreenDetailProps) => {
       className={classNames("screen-detail__container", {
         [`screen-detail__container--paess screen-detail__container--paess-${paessRouteLetter}`]:
           isPaess,
-        [`screen-detail__container--solari`]:
-          isSolari,
+        [`screen-detail__container--solari`]: isSolari,
       })}
       onClick={(e: SyntheticEvent) => e.stopPropagation()}
     >
@@ -136,7 +139,7 @@ const ScreenCard = (props: ScreenDetailProps) => {
           ))
         ))}
     </div>
-  )
-}
+  );
+};
 
 export default ScreenDetail;

--- a/assets/js/components/Dashboard/ScreenDetail.tsx
+++ b/assets/js/components/Dashboard/ScreenDetail.tsx
@@ -32,7 +32,7 @@ const ScreenCard = (props: ScreenDetailProps) => {
     ? screens[0].station_code.charAt(0).toLowerCase()
     : "";
 
-  const translateScreenType = SCREEN_TYPES.find(({ ids }) =>
+  const translatedScreenType = SCREEN_TYPES.find(({ ids }) =>
     ids.includes(screens[0].type)
   )?.label;
 
@@ -105,7 +105,7 @@ const ScreenCard = (props: ScreenDetailProps) => {
             "screen-detail__screen-type-location--paess": isPaess,
           })}
         >
-          {translateScreenType} {getScreenLocation}
+          {translatedScreenType} {getScreenLocation}
         </div>
         {screens[0].type === "dup" && (
           <div className="screen-detail__dup-ad-text">

--- a/assets/js/components/Dashboard/ScreenDetail.tsx
+++ b/assets/js/components/Dashboard/ScreenDetail.tsx
@@ -11,18 +11,30 @@ interface ScreenDetailProps {
 }
 
 const ScreenDetail = (props: ScreenDetailProps): JSX.Element => {
-  const translateScreenType = () => {
-    return SCREEN_TYPES.find(({ ids }) => ids.includes(props.screens[0].type))
-      ?.label;
-  };
+  const isSolari = props.screens.every((screen) => screen.type === "solari");
 
-  const isPaess = props.screens.every((screen) => screen.type === "pa_ess");
+  return (
+    isSolari
+    ? <div className="screen-detail__solari-layout">
+      {props.screens.map((screens, index) => (
+        <ScreenCard
+          {...props}
+          key={index}
+          screens={[screens]}
+        />
+      ))}
+    </div>
+    : <ScreenCard {...props}/>
+  );
+};
 
-  const getPaessRouteLetter = () => {
-    return props.screens[0].station_code
-      ? props.screens[0].station_code.charAt(0).toLowerCase()
-      : "";
-  };
+const ScreenCard = (props: ScreenDetailProps) => {
+  const {screens, isOpen} = props
+  const isPaess = screens.every((screen) => screen.type === "pa_ess");
+  const isSolari = screens.every((screen) => screen.type === "solari");
+  const paessRouteLetter = screens[0].station_code ? screens[0].station_code.charAt(0).toLowerCase() : "";
+
+  const translateScreenType = SCREEN_TYPES.find(({ ids }) => ids.includes(screens[0].type))?.label;
 
   const getPaessRoute = (routeLetter: string) => {
     switch (routeLetter) {
@@ -41,11 +53,7 @@ const ScreenDetail = (props: ScreenDetailProps): JSX.Element => {
     }
   };
 
-  const getScreenLocation = () => {
-    if (isPaess) {
-      return `/ ${getPaessRoute(getPaessRouteLetter())}`;
-    } else props.screens[0].location ? `/ ${props.screens[0].location}` : "";
-  };
+  const getScreenLocation = isPaess ? `/ ${getPaessRoute(paessRouteLetter)}` : screens[0].location ? `/ ${screens[0].location}` : ""
 
   const generateSource = (screen: Screen) => {
     const { id, type } = screen;
@@ -79,8 +87,10 @@ const ScreenDetail = (props: ScreenDetailProps): JSX.Element => {
   return (
     <div
       className={classNames("screen-detail__container", {
-        [`screen-detail__container--paess screen-detail__container--paess-${getPaessRouteLetter()}`]:
+        [`screen-detail__container--paess screen-detail__container--paess-${paessRouteLetter}`]:
           isPaess,
+        [`screen-detail__container--solari`]:
+          isSolari,
       })}
       onClick={(e: SyntheticEvent) => e.stopPropagation()}
     >
@@ -88,13 +98,13 @@ const ScreenDetail = (props: ScreenDetailProps): JSX.Element => {
         <div
           className={classNames("screen-detail__screen-type-location", {
             "screen-detail__screen-type-location--paess-s":
-              isPaess && getPaessRouteLetter() == "s",
+              isPaess && paessRouteLetter == "s",
             "screen-detail__screen-type-location--paess": isPaess,
           })}
         >
-          {translateScreenType()} {getScreenLocation()}
+          {translateScreenType} {getScreenLocation}
         </div>
-        {props.screens[0].type === "dup" && (
+        {screens[0].type === "dup" && (
           <div className="screen-detail__dup-ad-text">
             Cycle in the ad loop for 7.5 seconds every 45 seconds
           </div>
@@ -105,14 +115,14 @@ const ScreenDetail = (props: ScreenDetailProps): JSX.Element => {
           </div>
         )}
       </div>
-      {props.isOpen &&
+      {isOpen &&
         (isPaess ? (
           <PaessDetailContainer
-            key={props.screens[0].station_code}
-            screens={props.screens}
+            key={screens[0].station_code}
+            screens={screens}
           ></PaessDetailContainer>
         ) : (
-          props.screens.map((screen) => (
+          screens.map((screen) => (
             <div
               key={screen.id}
               className={`screen-detail__iframe-container screen-detail__iframe-container--${screen.type}`}
@@ -126,7 +136,7 @@ const ScreenDetail = (props: ScreenDetailProps): JSX.Element => {
           ))
         ))}
     </div>
-  );
-};
+  )
+}
 
 export default ScreenDetail;


### PR DESCRIPTION
[Notion](https://www.notion.so/mbta-downtown-crossing/Solari-screens-should-stack-side-by-side-072a894f2d8440a4ae262f6b1fb04e4c)

If the screen type is Solari, we want to wrap all said Solari screens in a different layout component that lets the screen cards flex and fill a row. (Currently, we only ever expect to see <2 Solari screens, and the flex method looks good up to 3 screens.)