### PR TITLE
tweak: Metadata Module Plug

### DIFF
--- a/assets/js/app.tsx
+++ b/assets/js/app.tsx
@@ -20,8 +20,12 @@ import ReactDOM from "react-dom";
 import App from "./components/App";
 import * as Sentry from "@sentry/react";
 
-const sentryDsn = document.getElementById("app")?.dataset.sentry;
-const username = document.getElementById("app")?.dataset.username;
+const sentryDsn = document
+  .querySelector("meta[name=sentry]")
+  ?.getAttribute("content");
+const username = document
+  .querySelector("meta[name=username]")
+  ?.getAttribute("content");
 
 if (sentryDsn) {
   Sentry.init({

--- a/assets/js/components/Dashboard/AlertsPage.tsx
+++ b/assets/js/components/Dashboard/AlertsPage.tsx
@@ -76,7 +76,9 @@ const AlertsPage: ComponentType<Props> = (props: Props) => {
     (alert) => screensByAlertMap[alert.id]
   );
 
-  const alertsUiUrl = document.getElementById("app")?.dataset.alertsUiUrl;
+  const alertsUiUrl = document
+    .querySelector("meta[name=alerts-ui-url]")
+    ?.getAttribute("content");
 
   return (
     <div

--- a/assets/js/components/Dashboard/PaessScreenDetail.tsx
+++ b/assets/js/components/Dashboard/PaessScreenDetail.tsx
@@ -9,7 +9,9 @@ interface PaessScreenDetailProps {
 const PaessScreenDetail = (props: PaessScreenDetailProps): JSX.Element => {
   const generateSource = () => {
     // @ts-ignore Suppressing "object could be null" warning
-    const { signsUiUrl } = document.getElementById("app").dataset;
+    const signsUiUrl = document
+      .querySelector("meta[name=signs-ui-url]")
+      ?.getAttribute("content");
     return `${signsUiUrl}/${props.stationCode}/${props.zone}`;
   };
 

--- a/assets/js/components/Dashboard/ScreenDetail.tsx
+++ b/assets/js/components/Dashboard/ScreenDetail.tsx
@@ -62,7 +62,9 @@ const ScreenCard = (props: ScreenDetailProps) => {
   const generateSource = (screen: Screen) => {
     const { id, type } = screen;
     // @ts-ignore Suppressing "object could be null" warning
-    const { screensUrl } = document.getElementById("app").dataset;
+    const screensUrl = document
+      .querySelector("meta[name=screens-url]")
+      ?.getAttribute("content");
     const queryParams = "requestor=screenplay";
 
     if (type.includes("v2")) {

--- a/assets/js/components/Dashboard/Sidebar.tsx
+++ b/assets/js/components/Dashboard/Sidebar.tsx
@@ -11,7 +11,9 @@ import TSquare from "../../../static/images/t-square.svg";
 const Sidebar: ComponentType = () => {
   const pathname = useLocation().pathname;
   // @ts-ignore Suppressing "object could be null" warning
-  const username = document.getElementById("app").dataset.username;
+  const username = document
+    .querySelector("meta[name=username]")
+    ?.getAttribute("content");
 
   return !pathname.includes("emergency-takeover") ? (
     <div className="sidebar-container">

--- a/lib/screenplay_web/plugs/metadata.ex
+++ b/lib/screenplay_web/plugs/metadata.ex
@@ -1,0 +1,37 @@
+defmodule ScreenplayWeb.Plugs.Metadata do
+  @moduledoc false
+
+  import Plug.Conn
+
+  alias Screenplay.Util
+
+  def init(default), do: default
+
+  def call(conn, _default) do
+    env_vars(conn)
+  end
+
+  defp env_vars(conn) do
+    username =
+      conn
+      |> Plug.Conn.fetch_session()
+      |> Plug.Conn.get_session("username")
+      |> Util.trim_username()
+
+    dsn =
+      if Application.get_env(:screenplay, :record_sentry, false) do
+        Application.get_env(:screenplay, :sentry_frontend_dsn)
+      else
+        ""
+      end
+
+    conn
+    |> assign(:username, username)
+    |> assign(:clarity_tag, System.get_env("CLARITY_TAG"))
+    |> assign(:environment_name, Application.get_env(:screenplay, :environment_name, "dev"))
+    |> assign(:sentry_frontend_dsn, dsn)
+    |> assign(:alerts_ui_url, Application.get_env(:screenplay, :alerts_ui_url))
+    |> assign(:screens_url, Application.get_env(:screenplay, :screens_url))
+    |> assign(:signs_ui_url, Application.get_env(:screenplay, :signs_ui_url))
+  end
+end

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -7,6 +7,7 @@ defmodule ScreenplayWeb.Router do
     plug :fetch_flash
     plug :protect_from_forgery
     plug :put_secure_browser_headers
+    plug ScreenplayWeb.Plugs.Metadata
   end
 
   pipeline :api do

--- a/lib/screenplay_web/templates/dashboard/index.html.eex
+++ b/lib/screenplay_web/templates/dashboard/index.html.eex
@@ -1,8 +1,1 @@
-<div
-    id="app"
-    data-username="<%= @username %>"
-    data-sentry="<%= @sentry_frontend_dsn %>"
-    data-screens-url="<%= @screens_url %>"
-    data-signs-ui-url="<%= @signs_ui_url %>"
-    data-alerts-ui-url="<%= @alerts_ui_url %>"
-></div>
+<div id="app"></div>

--- a/lib/screenplay_web/templates/layout/app.html.heex
+++ b/lib/screenplay_web/templates/layout/app.html.heex
@@ -4,8 +4,23 @@
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <%= if @conn.assigns[:clarity_tag] do %>
+    <%= if @clarity_tag do %>
       <meta name="clarity-tag" content={@clarity_tag}>
+    <% end %>
+    <%= if @username do %>
+        <meta name="username" content={@username}>
+    <% end %>
+    <%= if @sentry_frontend_dsn do %>
+        <meta name="sentry" content={@sentry_frontend_dsn}>
+    <% end %>
+    <%= if @screens_url do %>
+        <meta name="screens-url" content={@screens_url}>
+    <% end %>
+    <%= if @signs_ui_url do %>
+        <meta name="signs-ui-url" content={@signs_ui_url}>
+    <% end %>
+    <%= if @alerts_ui_url do %>
+        <meta name="alerts-ui-url" content={@alerts_ui_url}>
     <% end %>
     <%= csrf_meta_tag() %>
     <title>Screenplay</title>


### PR DESCRIPTION
**Asana task**: [[Screenplay] 🐞 Username not initialized from alerts page](https://app.asana.com/0/1185117109217413/1203236363940422/f)

The solution for communicating ENV variables and similar constants was originally borrowed from the way the screens app. That method is fine for applications that only use a single page with no routing. For Screenplay, when the application loaded from the `/alerts` URL, some things like `username` and `environment_name` were not being picked up because that controller did not add them to `conn.assigns`. A new module plug has been added so we no longer have to remember to add values at the controller level. In this plug, it grabs all necessary values the same way the `DashboardController` was. Instead of adding these as data attributes on the `dashboard` template, they are now meta attributes on the main `app.html.heex`. This allows all of these values to be accessed from any page, regardless of the URL used to get there.
