### PR TITLE
feat: Add optional place descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,6 @@ npm-debug.log
 /priv/alerts.json
 /priv/places_and_screens.json
 /priv/screen_locations.json
+/priv/place_descriptions.json
 
 .envrc

--- a/.gitignore
+++ b/.gitignore
@@ -34,10 +34,8 @@ npm-debug.log
 # this depending on your deployment strategy.
 /priv/static/
 
-# Local storage of takeover messages
-/priv/alerts.json
-/priv/places_and_screens.json
-/priv/screen_locations.json
-/priv/place_descriptions.json
+# All files in /priv/ are going to be for local development
+# so do not need to be tracked.
+/priv/*
 
 .envrc

--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@ This tool enables PIOs to upload urgent messages to the Outfront signs in and ou
 ## Development
 
 To start your Phoenix server:
-  * Set required env variables with
-    * `export SECRET_KEY_BASE=`. You can use the value in `config.exs`.
-    * `export GUARDIAN_SECRET_KEY=test_auth_secret`
-  * Add a `screen_locations.json` file to the `priv` directory. You can either ask an engineer for a copy of the file, or enter an empty array as its contents (`[]`). The file just needs to exist and contain an array of 0 or more `{"id": "<screen ID>", "location": "<location description>"}` objects.
-  * Install dependencies with `mix deps.get`
-  * Install Node.js dependencies by running `npm run install`
-  * Start Phoenix endpoint with `mix phx.server`
+
+- Set required env variables with
+  - `export SECRET_KEY_BASE=`. You can use the value in `config.exs`.
+  - `export GUARDIAN_SECRET_KEY=test_auth_secret`
+- Add a `screen_locations.json` file to the `priv` directory. You can either ask an engineer for a copy of the file, or enter an empty array as its contents (`[]`). The file just needs to exist and contain an array of 0 or more `{"id": "<screen ID>", "location": "<location description>"}` objects.
+- Add a `place_descriptions.json` file to the `priv` directory. You can either ask an engineer for a copy of the file, or enter an empty array as its contents (`[]`). The file just needs to exist and contain an array of 0 or more `{"id": "<screen ID>", "description": "<place description>"}` objects.
+- Install dependencies with `mix deps.get`
+- Install Node.js dependencies by running `npm run install`
+- Start Phoenix endpoint with `mix phx.server`
 
 If you want to develop on Screenplay with a local version of the Screens app, just spin up Screens (which will be at http://localhost:4000) and change the dev baseUrl in ScreenDetail.tsx to use that port 4000 url.
 

--- a/assets/js/components/Dashboard/PlaceRow.tsx
+++ b/assets/js/components/Dashboard/PlaceRow.tsx
@@ -30,7 +30,7 @@ interface PlaceRowProps {
  * Assumes it is displayed in an Accordion component from react-bootstrap.
  */
 const PlaceRow = (props: PlaceRowProps): JSX.Element => {
-  const { routes, name, screens } = props.place;
+  const { routes, name, description, screens } = props.place;
   const { activeEventKey } = useContext(AccordionContext);
   const rowOnClick = useAccordionButton(props.eventKey, () =>
     props.onClick(props.eventKey)
@@ -159,9 +159,9 @@ const PlaceRow = (props: PlaceRowProps): JSX.Element => {
     return <MapSegment station={station} line={line} />;
   };
 
-  // Function to capitalize terminal stops according to STATION_ORDER_BY_LINE
-  const formatStationName = (stationName: string) => {
+  const capitalizeTerminalStops = (stationName: string) => {
     let isTerminalStop = false;
+
     // If a filter is present, only look at stations for that filter.
     // This will prevent multi-route stops from being capitalized unless they are a terminal stop of the current filtered line.
     if (props.filteredLine) {
@@ -182,6 +182,15 @@ const PlaceRow = (props: PlaceRowProps): JSX.Element => {
     }
 
     return isTerminalStop ? stationName.toUpperCase() : stationName;
+  };
+
+  // Function to add optional description and capitalize terminal stops according to STATION_ORDER_BY_LINE
+  const formatStationName = (stationName: string, description?: string) => {
+    if (description) {
+      stationName = `${stationName} ${description}`;
+    }
+
+    return capitalizeTerminalStops(stationName);
   };
 
   return (
@@ -223,7 +232,7 @@ const PlaceRow = (props: PlaceRowProps): JSX.Element => {
               </div>
             )}
             <div className="place-row__name" data-testid="place-name">
-              {formatStationName(name)}
+              {formatStationName(name, description)}
             </div>
           </Col>
           <Col lg={1} className="d-flex justify-content-end">

--- a/assets/js/models/place.ts
+++ b/assets/js/models/place.ts
@@ -3,6 +3,7 @@ import { Screen } from "./screen";
 export interface Place {
   id: string;
   name: string;
+  description?: string;
   routes: string[];
   screens: Screen[];
   status: string;

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -79,7 +79,7 @@ config :screenplay,
   config_fetcher: Screenplay.Config.LocalFetch,
   local_config_file_spec: {:priv, "places_and_screens.json"},
   local_locations_file_spec: {:priv, "screen_locations.json"},
-  local_descriptions_file_spec: {:priv, "place_descriptions.json"}
+  local_place_descriptions_file_spec: {:priv, "place_descriptions.json"}
 
 config :ueberauth, Ueberauth,
   providers: [

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -78,7 +78,8 @@ config :screenplay,
   sftp_client_module: Screenplay.Outfront.FakeSFTPClient,
   config_fetcher: Screenplay.Config.LocalFetch,
   local_config_file_spec: {:priv, "places_and_screens.json"},
-  local_locations_file_spec: {:priv, "screen_locations.json"}
+  local_locations_file_spec: {:priv, "screen_locations.json"},
+  local_descriptions_file_spec: {:priv, "place_descriptions.json"}
 
 config :ueberauth, Ueberauth,
   providers: [

--- a/lib/screenplay/config/local_fetch.ex
+++ b/lib/screenplay/config/local_fetch.ex
@@ -6,9 +6,11 @@ defmodule Screenplay.Config.LocalFetch do
   def get_config do
     with {:ok, config_contents} <- do_get(:local_config_file_spec),
          {:ok, location_contents} <- do_get(:local_locations_file_spec),
+         {:ok, description_contents} <- do_get(:local_descriptions_file_spec),
          {:ok, config_json} <- Jason.decode(config_contents),
-         {:ok, location_json} <- Jason.decode(location_contents) do
-      {:ok, config_json, location_json}
+         {:ok, location_json} <- Jason.decode(location_contents),
+         {:ok, description_json} <- Jason.decode(description_contents) do
+      {:ok, config_json, location_json, description_json}
     else
       _ -> :error
     end

--- a/lib/screenplay/config/local_fetch.ex
+++ b/lib/screenplay/config/local_fetch.ex
@@ -6,11 +6,11 @@ defmodule Screenplay.Config.LocalFetch do
   def get_config do
     with {:ok, config_contents} <- do_get(:local_config_file_spec),
          {:ok, location_contents} <- do_get(:local_locations_file_spec),
-         {:ok, description_contents} <- do_get(:local_descriptions_file_spec),
+         {:ok, place_description_contents} <- do_get(:local_place_descriptions_file_spec),
          {:ok, config_json} <- Jason.decode(config_contents),
          {:ok, location_json} <- Jason.decode(location_contents),
-         {:ok, description_json} <- Jason.decode(description_contents) do
-      {:ok, config_json, location_json, description_json}
+         {:ok, place_description_json} <- Jason.decode(place_description_contents) do
+      {:ok, config_json, location_json, place_description_json}
     else
       _ -> :error
     end

--- a/lib/screenplay/config/s3_fetch.ex
+++ b/lib/screenplay/config/s3_fetch.ex
@@ -8,9 +8,11 @@ defmodule Screenplay.Config.S3Fetch do
   def get_config do
     with {:ok, config_contents} <- do_get(:config),
          {:ok, location_contents} <- do_get(:locations),
+         {:ok, description_contents} <- do_get(:descriptions),
          {:ok, config_json} <- Jason.decode(config_contents),
-         {:ok, location_json} <- Jason.decode(location_contents) do
-      {:ok, config_json, location_json}
+         {:ok, location_json} <- Jason.decode(location_contents),
+         {:ok, description_json} <- Jason.decode(description_contents) do
+      {:ok, config_json, location_json, description_json}
     else
       _ -> :error
     end
@@ -38,6 +40,7 @@ defmodule Screenplay.Config.S3Fetch do
     case file_spec do
       :config -> "#{base_path}/places_and_screens.json"
       :locations -> "#{base_path}/screen_locations.json"
+      :descriptions -> "#{base_path}/place_descriptions.json"
     end
   end
 end

--- a/lib/screenplay/config/s3_fetch.ex
+++ b/lib/screenplay/config/s3_fetch.ex
@@ -7,12 +7,12 @@ defmodule Screenplay.Config.S3Fetch do
 
   def get_config do
     with {:ok, config_contents} <- do_get(:config),
-         {:ok, location_contents} <- do_get(:locations),
-         {:ok, description_contents} <- do_get(:descriptions),
+         {:ok, location_contents} <- do_get(:screen_locations),
+         {:ok, place_description_contents} <- do_get(:place_descriptions),
          {:ok, config_json} <- Jason.decode(config_contents),
          {:ok, location_json} <- Jason.decode(location_contents),
-         {:ok, description_json} <- Jason.decode(description_contents) do
-      {:ok, config_json, location_json, description_json}
+         {:ok, place_description_json} <- Jason.decode(place_description_contents) do
+      {:ok, config_json, location_json, place_description_json}
     else
       _ -> :error
     end
@@ -39,8 +39,8 @@ defmodule Screenplay.Config.S3Fetch do
 
     case file_spec do
       :config -> "#{base_path}/places_and_screens.json"
-      :locations -> "#{base_path}/screen_locations.json"
-      :descriptions -> "#{base_path}/place_descriptions.json"
+      :screen_locations -> "#{base_path}/screen_locations.json"
+      :place_descriptions -> "#{base_path}/place_descriptions.json"
     end
   end
 end


### PR DESCRIPTION
**Asana task**: [[Screenplay] Group screens by stop ID, not stop name](https://app.asana.com/0/1185117109217413/1203093788250254/f)

I missed this part of the `Done When` on the above task. This is done similarly to how screen locations are added. A file called `place_descriptions.json` will be created that, at the very least, needs to have an empty array `[]`. See README for more info. If a description is provided, `PlaceRow` will show `<place_name> <description>`.