### PR TITLE
tweak: Refactor navigation

### DIFF
--- a/assets/js/components/App.tsx
+++ b/assets/js/components/App.tsx
@@ -6,6 +6,8 @@ const OutfrontTakeoverTool = React.lazy(
   () => import("./OutfrontTakeoverTool/OutfrontTakeoverTool")
 );
 const Dashboard = React.lazy(() => import("./Dashboard/Dashboard"));
+const PlacesPage = React.lazy(() => import("./Dashboard/PlacesPage"));
+const AlertsPage = React.lazy(() => import("./Dashboard/AlertsPage"));
 const clarityTag = document
   .querySelector("meta[name=clarity-tag]")
   ?.getAttribute("content");
@@ -23,11 +25,10 @@ class AppRoutes extends React.Component {
             path="/emergency-takeover"
             element={<OutfrontTakeoverTool />}
           ></Route>
-          <Route
-            path="/dashboard"
-            element={<Dashboard page="places" />}
-          ></Route>
-          <Route path="/alerts" element={<Dashboard page="alerts" />}></Route>
+          <Route path="*" element={<Dashboard />}>
+            <Route path="dashboard" element={<PlacesPage />}></Route>
+            <Route path="alerts" element={<AlertsPage />}></Route>
+          </Route>
         </Routes>
       </React.Suspense>
     );

--- a/assets/js/components/Dashboard/AlertsPage.tsx
+++ b/assets/js/components/Dashboard/AlertsPage.tsx
@@ -29,6 +29,7 @@ import { PlacesList } from "./PlacesPage";
 import classNames from "classnames";
 import AlertCard from "./AlertCard";
 import { formatEffect } from "../../util";
+import { usePlaces } from "./Dashboard";
 
 type DirectionID = 0 | 1;
 
@@ -37,28 +38,21 @@ interface AlertsResponse {
   screens_by_alert: ScreensByAlert;
 }
 
-interface Props {
-  places: Place[];
-  isVisible: boolean;
-}
-
-const AlertsPage: ComponentType<Props> = (props: Props) => {
-  const { places, isVisible } = props;
+const AlertsPage: ComponentType = () => {
+  const { places } = usePlaces();
 
   const [alerts, setAlerts] = useState<Alert[]>([]);
   const [screensByAlertMap, setScreensByAlertMap] = useState<ScreensByAlert>(
     {}
   );
   useEffect(() => {
-    if (!props.isVisible) return;
-
     fetch("/api/alerts")
       .then((response) => response.json())
       .then(({ alerts, screens_by_alert }: AlertsResponse) => {
         setAlerts(alerts);
         setScreensByAlertMap(screens_by_alert);
       });
-  }, [props.isVisible]);
+  }, []);
 
   const [selectedAlert, setSelectedAlert] = useState<Alert | null>(null);
 
@@ -81,11 +75,7 @@ const AlertsPage: ComponentType<Props> = (props: Props) => {
     ?.getAttribute("content");
 
   return (
-    <div
-      className={classNames("alerts-page", {
-        "alerts-page--hidden": !isVisible,
-      })}
-    >
+    <div className={classNames("alerts-page")}>
       <div className="page-content__header">
         {selectedAlert ? (
           <div>
@@ -127,7 +117,7 @@ const AlertsPage: ComponentType<Props> = (props: Props) => {
           </>
         ) : (
           <AlertsList
-            {...props}
+            places={places}
             alerts={alertsWithPlaces}
             selectAlert={setSelectedAlert}
             screensByAlertMap={screensByAlertMap}
@@ -139,11 +129,12 @@ const AlertsPage: ComponentType<Props> = (props: Props) => {
   );
 };
 
-interface AlertsListProps extends Props {
+interface AlertsListProps {
   alerts: Alert[];
   selectAlert: Dispatch<SetStateAction<Alert | null>>;
   screensByAlertMap: ScreensByAlert;
   placesWithSelectedAlert: (alert: Alert | null) => Place[];
+  places: Place[];
 }
 
 const AlertsList: ComponentType<AlertsListProps> = ({

--- a/assets/js/components/Dashboard/AlertsPage.tsx
+++ b/assets/js/components/Dashboard/AlertsPage.tsx
@@ -29,7 +29,7 @@ import { PlacesList } from "./PlacesPage";
 import classNames from "classnames";
 import AlertCard from "./AlertCard";
 import { formatEffect } from "../../util";
-import { usePlaces } from "./Dashboard";
+import { useOutletContext } from "react-router";
 
 type DirectionID = 0 | 1;
 
@@ -39,7 +39,7 @@ interface AlertsResponse {
 }
 
 const AlertsPage: ComponentType = () => {
-  const { places } = usePlaces();
+  const { places } = useOutletContext<{ places: Place[] }>();
 
   const [alerts, setAlerts] = useState<Alert[]>([]);
   const [screensByAlertMap, setScreensByAlertMap] = useState<ScreensByAlert>(

--- a/assets/js/components/Dashboard/AlertsPage.tsx
+++ b/assets/js/components/Dashboard/AlertsPage.tsx
@@ -28,7 +28,7 @@ import { ScreensByAlert } from "../../models/screensByAlert";
 import { PlacesList } from "./PlacesPage";
 import AlertCard from "./AlertCard";
 import { formatEffect } from "../../util";
-import { useOutletContext } from "react-router";
+import { usePlaces } from "./Dashboard";
 
 type DirectionID = 0 | 1;
 
@@ -38,7 +38,7 @@ interface AlertsResponse {
 }
 
 const AlertsPage: ComponentType = () => {
-  const { places } = useOutletContext<{ places: Place[] }>();
+  const { places } = usePlaces();
 
   const [alerts, setAlerts] = useState<Alert[]>([]);
   const [screensByAlertMap, setScreensByAlertMap] = useState<ScreensByAlert>(

--- a/assets/js/components/Dashboard/AlertsPage.tsx
+++ b/assets/js/components/Dashboard/AlertsPage.tsx
@@ -26,7 +26,6 @@ import { Place } from "../../models/place";
 import { Screen } from "../../models/screen";
 import { ScreensByAlert } from "../../models/screensByAlert";
 import { PlacesList } from "./PlacesPage";
-import classNames from "classnames";
 import AlertCard from "./AlertCard";
 import { formatEffect } from "../../util";
 import { useOutletContext } from "react-router";
@@ -75,7 +74,7 @@ const AlertsPage: ComponentType = () => {
     ?.getAttribute("content");
 
   return (
-    <div className={classNames("alerts-page")}>
+    <div className="alerts-page">
       <div className="page-content__header">
         {selectedAlert ? (
           <div>

--- a/assets/js/components/Dashboard/Dashboard.tsx
+++ b/assets/js/components/Dashboard/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React, { ComponentType, useEffect, useState } from "react";
-import { Outlet, useOutletContext } from "react-router";
+import { Outlet } from "react-router";
 import "../../../css/screenplay.scss";
 import { Place } from "../../models/place";
 import Sidebar from "./Sidebar";
@@ -24,9 +24,5 @@ const Dashboard: ComponentType = () => {
     </div>
   );
 };
-
-export function usePlaces() {
-  return useOutletContext<{ places: Place[] }>();
-}
 
 export default Dashboard;

--- a/assets/js/components/Dashboard/Dashboard.tsx
+++ b/assets/js/components/Dashboard/Dashboard.tsx
@@ -1,8 +1,11 @@
 import React, { ComponentType, useEffect, useState } from "react";
 import { Outlet } from "react-router";
+import { useOutletContext } from "react-router-dom";
 import "../../../css/screenplay.scss";
 import { Place } from "../../models/place";
 import Sidebar from "./Sidebar";
+
+type ContextType = { places: Place[] };
 
 const Dashboard: ComponentType = () => {
   const [places, setPlaces] = useState<Place[]>([]);
@@ -23,6 +26,10 @@ const Dashboard: ComponentType = () => {
       </div>
     </div>
   );
+};
+
+export const usePlaces = () => {
+  return useOutletContext<ContextType>();
 };
 
 export default Dashboard;

--- a/assets/js/components/Dashboard/Dashboard.tsx
+++ b/assets/js/components/Dashboard/Dashboard.tsx
@@ -1,16 +1,10 @@
 import React, { ComponentType, useEffect, useState } from "react";
+import { Outlet, useOutletContext } from "react-router";
 import "../../../css/screenplay.scss";
 import { Place } from "../../models/place";
 import Sidebar from "./Sidebar";
-import PlacesPage from "./PlacesPage";
-import AlertsPage from "./AlertsPage";
-import OverridesPage from "./OverridesPage";
 
-interface Props {
-  page: "places" | "alerts" | "overrides";
-}
-
-const Dashboard: ComponentType<Props> = (props: Props) => {
+const Dashboard: ComponentType = () => {
   const [places, setPlaces] = useState<Place[]>([]);
 
   useEffect(() => {
@@ -21,22 +15,18 @@ const Dashboard: ComponentType<Props> = (props: Props) => {
       });
   }, []);
 
-  const visible = {
-    places: props.page === "places",
-    alerts: props.page === "alerts",
-    overrides: props.page === "overrides",
-  };
-
   return (
     <div className="screenplay-container">
       <Sidebar />
       <div className="page-content">
-        <PlacesPage places={places} isVisible={visible.places} />
-        <AlertsPage places={places} isVisible={visible.alerts} />
-        <OverridesPage isVisible={visible.overrides} />
+        <Outlet context={{ places }} />
       </div>
     </div>
   );
 };
+
+export function usePlaces() {
+  return useOutletContext<{ places: Place[] }>();
+}
 
 export default Dashboard;

--- a/assets/js/components/Dashboard/PlacesPage.tsx
+++ b/assets/js/components/Dashboard/PlacesPage.tsx
@@ -12,7 +12,7 @@ import {
   SCREEN_TYPES,
   STATUSES,
 } from "../../constants/constants";
-import { useOutletContext } from "react-router";
+import { usePlaces } from "./Dashboard";
 
 type DirectionID = 0 | 1;
 
@@ -31,7 +31,7 @@ const getSortLabel = (
 };
 
 const PlacesPage: ComponentType = () => {
-  const { places } = useOutletContext<{ places: Place[] }>();
+  const { places } = usePlaces();
 
   return (
     <div className="places-page">

--- a/assets/js/components/Dashboard/PlacesPage.tsx
+++ b/assets/js/components/Dashboard/PlacesPage.tsx
@@ -1,5 +1,4 @@
 import React, { ComponentType, useEffect, useState } from "react";
-import classNames from "classnames";
 import PlaceRow from "./PlaceRow";
 import PlacesActionBar from "./PlacesActionBar";
 import FilterDropdown from "./FilterDropdown";
@@ -35,7 +34,7 @@ const PlacesPage: ComponentType = () => {
   const { places } = useOutletContext<{ places: Place[] }>();
 
   return (
-    <div className={classNames("places-page")}>
+    <div className="places-page">
       <div className="page-content__header">Places</div>
       <div className="page-content__body">
         <PlacesList places={places} />

--- a/assets/js/components/Dashboard/PlacesPage.tsx
+++ b/assets/js/components/Dashboard/PlacesPage.tsx
@@ -13,6 +13,7 @@ import {
   SCREEN_TYPES,
   STATUSES,
 } from "../../constants/constants";
+import { usePlaces } from "./Dashboard";
 
 type DirectionID = 0 | 1;
 
@@ -30,23 +31,18 @@ const getSortLabel = (
   }
 };
 
-interface Props {
-  places: Place[];
-  isVisible: boolean;
-}
+const PlacesPage: ComponentType = () => {
+  const { places } = usePlaces();
 
-const PlacesPage: ComponentType<Props> = (props: Props) => (
-  <div
-    className={classNames("places-page", {
-      "places-page--hidden": !props.isVisible,
-    })}
-  >
-    <div className="page-content__header">Places</div>
-    <div className="page-content__body">
-      <PlacesList places={props.places} />
+  return (
+    <div className={classNames("places-page")}>
+      <div className="page-content__header">Places</div>
+      <div className="page-content__body">
+        <PlacesList places={places} />
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 interface PlacesListProps {
   places: Place[];

--- a/assets/js/components/Dashboard/PlacesPage.tsx
+++ b/assets/js/components/Dashboard/PlacesPage.tsx
@@ -13,7 +13,7 @@ import {
   SCREEN_TYPES,
   STATUSES,
 } from "../../constants/constants";
-import { usePlaces } from "./Dashboard";
+import { useOutletContext } from "react-router";
 
 type DirectionID = 0 | 1;
 
@@ -32,7 +32,7 @@ const getSortLabel = (
 };
 
 const PlacesPage: ComponentType = () => {
-  const { places } = usePlaces();
+  const { places } = useOutletContext<{ places: Place[] }>();
 
   return (
     <div className={classNames("places-page")}>

--- a/assets/tests/components/alertsPage.test.tsx
+++ b/assets/tests/components/alertsPage.test.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { act, fireEvent, render, waitFor } from "@testing-library/react";
-import { Place } from "../../js/models/place";
 import alerts from "../alerts.test.json";
-import placesAndScreens from "../places_and_screens.test.json";
 import alertsOnScreens from "../alerts_on_screens.test.json";
 import AlertsPage from "../../js/components/Dashboard/AlertsPage";
+import {
+  mockOutletContextData,
+  RenderRouteWithOutletContext,
+} from "../utils/RenderRouteWithOutletContext";
 
 beforeAll(() => {
   const app = document.createElement("div");
@@ -33,7 +35,9 @@ describe("Alerts Page", () => {
   describe("filtering", () => {
     test("filters places by mode and route", async () => {
       const { getByRole, findByRole, getByTestId, queryByTestId } = render(
-        <AlertsPage places={placesAndScreens as Place[]} isVisible={true} />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <AlertsPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -80,7 +84,9 @@ describe("Alerts Page", () => {
 
     test("filters places by screen type", async () => {
       const { getByRole, findByRole, getByTestId, queryAllByTestId } = render(
-        <AlertsPage places={placesAndScreens as Place[]} isVisible={true} />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <AlertsPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -113,7 +119,9 @@ describe("Alerts Page", () => {
   describe("sorting", () => {
     test("sort label when clicked", async () => {
       const { getByTestId } = render(
-        <AlertsPage places={placesAndScreens as Place[]} isVisible={true} />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <AlertsPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -129,7 +137,9 @@ describe("Alerts Page", () => {
   describe("Alert Places List", () => {
     test("navigating to / from the places list for an alert", async () => {
       const { getByTestId, getByText, queryByTestId, queryByText } = render(
-        <AlertsPage places={placesAndScreens as Place[]} isVisible={true} />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <AlertsPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {

--- a/assets/tests/components/placesPage.test.tsx
+++ b/assets/tests/components/placesPage.test.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import placesAndScreens from "../places_and_screens.test.json";
-import { Place } from "../../js/models/place";
 import PlacesPage from "../../js/components/Dashboard/PlacesPage";
+import {
+  mockOutletContextData,
+  RenderRouteWithOutletContext,
+} from "../utils/RenderRouteWithOutletContext";
 
 beforeAll(() => {
   const app = document.createElement("div");
@@ -30,7 +33,9 @@ describe("PlacesPage", () => {
   describe("filtering", () => {
     test("filters places by screen type", async () => {
       const { getByRole, getByText, queryByText, findByRole } = render(
-        <PlacesPage places={placesAndScreens as Place[]} isVisible />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <PlacesPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -66,7 +71,9 @@ describe("PlacesPage", () => {
 
     test("filters places by mode and route", async () => {
       const { getByRole, getByText, queryByText, findByRole } = render(
-        <PlacesPage places={placesAndScreens as Place[]} isVisible />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <PlacesPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -102,7 +109,9 @@ describe("PlacesPage", () => {
 
     test("adds `filtered` class to PlaceRow when filtered", async () => {
       const { findByRole, getByRole, getAllByTestId } = render(
-        <PlacesPage places={placesAndScreens as Place[]} isVisible={true} />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <PlacesPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -118,7 +127,9 @@ describe("PlacesPage", () => {
 
     test("reset button clears filters", async () => {
       const { findByRole, getByRole, getByTestId, getByText } = render(
-        <PlacesPage places={placesAndScreens as Place[]} isVisible={true} />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <PlacesPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -135,7 +146,9 @@ describe("PlacesPage", () => {
   describe("sorting", () => {
     test("sort label changes depending on filter selected", async () => {
       const { getByTestId, getByRole, findByRole } = render(
-        <PlacesPage places={placesAndScreens as Place[]} isVisible />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <PlacesPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -166,7 +179,9 @@ describe("PlacesPage", () => {
 
     test("sort label changes when clicked", async () => {
       const { getByTestId, getByRole, findByRole } = render(
-        <PlacesPage places={placesAndScreens as Place[]} isVisible />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <PlacesPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -206,7 +221,9 @@ describe("PlacesPage", () => {
 
     test("sort order changes for RL", async () => {
       const { getByTestId, getAllByTestId, findByRole, getByRole } = render(
-        <PlacesPage places={placesAndScreens as Place[]} isVisible />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <PlacesPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -245,7 +262,9 @@ describe("PlacesPage", () => {
 
     test("sort order changes for OL", async () => {
       const { getByTestId, getAllByTestId, findByRole, getByRole } = render(
-        <PlacesPage places={placesAndScreens as Place[]} isVisible />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <PlacesPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -284,7 +303,9 @@ describe("PlacesPage", () => {
 
     test("sort order changes for GL", async () => {
       const { getByTestId, getAllByTestId, findByRole, getByRole } = render(
-        <PlacesPage places={placesAndScreens as Place[]} isVisible />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <PlacesPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -331,7 +352,9 @@ describe("PlacesPage", () => {
 
     test("sort order changes for BL", async () => {
       const { getByTestId, getAllByTestId, findByRole, getByRole } = render(
-        <PlacesPage places={placesAndScreens as Place[]} isVisible />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <PlacesPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {

--- a/assets/tests/utils/RenderRouteWithOutletContext.tsx
+++ b/assets/tests/utils/RenderRouteWithOutletContext.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { ReactNode } from "react";
+import placesAndScreens from "../places_and_screens.test.json";
+import { MemoryRouter, Outlet, Route, Routes } from "react-router-dom";
+
+export const mockOutletContextData: any = {
+  places: placesAndScreens,
+};
+
+interface RenderRouteWithOutletContextProps<T = any> {
+  context: T;
+  children: ReactNode;
+}
+
+export const RenderRouteWithOutletContext = <T,>({
+  context,
+  children,
+}: RenderRouteWithOutletContextProps<T>) => {
+  return (
+    <MemoryRouter>
+      <Routes>
+        <Route path="/" element={<Outlet context={context as T} />}>
+          <Route index element={children} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  );
+};


### PR DESCRIPTION
**Asana task**: ad-hoc

In order to complete [this task](https://app.asana.com/0/1185117109217413/1203236363940419/f), the way we implement navigation needed to be refactored a bit. 

Before this change, we were doing some work manually that `react-router` normally takes care of. To fix this, I removed all custom conditional rendering on the `Dashboard` and instead added some additional routes to `App.tsx`. The top level `*` route renders the `Dashboard`. Under that are two nested routes for `PlacesPage` and `AlertsPage`. When using nested routes, you no longer reference components in the parent route's component. Instead, you just render `<Outlet />`. `<Outlet />` will be replaced by the child route's element when navigating between routes. 

In lieu of passing props to `AlertsPage` and `PlacesPage`, the `Outlet` now holds a context that holds the result of the `/api/dashboard` fetch (the `placesAndScreens` data). Each child route's element will be able to grab this data using `useOutletContext`. This change required some test changes. The `RenderRouteWithOutletContext` util component should be used as a wrapper for any child route so that the context can be initialized correctly.