### PR TITLE
tweak: Alert Detail URL change

### DIFF
--- a/assets/css/dashboard/alert-details.scss
+++ b/assets/css/dashboard/alert-details.scss
@@ -1,0 +1,19 @@
+.alert-details {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+
+  &__back-button {
+    height: 40px;
+    font-weight: 500;
+    margin-right: 24px;
+    background: $main-blue;
+    border: 1px solid rgba(23, 31, 38, 0.3);
+  }
+
+  &__external-link {
+    margin-left: 24px;
+    background: unset;
+    border: 1px solid rgba(23, 31, 38, 0.3);
+  }
+}

--- a/assets/css/dashboard/alerts-page.scss
+++ b/assets/css/dashboard/alerts-page.scss
@@ -7,17 +7,3 @@
 .alerts-page.alerts-page--hidden {
   display: none;
 }
-
-.alerts-page .back-button {
-  height: 40px;
-  font-weight: 500;
-  margin-right: 24px;
-  background: $main-blue;
-  border: 1px solid rgba(23, 31, 38, 0.3);
-}
-
-.alerts-page .external-link {
-  margin-left: 24px;
-  background: unset;
-  border: 1px solid rgba(23, 31, 38, 0.3);
-}

--- a/assets/css/screenplay.scss
+++ b/assets/css/screenplay.scss
@@ -4,6 +4,7 @@
 @import "dashboard/places-page.scss";
 @import "dashboard/alerts-page.scss";
 @import "dashboard/overrides-page.scss";
+@import "dashboard/alert-details.scss";
 @import "place-row.scss";
 @import "places-action-bar.scss";
 @import "filter-dropdown.scss";

--- a/assets/js/components/App.tsx
+++ b/assets/js/components/App.tsx
@@ -6,6 +6,8 @@ const OutfrontTakeoverTool = React.lazy(
   () => import("./OutfrontTakeoverTool/OutfrontTakeoverTool")
 );
 const Dashboard = React.lazy(() => import("./Dashboard/Dashboard"));
+const PlacesPage = React.lazy(() => import("./Dashboard/PlacesPage"));
+const AlertsPage = React.lazy(() => import("./Dashboard/AlertsPage"));
 const clarityTag = document
   .querySelector("meta[name=clarity-tag]")
   ?.getAttribute("content");
@@ -23,11 +25,10 @@ class AppRoutes extends React.Component {
             path="/emergency-takeover"
             element={<OutfrontTakeoverTool />}
           ></Route>
-          <Route
-            path="/dashboard"
-            element={<Dashboard page="places" />}
-          ></Route>
-          <Route path="/alerts" element={<Dashboard page="alerts" />}></Route>
+          <Route path="*" element={<Dashboard />}>
+            <Route path="dashboard" element={<PlacesPage />}></Route>
+            <Route path="alerts" element={<AlertsPage />}></Route>
+          </Route>
         </Routes>
       </React.Suspense>
     );

--- a/assets/js/components/App.tsx
+++ b/assets/js/components/App.tsx
@@ -8,6 +8,7 @@ const OutfrontTakeoverTool = React.lazy(
 const Dashboard = React.lazy(() => import("./Dashboard/Dashboard"));
 const PlacesPage = React.lazy(() => import("./Dashboard/PlacesPage"));
 const AlertsPage = React.lazy(() => import("./Dashboard/AlertsPage"));
+const AlertDetails = React.lazy(() => import("./Dashboard/AlertDetails"));
 const clarityTag = document
   .querySelector("meta[name=clarity-tag]")
   ?.getAttribute("content");
@@ -28,6 +29,7 @@ class AppRoutes extends React.Component {
           <Route path="*" element={<Dashboard />}>
             <Route path="dashboard" element={<PlacesPage />}></Route>
             <Route path="alerts" element={<AlertsPage />}></Route>
+            <Route path="alerts/:id" element={<AlertDetails />}></Route>
           </Route>
         </Routes>
       </React.Suspense>

--- a/assets/js/components/Dashboard/AlertDetails.tsx
+++ b/assets/js/components/Dashboard/AlertDetails.tsx
@@ -1,0 +1,72 @@
+import React, { ComponentType } from "react";
+import AlertCard from "./AlertCard";
+import { PlacesList } from "./PlacesPage";
+import { useNavigate, useOutletContext, useParams } from "react-router-dom";
+import { Alert } from "../../models/alert";
+import { Place } from "../../models/place";
+import { Button } from "react-bootstrap";
+import { ArrowLeft, ArrowUpRight } from "react-bootstrap-icons";
+import { formatEffect, placesWithSelectedAlert } from "../../util";
+import { ScreensByAlert } from "../../models/screensByAlert";
+
+const AlertDetails: ComponentType = () => {
+  const { places, alerts, screensByAlertMap } = useOutletContext<{
+    places: Place[];
+    alerts: Alert[];
+    screensByAlertMap: ScreensByAlert;
+  }>();
+  const { id } = useParams();
+  const selectedAlert = alerts.find((alert) => alert.id === id);
+  const alertsUiUrl = document
+    .querySelector("meta[name=alerts-ui-url]")
+    ?.getAttribute("content");
+  const navigate = useNavigate();
+
+  if (!selectedAlert) {
+    navigate("/alerts", { replace: true });
+  }
+
+  return selectedAlert ? (
+    <div className="alert-details">
+      <div className="page-content__header">
+        <div>
+          <Button
+            className="alert-details__back-button"
+            data-testid="alert-details-back-button"
+            onClick={() => navigate(-1)}
+          >
+            <ArrowLeft /> Back
+          </Button>
+          <span>
+            {formatEffect(selectedAlert.effect)} #{selectedAlert.id}
+          </span>
+          <Button
+            href={alertsUiUrl + `/edit/${selectedAlert.id}`}
+            target="_blank"
+            className="alert-details__external-link"
+          >
+            Edit Alert <ArrowUpRight />
+          </Button>
+        </div>
+      </div>
+      <div className="page-content__body">
+        <>
+          <AlertCard alert={selectedAlert} classNames="selected-alert" />
+          <PlacesList
+            places={placesWithSelectedAlert(
+              selectedAlert,
+              places,
+              screensByAlertMap
+            )}
+            noModeFilter
+            isAlertPlacesList
+          />
+        </>
+      </div>
+    </div>
+  ) : (
+    <></>
+  );
+};
+
+export default AlertDetails;

--- a/assets/js/components/Dashboard/AlertDetails.tsx
+++ b/assets/js/components/Dashboard/AlertDetails.tsx
@@ -1,26 +1,22 @@
 import React, { ComponentType, useEffect, useState } from "react";
 import AlertCard from "./AlertCard";
 import { PlacesList } from "./PlacesPage";
-import { useNavigate, useOutletContext, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { Alert } from "../../models/alert";
-import { Place } from "../../models/place";
 import { Button } from "react-bootstrap";
 import { ArrowLeft, ArrowUpRight } from "react-bootstrap-icons";
 import { formatEffect, placesWithSelectedAlert } from "../../util";
-import { ScreensByAlert } from "../../models/screensByAlert";
+import { useDashboardContext } from "./Dashboard";
 
 const AlertDetails: ComponentType = () => {
-  const { places, alerts, screensByAlertMap } = useOutletContext<{
-    places: Place[];
-    alerts: Alert[];
-    screensByAlertMap: ScreensByAlert;
-  }>();
+  const { places, alerts, screensByAlertMap } = useDashboardContext();
   const { id } = useParams();
   const [selectedAlert, setSelectedAlert] = useState<Alert>();
 
   const alertsUiUrl = document
     .querySelector("meta[name=alerts-ui-url]")
     ?.getAttribute("content");
+
   const navigate = useNavigate();
 
   useEffect(() => {

--- a/assets/js/components/Dashboard/AlertDetails.tsx
+++ b/assets/js/components/Dashboard/AlertDetails.tsx
@@ -21,7 +21,7 @@ const AlertDetails: ComponentType = () => {
 
   useEffect(() => {
     // If the alerts fetch has finished and the ID in the URL does not exist in the list, go back to the Posted Alerts page.
-    if (alerts) {
+    if (alerts.length) {
       const selectedAlert = alerts.find((alert) => alert.id === id);
       if (!selectedAlert) {
         navigate("/alerts", { replace: true });

--- a/assets/js/components/Dashboard/AlertDetails.tsx
+++ b/assets/js/components/Dashboard/AlertDetails.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import React, { ComponentType, useEffect, useState } from "react";
 import AlertCard from "./AlertCard";
 import { PlacesList } from "./PlacesPage";
 import { useNavigate, useOutletContext, useParams } from "react-router-dom";
@@ -16,15 +16,18 @@ const AlertDetails: ComponentType = () => {
     screensByAlertMap: ScreensByAlert;
   }>();
   const { id } = useParams();
-  const selectedAlert = alerts.find((alert) => alert.id === id);
+  const [selectedAlert, setSelectedAlert] = useState<Alert>();
+
   const alertsUiUrl = document
     .querySelector("meta[name=alerts-ui-url]")
     ?.getAttribute("content");
   const navigate = useNavigate();
 
-  if (!selectedAlert) {
-    navigate("/alerts", { replace: true });
-  }
+  useEffect(() => {
+    const selectedAlert = alerts.find((alert) => alert.id === id);
+
+    setSelectedAlert(selectedAlert);
+  }, [alerts]);
 
   return selectedAlert ? (
     <div className="alert-details">
@@ -33,7 +36,7 @@ const AlertDetails: ComponentType = () => {
           <Button
             className="alert-details__back-button"
             data-testid="alert-details-back-button"
-            onClick={() => navigate(-1)}
+            onClick={() => navigate("/alerts", { replace: true })}
           >
             <ArrowLeft /> Back
           </Button>

--- a/assets/js/components/Dashboard/AlertDetails.tsx
+++ b/assets/js/components/Dashboard/AlertDetails.tsx
@@ -20,9 +20,15 @@ const AlertDetails: ComponentType = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    const selectedAlert = alerts.find((alert) => alert.id === id);
-
-    setSelectedAlert(selectedAlert);
+    // If the alerts fetch has finished and the ID in the URL does not exist in the list, go back to the Posted Alerts page.
+    if (alerts) {
+      const selectedAlert = alerts.find((alert) => alert.id === id);
+      if (!selectedAlert) {
+        navigate("/alerts", { replace: true });
+      } else {
+        setSelectedAlert(selectedAlert);
+      }
+    }
   }, [alerts]);
 
   return selectedAlert ? (

--- a/assets/js/components/Dashboard/AlertsPage.tsx
+++ b/assets/js/components/Dashboard/AlertsPage.tsx
@@ -29,6 +29,7 @@ import { PlacesList } from "./PlacesPage";
 import classNames from "classnames";
 import AlertCard from "./AlertCard";
 import { formatEffect } from "../../util";
+import { usePlaces } from "./Dashboard";
 
 type DirectionID = 0 | 1;
 
@@ -37,28 +38,21 @@ interface AlertsResponse {
   screens_by_alert: ScreensByAlert;
 }
 
-interface Props {
-  places: Place[];
-  isVisible: boolean;
-}
-
-const AlertsPage: ComponentType<Props> = (props: Props) => {
-  const { places, isVisible } = props;
+const AlertsPage: ComponentType = () => {
+  const { places } = usePlaces();
 
   const [alerts, setAlerts] = useState<Alert[]>([]);
   const [screensByAlertMap, setScreensByAlertMap] = useState<ScreensByAlert>(
     {}
   );
   useEffect(() => {
-    if (!props.isVisible) return;
-
     fetch("/api/alerts")
       .then((response) => response.json())
       .then(({ alerts, screens_by_alert }: AlertsResponse) => {
         setAlerts(alerts);
         setScreensByAlertMap(screens_by_alert);
       });
-  }, [props.isVisible]);
+  }, []);
 
   const [selectedAlert, setSelectedAlert] = useState<Alert | null>(null);
 
@@ -81,11 +75,7 @@ const AlertsPage: ComponentType<Props> = (props: Props) => {
     ?.getAttribute("content");
 
   return (
-    <div
-      className={classNames("alerts-page", {
-        "alerts-page--hidden": !isVisible,
-      })}
-    >
+    <div className={classNames("alerts-page")}>
       <div className="page-content__header">
         {selectedAlert ? (
           <div>
@@ -127,7 +117,7 @@ const AlertsPage: ComponentType<Props> = (props: Props) => {
           </>
         ) : (
           <AlertsList
-            {...props}
+            places={places}
             alerts={alertsWithPlaces}
             selectAlert={setSelectedAlert}
             screensByAlertMap={screensByAlertMap}
@@ -139,11 +129,12 @@ const AlertsPage: ComponentType<Props> = (props: Props) => {
   );
 };
 
-interface AlertsListProps extends Props {
+interface AlertsListProps {
   alerts: Alert[];
   selectAlert: Dispatch<SetStateAction<Alert | null>>;
   screensByAlertMap: ScreensByAlert;
   placesWithSelectedAlert: (alert: Alert | null) => Place[];
+  places: Place[];
 }
 
 const AlertsList: ComponentType<AlertsListProps> = ({

--- a/assets/js/components/Dashboard/AlertsPage.tsx
+++ b/assets/js/components/Dashboard/AlertsPage.tsx
@@ -29,7 +29,7 @@ import { PlacesList } from "./PlacesPage";
 import classNames from "classnames";
 import AlertCard from "./AlertCard";
 import { formatEffect } from "../../util";
-import { usePlaces } from "./Dashboard";
+import { useOutletContext } from "react-router";
 
 type DirectionID = 0 | 1;
 
@@ -39,7 +39,7 @@ interface AlertsResponse {
 }
 
 const AlertsPage: ComponentType = () => {
-  const { places } = usePlaces();
+  const { places } = useOutletContext<{ places: Place[] }>();
 
   const [alerts, setAlerts] = useState<Alert[]>([]);
   const [screensByAlertMap, setScreensByAlertMap] = useState<ScreensByAlert>(

--- a/assets/js/components/Dashboard/AlertsPage.tsx
+++ b/assets/js/components/Dashboard/AlertsPage.tsx
@@ -14,7 +14,6 @@ import { Alert } from "../../models/alert";
 import { Place } from "../../models/place";
 import { Screen } from "../../models/screen";
 import { ScreensByAlert } from "../../models/screensByAlert";
-import classNames from "classnames";
 import AlertCard from "./AlertCard";
 import { useNavigate } from "react-router-dom";
 import { placesWithSelectedAlert } from "../../util";
@@ -30,7 +29,7 @@ const AlertsPage: ComponentType = () => {
   );
 
   return (
-    <div className={classNames("alerts-page")}>
+    <div className="alerts-page">
       <div className="page-content__header">Posted Alerts</div>
       <div className="page-content__body">
         <AlertsList

--- a/assets/js/components/Dashboard/AlertsPage.tsx
+++ b/assets/js/components/Dashboard/AlertsPage.tsx
@@ -33,46 +33,16 @@ import { useOutletContext } from "react-router";
 
 type DirectionID = 0 | 1;
 
-interface AlertsResponse {
-  alerts: Alert[];
-  screens_by_alert: ScreensByAlert;
-}
-
 const AlertsPage: ComponentType = () => {
-  const { places } = useOutletContext<{ places: Place[] }>();
-
-  const [alerts, setAlerts] = useState<Alert[]>([]);
-  const [screensByAlertMap, setScreensByAlertMap] = useState<ScreensByAlert>(
-    {}
-  );
-  useEffect(() => {
-    fetch("/api/alerts")
-      .then((response) => response.json())
-      .then(({ alerts, screens_by_alert }: AlertsResponse) => {
-        setAlerts(alerts);
-        setScreensByAlertMap(screens_by_alert);
-      });
-  }, []);
-
-  const [selectedAlert, setSelectedAlert] = useState<Alert | null>(null);
-
-  const placesWithSelectedAlert = (alert: Alert | null) => {
-    return alert
-      ? places.filter((place) =>
-          place.screens.some((screen: Screen) =>
-            screensByAlertMap[alert.id].includes(screen.id)
-          )
-        )
-      : [];
-  };
+  const { places, alerts, screensByAlertMap } = useOutletContext<{
+    places: Place[];
+    alerts: Alert[];
+    screensByAlertMap: ScreensByAlert;
+  }>();
 
   const alertsWithPlaces = alerts.filter(
     (alert) => screensByAlertMap[alert.id]
   );
-
-  const alertsUiUrl = document
-    .querySelector("meta[name=alerts-ui-url]")
-    ?.getAttribute("content");
 
   return (
     <div className={classNames("alerts-page")}>

--- a/assets/js/components/Dashboard/AlertsPage.tsx
+++ b/assets/js/components/Dashboard/AlertsPage.tsx
@@ -1,18 +1,7 @@
-import React, {
-  ComponentType,
-  Dispatch,
-  SetStateAction,
-  useEffect,
-  useState,
-} from "react";
+import React, { ComponentType, useState } from "react";
 import FilterDropdown from "./FilterDropdown";
-import { Button, Col, Container, Row } from "react-bootstrap";
-import {
-  ArrowDown,
-  ArrowLeft,
-  ArrowUp,
-  ArrowUpRight,
-} from "react-bootstrap-icons";
+import { Col, Container, Row } from "react-bootstrap";
+import { ArrowDown, ArrowUp } from "react-bootstrap-icons";
 import "../../../css/screenplay.scss";
 import {
   MODES_AND_LINES,
@@ -25,11 +14,11 @@ import { Alert } from "../../models/alert";
 import { Place } from "../../models/place";
 import { Screen } from "../../models/screen";
 import { ScreensByAlert } from "../../models/screensByAlert";
-import { PlacesList } from "./PlacesPage";
 import classNames from "classnames";
 import AlertCard from "./AlertCard";
-import { formatEffect } from "../../util";
 import { useOutletContext } from "react-router";
+import { useNavigate } from "react-router-dom";
+import { placesWithSelectedAlert } from "../../util";
 
 type DirectionID = 0 | 1;
 
@@ -46,54 +35,13 @@ const AlertsPage: ComponentType = () => {
 
   return (
     <div className={classNames("alerts-page")}>
-      <div className="page-content__header">
-        {selectedAlert ? (
-          <div>
-            <Button
-              className="back-button"
-              data-testid="places-list-back-button"
-              onClick={() => setSelectedAlert(null)}
-            >
-              <ArrowLeft /> Back
-            </Button>
-            <span>
-              {formatEffect(selectedAlert.effect)} #{selectedAlert.id}
-            </span>
-            <Button
-              href={alertsUiUrl + `/edit/${selectedAlert.id}`}
-              target="_blank"
-              className="external-link"
-            >
-              Edit Alert <ArrowUpRight />
-            </Button>
-          </div>
-        ) : (
-          "Posted Alerts"
-        )}
-      </div>
+      <div className="page-content__header">Posted Alerts</div>
       <div className="page-content__body">
-        {selectedAlert ? (
-          <>
-            <AlertCard
-              key={selectedAlert.id}
-              alert={selectedAlert}
-              classNames="selected-alert"
-            />
-            <PlacesList
-              places={placesWithSelectedAlert(selectedAlert)}
-              noModeFilter
-              isAlertPlacesList
-            />
-          </>
-        ) : (
-          <AlertsList
-            places={places}
-            alerts={alertsWithPlaces}
-            selectAlert={setSelectedAlert}
-            screensByAlertMap={screensByAlertMap}
-            placesWithSelectedAlert={placesWithSelectedAlert}
-          />
-        )}
+        <AlertsList
+          places={places}
+          alerts={alertsWithPlaces}
+          screensByAlertMap={screensByAlertMap}
+        />
       </div>
     </div>
   );
@@ -101,18 +49,14 @@ const AlertsPage: ComponentType = () => {
 
 interface AlertsListProps {
   alerts: Alert[];
-  selectAlert: Dispatch<SetStateAction<Alert | null>>;
   screensByAlertMap: ScreensByAlert;
-  placesWithSelectedAlert: (alert: Alert | null) => Place[];
   places: Place[];
 }
 
 const AlertsList: ComponentType<AlertsListProps> = ({
   alerts,
-  selectAlert,
   places,
   screensByAlertMap,
-  placesWithSelectedAlert,
 }: AlertsListProps) => {
   const [alertSortDirection, setAlertSortDirection] = useState<DirectionID>(0);
   const [alertModeLineFilterValue, setAlertModeLineFilterValue] = useState(
@@ -124,6 +68,7 @@ const AlertsList: ComponentType<AlertsListProps> = ({
   const [alertStatusFilterValue, setAlertStatusFilterValue] = useState(
     STATUSES[0]
   );
+  const navigate = useNavigate();
 
   const alertSortLabel = SORT_LABELS["Alerts"][alertSortDirection];
 
@@ -298,14 +243,20 @@ const AlertsList: ComponentType<AlertsListProps> = ({
 
           if (screensByAlert) {
             numScreens = screensByAlert.length;
-            numPlaces = placesWithSelectedAlert(alert).length;
+            numPlaces = placesWithSelectedAlert(
+              alert,
+              places,
+              screensByAlertMap
+            ).length;
           }
 
           return (
             <AlertCard
               key={alert.id}
               alert={alert}
-              selectAlert={() => selectAlert(alert)}
+              selectAlert={() => {
+                navigate(`/alerts/${alert.id}`);
+              }}
               numberOfScreens={numScreens}
               numberOfPlaces={numPlaces}
             />

--- a/assets/js/components/Dashboard/Dashboard.tsx
+++ b/assets/js/components/Dashboard/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React, { ComponentType, useEffect, useState } from "react";
-import { Outlet, useOutletContext } from "react-router";
+import { Outlet } from "react-router";
 import "../../../css/screenplay.scss";
 import { Place } from "../../models/place";
 import Sidebar from "./Sidebar";
@@ -24,9 +24,5 @@ const Dashboard: ComponentType = () => {
     </div>
   );
 };
-
-export function usePlaces() {
-  return useOutletContext<{ places: Place[] }>();
-}
 
 export default Dashboard;

--- a/assets/js/components/Dashboard/Dashboard.tsx
+++ b/assets/js/components/Dashboard/Dashboard.tsx
@@ -1,16 +1,10 @@
 import React, { ComponentType, useEffect, useState } from "react";
+import { Outlet, useOutletContext } from "react-router";
 import "../../../css/screenplay.scss";
 import { Place } from "../../models/place";
 import Sidebar from "./Sidebar";
-import PlacesPage from "./PlacesPage";
-import AlertsPage from "./AlertsPage";
-import OverridesPage from "./OverridesPage";
 
-interface Props {
-  page: "places" | "alerts" | "overrides";
-}
-
-const Dashboard: ComponentType<Props> = (props: Props) => {
+const Dashboard: ComponentType = () => {
   const [places, setPlaces] = useState<Place[]>([]);
 
   useEffect(() => {
@@ -21,22 +15,18 @@ const Dashboard: ComponentType<Props> = (props: Props) => {
       });
   }, []);
 
-  const visible = {
-    places: props.page === "places",
-    alerts: props.page === "alerts",
-    overrides: props.page === "overrides",
-  };
-
   return (
     <div className="screenplay-container">
       <Sidebar />
       <div className="page-content">
-        <PlacesPage places={places} isVisible={visible.places} />
-        <AlertsPage places={places} isVisible={visible.alerts} />
-        <OverridesPage isVisible={visible.overrides} />
+        <Outlet context={{ places }} />
       </div>
     </div>
   );
 };
+
+export function usePlaces() {
+  return useOutletContext<{ places: Place[] }>();
+}
 
 export default Dashboard;

--- a/assets/js/components/Dashboard/Dashboard.tsx
+++ b/assets/js/components/Dashboard/Dashboard.tsx
@@ -1,11 +1,31 @@
 import React, { ComponentType, useEffect, useState } from "react";
 import { Outlet } from "react-router";
 import "../../../css/screenplay.scss";
+import { Alert } from "../../models/alert";
 import { Place } from "../../models/place";
+import { ScreensByAlert } from "../../models/screensByAlert";
 import Sidebar from "./Sidebar";
+
+interface AlertsResponse {
+  alerts: Alert[];
+  screens_by_alert: ScreensByAlert;
+}
 
 const Dashboard: ComponentType = () => {
   const [places, setPlaces] = useState<Place[]>([]);
+  const [alerts, setAlerts] = useState<Alert[]>([]);
+  const [screensByAlertMap, setScreensByAlertMap] = useState<ScreensByAlert>(
+    {}
+  );
+
+  useEffect(() => {
+    fetch("/api/alerts")
+      .then((response) => response.json())
+      .then(({ alerts, screens_by_alert }: AlertsResponse) => {
+        setAlerts(alerts);
+        setScreensByAlertMap(screens_by_alert);
+      });
+  }, []);
 
   useEffect(() => {
     fetch("/api/dashboard")
@@ -19,7 +39,7 @@ const Dashboard: ComponentType = () => {
     <div className="screenplay-container">
       <Sidebar />
       <div className="page-content">
-        <Outlet context={{ places }} />
+        <Outlet context={{ places, alerts, screensByAlertMap }} />
       </div>
     </div>
   );

--- a/assets/js/components/Dashboard/PlacesPage.tsx
+++ b/assets/js/components/Dashboard/PlacesPage.tsx
@@ -13,6 +13,7 @@ import {
   SCREEN_TYPES,
   STATUSES,
 } from "../../constants/constants";
+import { usePlaces } from "./Dashboard";
 
 type DirectionID = 0 | 1;
 
@@ -30,23 +31,18 @@ const getSortLabel = (
   }
 };
 
-interface Props {
-  places: Place[];
-  isVisible: boolean;
-}
+const PlacesPage: ComponentType = () => {
+  const { places } = usePlaces();
 
-const PlacesPage: ComponentType<Props> = (props: Props) => (
-  <div
-    className={classNames("places-page", {
-      "places-page--hidden": !props.isVisible,
-    })}
-  >
-    <div className="page-content__header">Places</div>
-    <div className="page-content__body">
-      <PlacesList places={props.places} />
+  return (
+    <div className={classNames("places-page")}>
+      <div className="page-content__header">Places</div>
+      <div className="page-content__body">
+        <PlacesList places={places} />
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 interface PlacesListProps {
   places: Place[];

--- a/assets/js/components/Dashboard/PlacesPage.tsx
+++ b/assets/js/components/Dashboard/PlacesPage.tsx
@@ -13,7 +13,7 @@ import {
   SCREEN_TYPES,
   STATUSES,
 } from "../../constants/constants";
-import { usePlaces } from "./Dashboard";
+import { useOutletContext } from "react-router";
 
 type DirectionID = 0 | 1;
 
@@ -32,7 +32,7 @@ const getSortLabel = (
 };
 
 const PlacesPage: ComponentType = () => {
-  const { places } = usePlaces();
+  const { places } = useOutletContext<{ places: Place[] }>();
 
   return (
     <div className={classNames("places-page")}>

--- a/assets/js/util.ts
+++ b/assets/js/util.ts
@@ -4,6 +4,10 @@ import {
 } from "./components/OutfrontTakeoverTool/OutfrontTakeoverTool";
 import CANNED_MESSAGES from "./constants/messages";
 import STATIONS_BY_LINE from "./constants/stations";
+import { Alert } from "./models/alert";
+import { Place } from "./models/place";
+import { ScreensByAlert } from "./models/screensByAlert";
+import { Screen } from "./models/screen";
 
 export const color = (line: string) => {
   switch (line) {
@@ -87,4 +91,18 @@ export const formatEffect = (effect: string) => {
     .split("_")
     .map((str: string) => str[0].toUpperCase() + str.substring(1))
     .join(" ");
+};
+
+export const placesWithSelectedAlert = (
+  alert: Alert | null,
+  places: Place[],
+  screensByAlertMap: ScreensByAlert
+) => {
+  return alert
+    ? places.filter((place) =>
+        place.screens.some((screen: Screen) =>
+          screensByAlertMap[alert.id].includes(screen.id)
+        )
+      )
+    : [];
 };

--- a/assets/tests/components/alertsPage.test.tsx
+++ b/assets/tests/components/alertsPage.test.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 import { act, fireEvent, render, waitFor } from "@testing-library/react";
-import alerts from "../alerts.test.json";
-import alertsOnScreens from "../alerts_on_screens.test.json";
 import AlertsPage from "../../js/components/Dashboard/AlertsPage";
 import {
   mockOutletContextData,
@@ -16,22 +14,6 @@ beforeAll(() => {
 });
 
 describe("Alerts Page", () => {
-  let originalFetch: any;
-
-  beforeEach(() => {
-    originalFetch = global.fetch;
-    global.fetch = jest.fn(() =>
-      Promise.resolve({
-        json: () =>
-          Promise.resolve({ alerts, screens_by_alert: alertsOnScreens }),
-      })
-    ) as jest.Mock;
-  });
-
-  afterEach(() => {
-    global.fetch = originalFetch;
-  });
-
   describe("filtering", () => {
     test("filters places by mode and route", async () => {
       const { getByRole, findByRole, getByTestId, queryByTestId } = render(
@@ -129,26 +111,6 @@ describe("Alerts Page", () => {
         fireEvent.click(getByTestId("sort-label"));
         await waitFor(() => {
           expect(getByTestId("sort-label").textContent?.trim()).toBe("END");
-        });
-      });
-    });
-  });
-
-  describe("Alert Places List", () => {
-    test("navigating to / from the places list for an alert", async () => {
-      const { getByTestId, getByText, queryByTestId, queryByText } = render(
-        <RenderRouteWithOutletContext context={mockOutletContextData}>
-          <AlertsPage />
-        </RenderRouteWithOutletContext>
-      );
-
-      await act(async () => {
-        await waitFor(() => {
-          expect(queryByTestId("10")).toBeInTheDocument();
-          fireEvent.click(getByTestId("10"));
-          expect(getByText(/delay #10/i)).toBeInTheDocument();
-          fireEvent.click(getByTestId("places-list-back-button"));
-          expect(queryByText(/delay #10/i)).not.toBeInTheDocument();
         });
       });
     });

--- a/assets/tests/components/alertsPage.test.tsx
+++ b/assets/tests/components/alertsPage.test.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { act, fireEvent, render, waitFor } from "@testing-library/react";
-import { Place } from "../../js/models/place";
 import alerts from "../alerts.test.json";
-import placesAndScreens from "../places_and_screens.test.json";
 import alertsOnScreens from "../alerts_on_screens.test.json";
 import AlertsPage from "../../js/components/Dashboard/AlertsPage";
+import {
+  mockOutletContextData,
+  RenderRouteWithOutletContext,
+} from "../utils/RenderRouteWithOutletContext";
 
 beforeAll(() => {
   const app = document.createElement("div");
@@ -33,7 +35,9 @@ describe("Alerts Page", () => {
   describe("filtering", () => {
     test("filters places by mode and route", async () => {
       const { getByRole, findByRole, getByTestId, queryByTestId } = render(
-        <AlertsPage places={placesAndScreens as Place[]} isVisible={true} />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <AlertsPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -80,7 +84,9 @@ describe("Alerts Page", () => {
 
     test("filters places by screen type", async () => {
       const { getByRole, findByRole, getByTestId, queryAllByTestId } = render(
-        <AlertsPage places={placesAndScreens as Place[]} isVisible={true} />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <AlertsPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -113,7 +119,9 @@ describe("Alerts Page", () => {
   describe("sorting", () => {
     test("sort label when clicked", async () => {
       const { getByTestId } = render(
-        <AlertsPage places={placesAndScreens as Place[]} isVisible={true} />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <AlertsPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -129,7 +137,9 @@ describe("Alerts Page", () => {
   describe("Alert Places List", () => {
     test("navigating to / from the places list for an alert", async () => {
       const { getByTestId, getByText, queryByTestId, queryByText } = render(
-        <AlertsPage places={placesAndScreens as Place[]} isVisible={true} />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <AlertsPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {

--- a/assets/tests/components/placesPage.test.tsx
+++ b/assets/tests/components/placesPage.test.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import placesAndScreens from "../places_and_screens.test.json";
-import { Place } from "../../js/models/place";
 import PlacesPage from "../../js/components/Dashboard/PlacesPage";
+import {
+  mockOutletContextData,
+  RenderRouteWithOutletContext,
+} from "../utils/RenderRouteWithOutletContext";
 
 beforeAll(() => {
   const app = document.createElement("div");
@@ -30,7 +33,9 @@ describe("PlacesPage", () => {
   describe("filtering", () => {
     test("filters places by screen type", async () => {
       const { getByRole, getByText, queryByText, findByRole } = render(
-        <PlacesPage places={placesAndScreens as Place[]} isVisible />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <PlacesPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -66,7 +71,9 @@ describe("PlacesPage", () => {
 
     test("filters places by mode and route", async () => {
       const { getByRole, getByText, queryByText, findByRole } = render(
-        <PlacesPage places={placesAndScreens as Place[]} isVisible />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <PlacesPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -102,7 +109,9 @@ describe("PlacesPage", () => {
 
     test("adds `filtered` class to PlaceRow when filtered", async () => {
       const { findByRole, getByRole, getAllByTestId } = render(
-        <PlacesPage places={placesAndScreens as Place[]} isVisible={true} />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <PlacesPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -118,7 +127,9 @@ describe("PlacesPage", () => {
 
     test("reset button clears filters", async () => {
       const { findByRole, getByRole, getByTestId, getByText } = render(
-        <PlacesPage places={placesAndScreens as Place[]} isVisible={true} />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <PlacesPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -135,7 +146,9 @@ describe("PlacesPage", () => {
   describe("sorting", () => {
     test("sort label changes depending on filter selected", async () => {
       const { getByTestId, getByRole, findByRole } = render(
-        <PlacesPage places={placesAndScreens as Place[]} isVisible />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <PlacesPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -166,7 +179,9 @@ describe("PlacesPage", () => {
 
     test("sort label changes when clicked", async () => {
       const { getByTestId, getByRole, findByRole } = render(
-        <PlacesPage places={placesAndScreens as Place[]} isVisible />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <PlacesPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -206,7 +221,9 @@ describe("PlacesPage", () => {
 
     test("sort order changes for RL", async () => {
       const { getByTestId, getAllByTestId, findByRole, getByRole } = render(
-        <PlacesPage places={placesAndScreens as Place[]} isVisible />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <PlacesPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -245,7 +262,9 @@ describe("PlacesPage", () => {
 
     test("sort order changes for OL", async () => {
       const { getByTestId, getAllByTestId, findByRole, getByRole } = render(
-        <PlacesPage places={placesAndScreens as Place[]} isVisible />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <PlacesPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -284,7 +303,9 @@ describe("PlacesPage", () => {
 
     test("sort order changes for GL", async () => {
       const { getByTestId, getAllByTestId, findByRole, getByRole } = render(
-        <PlacesPage places={placesAndScreens as Place[]} isVisible />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <PlacesPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {
@@ -331,7 +352,9 @@ describe("PlacesPage", () => {
 
     test("sort order changes for BL", async () => {
       const { getByTestId, getAllByTestId, findByRole, getByRole } = render(
-        <PlacesPage places={placesAndScreens as Place[]} isVisible />
+        <RenderRouteWithOutletContext context={mockOutletContextData}>
+          <PlacesPage />
+        </RenderRouteWithOutletContext>
       );
 
       await act(async () => {

--- a/assets/tests/components/placesPage.test.tsx
+++ b/assets/tests/components/placesPage.test.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { act, fireEvent, render, waitFor } from "@testing-library/react";
-import placesAndScreens from "../places_and_screens.test.json";
 import PlacesPage from "../../js/components/Dashboard/PlacesPage";
 import {
   mockOutletContextData,
@@ -15,21 +14,6 @@ beforeAll(() => {
 });
 
 describe("PlacesPage", () => {
-  let originalFetch: any;
-
-  beforeEach(() => {
-    originalFetch = global.fetch;
-    global.fetch = jest.fn(() =>
-      Promise.resolve({
-        json: () => Promise.resolve(placesAndScreens),
-      })
-    ) as jest.Mock;
-  });
-
-  afterEach(() => {
-    global.fetch = originalFetch;
-  });
-
   describe("filtering", () => {
     test("filters places by screen type", async () => {
       const { getByRole, getByText, queryByText, findByRole } = render(

--- a/assets/tests/utils/RenderRouteWithOutletContext.tsx
+++ b/assets/tests/utils/RenderRouteWithOutletContext.tsx
@@ -2,9 +2,13 @@ import React from "react";
 import { ReactNode } from "react";
 import placesAndScreens from "../places_and_screens.test.json";
 import { MemoryRouter, Outlet, Route, Routes } from "react-router-dom";
+import alerts from "../alerts.test.json";
+import alertsOnScreens from "../alerts_on_screens.test.json";
 
 export const mockOutletContextData: any = {
   places: placesAndScreens,
+  alerts: alerts,
+  screensByAlertMap: alertsOnScreens,
 };
 
 interface RenderRouteWithOutletContextProps<T = any> {

--- a/assets/tests/utils/RenderRouteWithOutletContext.tsx
+++ b/assets/tests/utils/RenderRouteWithOutletContext.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { ReactNode } from "react";
+import placesAndScreens from "../places_and_screens.test.json";
+import { MemoryRouter, Outlet, Route, Routes } from "react-router-dom";
+
+export const mockOutletContextData: any = {
+  places: placesAndScreens,
+};
+
+interface RenderRouteWithOutletContextProps<T = any> {
+  context: T;
+  children: ReactNode;
+}
+
+export const RenderRouteWithOutletContext = <T,>({
+  context,
+  children,
+}: RenderRouteWithOutletContextProps<T>) => {
+  return (
+    <MemoryRouter>
+      <Routes>
+        <Route path="/" element={<Outlet context={context as T} />}>
+          <Route index element={children} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  );
+};

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -2,16 +2,16 @@ defmodule ScreenplayWeb.Router do
   use ScreenplayWeb, :router
 
   pipeline :browser do
-    plug :accepts, ["html"]
-    plug :fetch_session
-    plug :fetch_flash
-    plug :protect_from_forgery
-    plug :put_secure_browser_headers
-    plug ScreenplayWeb.Plugs.Metadata
+    plug(:accepts, ["html"])
+    plug(:fetch_session)
+    plug(:fetch_flash)
+    plug(:protect_from_forgery)
+    plug(:put_secure_browser_headers)
+    plug(ScreenplayWeb.Plugs.Metadata)
   end
 
   pipeline :api do
-    plug :accepts, ["json"]
+    plug(:accepts, ["json"])
   end
 
   pipeline :redirect_prod_http do
@@ -35,32 +35,32 @@ defmodule ScreenplayWeb.Router do
   # Load balancer health check
   # Exempt from auth checks and SSL redirects
   scope "/", ScreenplayWeb do
-    get "/_health", HealthController, :index
+    get("/_health", HealthController, :index)
   end
 
   scope "/", ScreenplayWeb.OutfrontTakeoverTool do
-    pipe_through [
+    pipe_through([
       :redirect_prod_http,
       :browser,
       :auth,
       :ensure_auth,
       :ensure_screenplay_admin_group
-    ]
+    ])
 
     get("/", PageController, :takeover_redirect)
     get("/emergency-takeover", PageController, :index)
   end
 
   scope "/", ScreenplayWeb do
-    pipe_through [:redirect_prod_http, :browser, :auth, :ensure_auth]
+    pipe_through([:redirect_prod_http, :browser, :auth, :ensure_auth])
 
     get("/dashboard", DashboardController, :index)
-    get("/alerts", AlertsController, :index)
+    get("/alerts/*id", AlertsController, :index)
     get("/unauthorized", UnauthorizedController, :index)
   end
 
   scope "/api", ScreenplayWeb do
-    pipe_through [:redirect_prod_http, :browser, :auth, :ensure_auth]
+    pipe_through([:redirect_prod_http, :browser, :auth, :ensure_auth])
 
     get("/dashboard", DashboardApiController, :index)
     get("/alerts", AlertsApiController, :index)
@@ -75,14 +75,14 @@ defmodule ScreenplayWeb.Router do
   end
 
   scope "/api", ScreenplayWeb.OutfrontTakeoverTool do
-    pipe_through [
+    pipe_through([
       :redirect_prod_http,
       :api,
       :browser,
       :auth,
       :ensure_auth,
       :ensure_screenplay_admin_group
-    ]
+    ])
 
     post("/create", AlertController, :create)
     post("/edit", AlertController, :edit)
@@ -103,8 +103,8 @@ defmodule ScreenplayWeb.Router do
     import Phoenix.LiveDashboard.Router
 
     scope "/" do
-      pipe_through :browser
-      live_dashboard "/telemetry_dashboard", metrics: ScreenplayWeb.Telemetry
+      pipe_through(:browser)
+      live_dashboard("/telemetry_dashboard", metrics: ScreenplayWeb.Telemetry)
     end
   end
 end


### PR DESCRIPTION
**Asana task**: [Alert details / alert places list to be at new URL](https://app.asana.com/0/1185117109217413/1203236363940419/f)

Task above lays out the reason for this change very well.

Implementation for it was fairly straightforward after the refactor to navigation. Only thing that may look odd is this new URL is its own `Route` on the same level as `/alerts`. I could not find a good place to render the `<Outlet />` on the `AlertsPage` when I tried to add it as a nested route. It would require more conditional rendering, which we are trying to avoid. `AlertDetails` also needs all of the same context values present in the `Outlet` in `Dashboard`. If you feel strongly above making it a nested route, I can give that a shot and we can decide the best method.

This new URL works if you navigate straight to a specific alert. And if the ID in the URL does not exist, it takes you back to `/alerts` (with a new modal to be displayed in a future task).