### PR TITLE
fix: Force filter dropdown button to not have left border-radius when a filter is selected

### DIFF
--- a/assets/css/filter-dropdown.scss
+++ b/assets/css/filter-dropdown.scss
@@ -1,5 +1,6 @@
 .filter-dropdown__button-group {
   width: 100%;
+
   .filter-dropdown__dropdown {
     .filter-dropdown__dropdown-button {
       border-color: transparent;
@@ -8,27 +9,31 @@
       line-height: 24px;
 
       &--large {
+
         &:hover,
         &:focus {
-          background-color: $main-blue !important;
+          background-color: $main-blue  !important;
         }
       }
     }
   }
 
   &:not(.filter-dropdown__button-group--modes-and-lines) {
+
     .filter-dropdown__clear-button,
-    .filter-dropdown__dropdown > .filter-dropdown__dropdown-button--small {
-      background-color: $main-blue !important;
+    .filter-dropdown__dropdown>.filter-dropdown__dropdown-button--small {
+      background-color: $main-blue  !important;
     }
   }
 
   .filter-dropdown__clear-button {
     border: transparent;
     border-radius: 6px 0 0 6px !important;
+
     &:hover {
       opacity: 0.6;
     }
+
     flex-grow: 0;
     height: 36px;
     min-width: 34px;
@@ -39,9 +44,9 @@
   .filter-dropdown__dropdown {
     flex-grow: 1;
 
-    &:not(:only-child) > .filter-dropdown__dropdown-button {
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
+    &:not(:only-child)>.filter-dropdown__dropdown-button {
+      border-top-left-radius: 0 !important;
+      border-bottom-left-radius: 0 !important;
     }
 
     .filter-dropdown__dropdown-button {
@@ -71,7 +76,7 @@
     .filter-dropdown__dropdown-menu {
       padding: 8px 8px 0 8px;
 
-      & > ul {
+      &>ul {
         padding-left: 0;
       }
     }

--- a/assets/css/filter-dropdown.scss
+++ b/assets/css/filter-dropdown.scss
@@ -9,20 +9,18 @@
       line-height: 24px;
 
       &--large {
-
         &:hover,
         &:focus {
-          background-color: $main-blue  !important;
+          background-color: $main-blue !important;
         }
       }
     }
   }
 
   &:not(.filter-dropdown__button-group--modes-and-lines) {
-
     .filter-dropdown__clear-button,
-    .filter-dropdown__dropdown>.filter-dropdown__dropdown-button--small {
-      background-color: $main-blue  !important;
+    .filter-dropdown__dropdown > .filter-dropdown__dropdown-button--small {
+      background-color: $main-blue !important;
     }
   }
 
@@ -44,7 +42,7 @@
   .filter-dropdown__dropdown {
     flex-grow: 1;
 
-    &:not(:only-child)>.filter-dropdown__dropdown-button {
+    &:not(:only-child) > .filter-dropdown__dropdown-button {
       border-top-left-radius: 0 !important;
       border-bottom-left-radius: 0 !important;
     }
@@ -76,7 +74,7 @@
     .filter-dropdown__dropdown-menu {
       padding: 8px 8px 0 8px;
 
-      &>ul {
+      & > ul {
         padding-left: 0;
       }
     }


### PR DESCRIPTION
**Asana task**: ad hoc

`!important` is necessary to override bootstrap's base styles.

![image](https://user-images.githubusercontent.com/63608771/192852908-aa11cc1b-c13d-4a01-a39d-7c43dd495266.png)
Before

![image](https://user-images.githubusercontent.com/63608771/192852837-73849a91-dbed-4099-af6f-351882b28e21.png)
After
