### PR TITLE
feat: Add place and screen count to AlertCard

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -9,6 +9,8 @@
 # export SECRET_KEY_BASE=
 # export GUARDIAN_SECRET_KEY=
 # export API_V3_KEY=
+# export API_V3_URL=
 # export CLARITY_TAG=
 # export ENVIRONMENT_NAME=
 # export SCREENS_URL=
+# export SIGNS_UI_URL=

--- a/.envrc.template
+++ b/.envrc.template
@@ -11,3 +11,4 @@
 # export API_V3_KEY=
 # export CLARITY_TAG=
 # export ENVIRONMENT_NAME=
+# export SCREENS_URL=

--- a/assets/js/components/Dashboard/AlertCard.tsx
+++ b/assets/js/components/Dashboard/AlertCard.tsx
@@ -6,10 +6,12 @@ import { ActivePeriod, Alert } from "../../models/alert";
 
 interface AlertCardProps {
   alert: Alert;
+  numberOfScreens: number;
+  numberOfPlaces: number;
 }
 
 const AlertCard = (props: AlertCardProps): JSX.Element => {
-  const { alert } = props;
+  const { alert, numberOfPlaces, numberOfScreens } = props;
 
   const formatEffect = (effect: string) => {
     return effect
@@ -100,7 +102,7 @@ const AlertCard = (props: AlertCardProps): JSX.Element => {
         <div className="alert-card__place-details__alert-id">ID {alert.id}</div>
         <div className="alert-card__place-details__place-count">
           <span className="alert-card__place-details__place-count__number">
-            XX
+            {numberOfPlaces}
           </span>{" "}
           <span className="alert-card__place-details__place-count__text">
             places
@@ -108,7 +110,7 @@ const AlertCard = (props: AlertCardProps): JSX.Element => {
         </div>
         <div className="alert-card__place-details__screen-count">
           <span className="alert-card__place-details__screen-count__number">
-            XX
+            {numberOfScreens}
           </span>{" "}
           <span className="alert-card__place-details__screen-count__text">
             screens

--- a/assets/js/components/Dashboard/AlertsPage.tsx
+++ b/assets/js/components/Dashboard/AlertsPage.tsx
@@ -145,7 +145,6 @@ const AlertsPage: ComponentType<Props> = (props: Props) => {
   ) => {
     return alerts.filter((alert) => {
       // Get this alert's list of affected screens.
-      // Later should be replaced with a call to memcached?
       const screensWithAlert = screensByAlertMap[alert.id];
 
       return screensWithAlert

--- a/assets/js/components/Dashboard/AlertsPage.tsx
+++ b/assets/js/components/Dashboard/AlertsPage.tsx
@@ -178,6 +178,22 @@ const AlertsPage: ComponentType<Props> = (props: Props) => {
     return Date.parse(end1) - Date.parse(end2);
   };
 
+  const getNumberOfAffectedPlaces = (screensByAlert: string[]) => {
+    // Using a Set so we don't have to worry about counting a place more than once.
+    const placesCounted = new Set();
+
+    props.places.forEach((place) => {
+      if (
+        place.screens.filter((screen) => screensByAlert.includes(screen.id))
+          .length > 0
+      ) {
+        placesCounted.add(place.id);
+      }
+    });
+
+    return placesCounted.size;
+  };
+
   return (
     <div
       className={classNames("alerts-page", {
@@ -229,9 +245,25 @@ const AlertsPage: ComponentType<Props> = (props: Props) => {
           .sort((a: Alert, b: Alert) =>
             alertSortDirection === 0 ? compareAlerts(a, b) : compareAlerts(b, a)
           )
-          .map((alert: Alert) => (
-            <AlertCard key={alert.id} alert={alert} />
-          ))}
+          .map((alert: Alert) => {
+            const screensByAlert = screensByAlertMap[alert.id];
+            let numPlaces = 0;
+            let numScreens = 0;
+
+            if (screensByAlert) {
+              numScreens = screensByAlert.length;
+              numPlaces = getNumberOfAffectedPlaces(screensByAlert);
+            }
+
+            return (
+              <AlertCard
+                key={alert.id}
+                alert={alert}
+                numberOfScreens={numScreens}
+                numberOfPlaces={numPlaces}
+              />
+            );
+          })}
       </div>
     </div>
   );

--- a/assets/js/components/Dashboard/AlertsPage.tsx
+++ b/assets/js/components/Dashboard/AlertsPage.tsx
@@ -62,13 +62,15 @@ const AlertsPage: ComponentType<Props> = (props: Props) => {
 
   const [selectedAlert, setSelectedAlert] = useState<Alert | null>(null);
 
-  const placesWithSelectedAlert = selectedAlert
-    ? places.filter((place) =>
-        place.screens.some((screen: Screen) =>
-          screensByAlertMap[selectedAlert.id].includes(screen.id)
+  const placesWithSelectedAlert = (alert: Alert | null) => {
+    return alert
+      ? places.filter((place) =>
+          place.screens.some((screen: Screen) =>
+            screensByAlertMap[alert.id].includes(screen.id)
+          )
         )
-      )
-    : [];
+      : [];
+  };
 
   const alertsWithPlaces = alerts.filter(
     (alert) => screensByAlertMap[alert.id]
@@ -116,7 +118,7 @@ const AlertsPage: ComponentType<Props> = (props: Props) => {
               classNames="selected-alert"
             />
             <PlacesList
-              places={placesWithSelectedAlert}
+              places={placesWithSelectedAlert(selectedAlert)}
               noModeFilter
               isAlertPlacesList
             />
@@ -127,6 +129,7 @@ const AlertsPage: ComponentType<Props> = (props: Props) => {
             alerts={alertsWithPlaces}
             selectAlert={setSelectedAlert}
             screensByAlertMap={screensByAlertMap}
+            placesWithSelectedAlert={placesWithSelectedAlert}
           />
         )}
       </div>
@@ -138,6 +141,7 @@ interface AlertsListProps extends Props {
   alerts: Alert[];
   selectAlert: Dispatch<SetStateAction<Alert | null>>;
   screensByAlertMap: ScreensByAlert;
+  placesWithSelectedAlert: (alert: Alert | null) => Place[];
 }
 
 const AlertsList: ComponentType<AlertsListProps> = ({
@@ -145,6 +149,7 @@ const AlertsList: ComponentType<AlertsListProps> = ({
   selectAlert,
   places,
   screensByAlertMap,
+  placesWithSelectedAlert,
 }: AlertsListProps) => {
   const [alertSortDirection, setAlertSortDirection] = useState<DirectionID>(0);
   const [alertModeLineFilterValue, setAlertModeLineFilterValue] = useState(
@@ -278,22 +283,6 @@ const AlertsList: ComponentType<AlertsListProps> = ({
     return Date.parse(end1) - Date.parse(end2);
   };
 
-  const getNumberOfAffectedPlaces = (screensByAlert: string[]) => {
-    // Using a Set so we don't have to worry about counting a place more than once.
-    const placesCounted = new Set();
-
-    places.forEach((place) => {
-      if (
-        place.screens.filter((screen) => screensByAlert.includes(screen.id))
-          .length > 0
-      ) {
-        placesCounted.add(place.id);
-      }
-    });
-
-    return placesCounted.size;
-  };
-
   return (
     <>
       <Container fluid>
@@ -346,7 +335,7 @@ const AlertsList: ComponentType<AlertsListProps> = ({
 
           if (screensByAlert) {
             numScreens = screensByAlert.length;
-            numPlaces = getNumberOfAffectedPlaces(screensByAlert);
+            numPlaces = placesWithSelectedAlert(alert).length;
           }
 
           return (

--- a/assets/js/components/Dashboard/AlertsPage.tsx
+++ b/assets/js/components/Dashboard/AlertsPage.tsx
@@ -19,21 +19,29 @@ import AlertCard from "./AlertCard";
 
 type DirectionID = 0 | 1;
 
+interface AlertsResponse {
+  alerts: Alert[];
+  screens_by_alert: ScreensByAlert;
+}
+
 interface Props {
   places: Place[];
-  screensByAlertId: ScreensByAlert;
   isVisible: boolean;
 }
 
 const AlertsPage: ComponentType<Props> = (props: Props) => {
   const [alerts, setAlerts] = useState<Alert[]>([]);
+  const [screensByAlertMap, setScreensByAlertMap] = useState<ScreensByAlert>(
+    {}
+  );
   useEffect(() => {
     if (!props.isVisible) return;
 
     fetch("/api/alerts")
       .then((response) => response.json())
-      .then((alertsList: []) => {
-        setAlerts(alertsList);
+      .then(({ alerts, screens_by_alert }: AlertsResponse) => {
+        setAlerts(alerts);
+        setScreensByAlertMap(screens_by_alert);
       });
   }, [props.isVisible]);
 
@@ -138,7 +146,7 @@ const AlertsPage: ComponentType<Props> = (props: Props) => {
     return alerts.filter((alert) => {
       // Get this alert's list of affected screens.
       // Later should be replaced with a call to memcached?
-      const screensWithAlert = props.screensByAlertId[alert.id];
+      const screensWithAlert = screensByAlertMap[alert.id];
 
       return screensWithAlert
         ? screensWithAlert.find((screen_id) =>

--- a/assets/js/components/Dashboard/Dashboard.tsx
+++ b/assets/js/components/Dashboard/Dashboard.tsx
@@ -1,7 +1,6 @@
 import React, { ComponentType, useEffect, useState } from "react";
 import "../../../css/screenplay.scss";
 import { Place } from "../../models/place";
-import { ScreensByAlert } from "../../models/screensByAlert";
 import Sidebar from "./Sidebar";
 import PlacesPage from "./PlacesPage";
 import AlertsPage from "./AlertsPage";
@@ -33,22 +32,11 @@ const Dashboard: ComponentType<Props> = (props: Props) => {
       <Sidebar />
       <div className="page-content">
         <PlacesPage places={places} isVisible={visible.places} />
-        <AlertsPage
-          places={places}
-          screensByAlertId={dummyScreensByAlertId}
-          isVisible={visible.alerts}
-        />
+        <AlertsPage places={places} isVisible={visible.alerts} />
         <OverridesPage isVisible={visible.overrides} />
       </div>
     </div>
   );
-};
-
-const dummyScreensByAlertId: ScreensByAlert = {
-  "1": ["EIB-101", "EIG-404"],
-  "2": ["PRE-105"],
-  "3": ["MUL-101"],
-  "4": ["PRE-112", "DUP-BackBay", "BUS-104"],
 };
 
 export default Dashboard;

--- a/assets/js/components/Dashboard/PaessScreenDetail.tsx
+++ b/assets/js/components/Dashboard/PaessScreenDetail.tsx
@@ -9,10 +9,8 @@ interface PaessScreenDetailProps {
 const PaessScreenDetail = (props: PaessScreenDetailProps): JSX.Element => {
   const generateSource = () => {
     // @ts-ignore Suppressing "object could be null" warning
-    const { environmentName } = document.getElementById("app").dataset;
-    return environmentName === "dev" || environmentName === "dev-green"
-      ? `https://signs-dev.mbtace.com/${props.stationCode}/${props.zone}`
-      : `https://signs.mbta.com/${props.stationCode}/${props.zone}`;
+    const { signsUiUrl } = document.getElementById("app").dataset;
+    return `${signsUiUrl}/${props.stationCode}/${props.zone}`;
   };
 
   function getZoneLabel(zone: string) {

--- a/assets/js/components/Dashboard/ScreenDetail.tsx
+++ b/assets/js/components/Dashboard/ScreenDetail.tsx
@@ -62,28 +62,19 @@ const ScreenCard = (props: ScreenDetailProps) => {
   const generateSource = (screen: Screen) => {
     const { id, type } = screen;
     // @ts-ignore Suppressing "object could be null" warning
-    const { environmentName } = document.getElementById("app").dataset;
+    const { screensUrl } = document.getElementById("app").dataset;
     const queryParams = "requestor=screenplay";
 
-    let baseUrl;
-    if (environmentName === "dev") {
-      baseUrl = "https://screens-dev.mbtace.com";
-    } else if (environmentName === "dev-green") {
-      baseUrl = "https://screens-dev-green.mbtace.com";
-    } else {
-      baseUrl = "https://screens.mbta.com";
-    }
-
     if (type.includes("v2")) {
-      return `${baseUrl}/v2/screen/${id}/simulation?${queryParams}`;
+      return `${screensUrl}/v2/screen/${id}/simulation?${queryParams}`;
     }
     if (
       ["bus_eink", "gl_eink_single", "gl_eink_double", "solari"].includes(type)
     ) {
-      return `${baseUrl}/screen/${id}?${queryParams}`;
+      return `${screensUrl}/screen/${id}?${queryParams}`;
     }
     if (type === "dup") {
-      return `${baseUrl}/screen/${id}/simulation?${queryParams}`;
+      return `${screensUrl}/screen/${id}/simulation?${queryParams}`;
     }
 
     return "";

--- a/assets/tests/components/alertCard.test.tsx
+++ b/assets/tests/components/alertCard.test.tsx
@@ -17,7 +17,9 @@ describe("AlertCard", () => {
       affected_list: ["red"],
     };
 
-    const { getByText } = render(<AlertCard alert={alert} />);
+    const { getByText } = render(
+      <AlertCard alert={alert} numberOfPlaces={0} numberOfScreens={0} />
+    );
 
     expect(getByText("Station Closure")).toBeInTheDocument();
   });
@@ -35,7 +37,9 @@ describe("AlertCard", () => {
       affected_list: ["red"],
     };
 
-    const { getByText } = render(<AlertCard alert={alert} />);
+    const { getByText } = render(
+      <AlertCard alert={alert} numberOfPlaces={0} numberOfScreens={0} />
+    );
 
     expect(getByText("Delay—up to 15 minutes")).toBeInTheDocument();
   });
@@ -58,7 +62,9 @@ describe("AlertCard", () => {
       affected_list: ["red"],
     };
 
-    const { getByText } = render(<AlertCard alert={alert} />);
+    const { getByText } = render(
+      <AlertCard alert={alert} numberOfPlaces={0} numberOfScreens={0} />
+    );
 
     expect(getByText("9/16/2022 · 5:00 AM")).toBeInTheDocument();
     expect(getByText("9/16/2022 · 6:00 AM")).toBeInTheDocument();
@@ -82,7 +88,9 @@ describe("AlertCard", () => {
       affected_list: ["red"],
     };
 
-    const { getByText } = render(<AlertCard alert={alert} />);
+    const { getByText } = render(
+      <AlertCard alert={alert} numberOfPlaces={0} numberOfScreens={0} />
+    );
 
     expect(getByText("9/16/2022 · 5:00 AM")).toBeInTheDocument();
     expect(getByText("Until further notice")).toBeInTheDocument();

--- a/assets/tests/components/alertsPage.test.tsx
+++ b/assets/tests/components/alertsPage.test.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import { Place } from "../../js/models/place";
-import { ScreensByAlert } from "../../js/models/screensByAlert";
 import alerts from "../alerts.test.json";
 import placesAndScreens from "../places_and_screens.test.json";
 import alertsOnScreens from "../alerts_on_screens.test.json";
@@ -21,7 +20,8 @@ describe("Alerts Page", () => {
     originalFetch = global.fetch;
     global.fetch = jest.fn(() =>
       Promise.resolve({
-        json: () => Promise.resolve(alerts),
+        json: () =>
+          Promise.resolve({ alerts, screens_by_alert: alertsOnScreens }),
       })
     ) as jest.Mock;
   });
@@ -33,11 +33,7 @@ describe("Alerts Page", () => {
   describe("filtering", () => {
     test("filters places by mode and route", async () => {
       const { getByRole, findByRole, getByTestId } = render(
-        <AlertsPage
-          places={placesAndScreens as Place[]}
-          screensByAlertId={alertsOnScreens as ScreensByAlert}
-          isVisible={true}
-        />
+        <AlertsPage places={placesAndScreens as Place[]} isVisible={true} />
       );
 
       await act(async () => {
@@ -70,11 +66,7 @@ describe("Alerts Page", () => {
   describe("sorting", () => {
     test("sort label when clicked", async () => {
       const { getByTestId } = render(
-        <AlertsPage
-          places={placesAndScreens as Place[]}
-          screensByAlertId={alertsOnScreens as ScreensByAlert}
-          isVisible={true}
-        />
+        <AlertsPage places={placesAndScreens as Place[]} isVisible={true} />
       );
 
       await act(async () => {

--- a/assets/tests/components/placeRow.test.tsx
+++ b/assets/tests/components/placeRow.test.tsx
@@ -7,7 +7,6 @@ import { Place } from "../../js/models/place";
 beforeAll(() => {
   const app = document.createElement("div");
   app.id = "app";
-  app.dataset.environmentName = "dev";
   document.body.appendChild(app);
 });
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -29,4 +29,5 @@ config :screenplay,
   slack_webhook_url: System.get_env("SLACK_WEBHOOK_URL"),
   environment_name: System.get_env("ENVIRONMENT_NAME"),
   sentry_frontend_dsn: System.get_env("SENTRY_DSN"),
-  api_v3_key: System.get_env("API_V3_KEY")
+  api_v3_key: System.get_env("API_V3_KEY"),
+  screens_url: System.get_env("SCREENS_URL")

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -30,4 +30,6 @@ config :screenplay,
   environment_name: System.get_env("ENVIRONMENT_NAME"),
   sentry_frontend_dsn: System.get_env("SENTRY_DSN"),
   api_v3_key: System.get_env("API_V3_KEY"),
-  screens_url: System.get_env("SCREENS_URL")
+  api_v3_url: System.get_env("API_V3_URL"),
+  screens_url: System.get_env("SCREENS_URL"),
+  signs_ui_url: System.get_env("SIGNS_UI_URL")

--- a/lib/screenplay/alerts/screens_by_alert.ex
+++ b/lib/screenplay/alerts/screens_by_alert.ex
@@ -17,17 +17,19 @@ defmodule Screenplay.Alerts.ScreensByAlert do
       {:http_request, e} ->
         {:error, httpoison_error} = e
         log_api_error({:http_fetch_error, e}, message: Exception.message(httpoison_error))
+        :error
 
       {:response_success, %{status_code: status_code, body: body}} = response ->
         _ = log_api_error({:bad_response_code, response}, status_code: status_code, body: body)
-
-        :bad_response_code
+        :error
 
       {:parse, {:error, e}} ->
         log_api_error({:parse_error, e})
+        :error
 
       e ->
         log_api_error({:error, e})
+        :error
     end
   end
 

--- a/lib/screenplay/alerts/screens_by_alert.ex
+++ b/lib/screenplay/alerts/screens_by_alert.ex
@@ -1,0 +1,45 @@
+defmodule Screenplay.Alerts.ScreensByAlert do
+  require Logger
+
+  def get_screens_by_alert(alert_ids) do
+    url = build_url(alert_ids)
+
+    with {:http_request, {:ok, response}} <-
+           {:http_request, HTTPoison.get(url)},
+         {:response_success, %{status_code: 200, body: body}} <-
+           {:response_success, response},
+         {:parse, {:ok, parsed}} <- {:parse, Jason.decode(body)} do
+      {:ok, parsed}
+    else
+      {:http_request, e} ->
+        {:error, httpoison_error} = e
+        log_api_error({:http_fetch_error, e}, message: Exception.message(httpoison_error))
+
+      {:response_success, %{status_code: status_code, body: body}} = response ->
+        _ = log_api_error({:bad_response_code, response}, status_code: status_code, body: body)
+
+        :bad_response_code
+
+      {:parse, {:error, e}} ->
+        log_api_error({:parse_error, e})
+
+      e ->
+        log_api_error({:error, e})
+    end
+  end
+
+  defp log_api_error(error = {error_type, _error_data}, extra_fields \\ []) do
+    extra_fields
+    |> Enum.map_join(" ", fn {label, value} -> "#{label}=\"#{value}\"" end)
+    |> then(fn fields ->
+      Logger.info("[screens_by_alert_error] error_type=#{error_type} " <> fields)
+    end)
+
+    error
+  end
+
+  defp build_url(alert_ids) do
+    base_url = Application.get_env(:screenplay, :screens_url)
+    "#{base_url}/api/screens_by_alert?ids=#{Enum.join(alert_ids, ",")}"
+  end
+end

--- a/lib/screenplay/alerts/screens_by_alert.ex
+++ b/lib/screenplay/alerts/screens_by_alert.ex
@@ -1,4 +1,7 @@
 defmodule Screenplay.Alerts.ScreensByAlert do
+  @moduledoc """
+  Module used to get ScreensByAlert data from the Screens app.
+  """
   require Logger
 
   def get_screens_by_alert(alert_ids) do

--- a/lib/screenplay/v3_api.ex
+++ b/lib/screenplay/v3_api.ex
@@ -66,22 +66,11 @@ defmodule Screenplay.V3Api do
   end
 
   defp build_url(route, params) do
-    "#{base_url()}#{route}?#{URI.encode_query(params)}"
+    "#{base_url()}/#{route}?#{URI.encode_query(params)}"
   end
 
   defp base_url do
-    :screenplay
-    |> Application.get_env(:environment_name)
-    |> base_url_for_environment()
-  end
-
-  defp base_url_for_environment(environment_name) do
-    case environment_name do
-      "prod" -> "https://api-v3.mbta.com/"
-      "dev" -> "https://api-dev.mbtace.com/"
-      "dev-green" -> "https://api-dev-green.mbtace.com/"
-      _ -> Application.get_env(:screenplay, :default_api_v3_url)
-    end
+    Application.get_env(:screenplay, :api_v3_url)
   end
 
   defp api_key_headers(nil), do: []

--- a/lib/screenplay_web/controllers/alerts_api_controller.ex
+++ b/lib/screenplay_web/controllers/alerts_api_controller.ex
@@ -2,9 +2,17 @@ defmodule ScreenplayWeb.AlertsApiController do
   use ScreenplayWeb, :controller
 
   alias Screenplay.Alerts.Alert
+  alias Screenplay.Alerts.ScreensByAlert
 
   def index(conn, _params) do
     {:ok, alerts} = Alert.fetch()
-    json(conn, Enum.map(alerts, &Alert.to_full_map/1))
+
+    {:ok, screens_by_alerts} =
+      alerts |> Enum.map(& &1.id) |> ScreensByAlert.get_screens_by_alert()
+
+    json(conn, %{
+      alerts: Enum.map(alerts, &Alert.to_full_map/1),
+      screens_by_alert: screens_by_alerts
+    })
   end
 end

--- a/lib/screenplay_web/controllers/alerts_api_controller.ex
+++ b/lib/screenplay_web/controllers/alerts_api_controller.ex
@@ -7,8 +7,13 @@ defmodule ScreenplayWeb.AlertsApiController do
   def index(conn, _params) do
     {:ok, alerts} = Alert.fetch()
 
-    {:ok, screens_by_alerts} =
-      alerts |> Enum.map(& &1.id) |> ScreensByAlert.get_screens_by_alert()
+    alert_ids = Enum.map(alerts, & &1.id)
+
+    screens_by_alerts =
+      case ScreensByAlert.get_screens_by_alert(alert_ids) do
+        {:ok, screens_by_alerts} -> screens_by_alerts
+        _ -> Map.new(alert_ids, fn alert_id -> {alert_id, []} end)
+      end
 
     json(conn, %{
       alerts: Enum.map(alerts, &Alert.to_full_map/1),

--- a/lib/screenplay_web/controllers/dashboard_controller.ex
+++ b/lib/screenplay_web/controllers/dashboard_controller.ex
@@ -4,8 +4,9 @@ defmodule ScreenplayWeb.DashboardController do
   alias Screenplay.Util
 
   plug(:username)
-  plug(:environment_name)
   plug(:sentry_dsn)
+  plug(:screens_url)
+  plug(:signs_ui_url)
 
   def index(conn, _params) do
     render(conn, "index.html", clarity_tag: System.get_env("CLARITY_TAG"))
@@ -20,10 +21,6 @@ defmodule ScreenplayWeb.DashboardController do
     assign(conn, :username, username)
   end
 
-  defp environment_name(conn, _) do
-    assign(conn, :environment_name, Application.get_env(:screenplay, :environment_name, "dev"))
-  end
-
   defp sentry_dsn(conn, _) do
     dsn =
       if Application.get_env(:screenplay, :record_sentry, false) do
@@ -33,5 +30,13 @@ defmodule ScreenplayWeb.DashboardController do
       end
 
     assign(conn, :sentry_frontend_dsn, dsn)
+  end
+
+  defp screens_url(conn, _) do
+    assign(conn, :screens_url, Application.get_env(:screenplay, :screens_url))
+  end
+
+  defp signs_ui_url(conn, _) do
+    assign(conn, :signs_ui_url, Application.get_env(:screenplay, :signs_ui_url))
   end
 end

--- a/lib/screenplay_web/templates/dashboard/index.html.eex
+++ b/lib/screenplay_web/templates/dashboard/index.html.eex
@@ -1,6 +1,7 @@
 <div
     id="app"
     data-username="<%= @username %>"
-    data-environment-name="<%= @environment_name %>"
     data-sentry="<%= @sentry_frontend_dsn %>"
+    data-screens-url="<%= @screens_url %>"
+    data-signs-ui-url="<%= @signs_ui_url %>"
 ></div>


### PR DESCRIPTION
**Asana task**: [[Screenplay] Include "places" and "screens" counts on alerts](https://app.asana.com/0/1185117109217413/1202932249366380/f)

`AlertCard`s now display the number of screens and places that are affected by the alert. 3 new ENV variables have also been added: `API_V3_URL`, `SCREENS_URL`, and `SIGNS_UI_URL`. These URLs  used to be picked conditional in code based on environment. They now live in terraform so each environment will automatically pick the correct URL. That PR is [here](https://github.com/mbta/devops/pull/675) and will need to be merged and applied before merging this PR.
