### PR TITLE
fix: v1 sim overflow

### DIFF
--- a/assets/css/screen-detail.scss
+++ b/assets/css/screen-detail.scss
@@ -77,6 +77,7 @@
   margin-left: auto;
   margin-right: auto;
   margin-top: 16px;
+  overflow: hidden;
 
   // The below values are "height of the iframe's container", which is different than the iframe content
 


### PR DESCRIPTION
**Asana task**: [[Screenplay] 🐞 Formatting for v1 screens](https://app.asana.com/0/1185117109217413/1203236363940429/f)

V1 screen sims were not hiding overflow, so viewing a sim towards the bottom of the page was creating a huge amount of blank space. Hiding overflow in the `iframe` container fixes this.
