### PR TITLE
bugfix: Needed to set redirect_http for prod!

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -10,10 +10,11 @@ import Config
 # which you should run after static files are built and
 # before starting your production server.
 config :screenplay, ScreenplayWeb.Endpoint,
-  url: [port: 80],
+  cache_static_manifest: "priv/static/cache_manifest.json",
   http: [:inet6, port: 4000],
+  redirect_http?: true,
   server: true,
-  cache_static_manifest: "priv/static/cache_manifest.json"
+  url: [port: 80]
 
 config :screenplay,
   alerts_fetch_module: Screenplay.Alerts.S3Fetch,


### PR DESCRIPTION
**Asana task**: [[Screenplay] Fix http / https routing](https://app.asana.com/0/1185117109217413/1203259339371911)

We have a plug in all CTD apps called `redirect_prod_http`, which checks to see whether there's a `redirect_http` in the app config and then runs a redirect from the nonsecured to the secured url. We had forgotten to set the config variable to true for prod! 💡 