### PR TITLE
bugfix: http to https redirect

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -16,7 +16,6 @@ config :screenplay, ScreenplayWeb.Endpoint,
   live_view: [signing_salt: "vSiyKz7D"]
 
 config :screenplay,
-  redirect_http?: true,
   config_fetcher: Screenplay.Config.S3Fetch,
   config_s3_bucket: "mbta-ctd-config",
   record_sentry: false

--- a/config/config.exs
+++ b/config/config.exs
@@ -16,6 +16,7 @@ config :screenplay, ScreenplayWeb.Endpoint,
   live_view: [signing_salt: "vSiyKz7D"]
 
 config :screenplay,
+  redirect_http?: true,
   config_fetcher: Screenplay.Config.S3Fetch,
   config_s3_bucket: "mbta-ctd-config",
   record_sentry: false

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -67,7 +67,6 @@ config :phoenix, :stacktrace_depth, 20
 config :phoenix, :plug_init_mode, :runtime
 
 config :screenplay,
-  redirect_http?: false,
   sftp_host: System.get_env("SFTP_HOST"),
   sftp_user: System.get_env("SFTP_USER"),
   sftp_password: System.get_env("SFTP_PASSWORD"),

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -12,7 +12,6 @@ import Config
 config :screenplay, ScreenplayWeb.Endpoint,
   cache_static_manifest: "priv/static/cache_manifest.json",
   http: [:inet6, port: 4000],
-  redirect_http?: true,
   server: true,
   url: [port: 80]
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -62,7 +62,7 @@ unless System.get_env("PORT") do
   config :screenplay, SiteWeb.Endpoint, url: [scheme: "https", port: 443]
 
   config :screenplay, :secure_pipeline,
-    force_ssl: [host nil, rewrite_on: [:x_forwarded_proto]]
+    force_ssl: [host: nil, rewrite_on: [:x_forwarded_proto]]
 end
 
 # Check `Plug.SSL` for all available options in `force_ssl`.

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -58,7 +58,11 @@ config :ueberauth, Ueberauth,
 # We also recommend setting `force_ssl` in your endpoint, ensuring
 # no data is ever sent via http, always redirecting to https:
 
-config :screenplay, ScreenplayWeb.Endpoint,
-  force_ssl: [hsts: true]
+unless System.get_env("PORT") do
+  config :screenplay, SiteWeb.Endpoint, url: [scheme: "https", port: 443]
+
+  config :screenplay, :secure_pipeline,
+    force_ssl: [host nil, rewrite_on: [:x_forwarded_proto]]
+end
 
 # Check `Plug.SSL` for all available options in `force_ssl`.

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -63,5 +63,4 @@ config :ueberauth, Ueberauth,
 #     config :screenplay, ScreenplayWeb.Endpoint,
 #       force_ssl: [hsts: true]
 #
-
 # Check `Plug.SSL` for all available options in `force_ssl`.

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -58,8 +58,8 @@ config :ueberauth, Ueberauth,
 #
 # We also recommend setting `force_ssl` in your endpoint, ensuring
 # no data is ever sent via http, always redirecting to https:
-#
-#     config :screenplay, ScreenplayWeb.Endpoint,
-#       force_ssl: [hsts: true]
-#
+
+config :screenplay, ScreenplayWeb.Endpoint,
+  force_ssl: [hsts: true]
+
 # Check `Plug.SSL` for all available options in `force_ssl`.

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -13,7 +13,9 @@ config :screenplay, ScreenplayWeb.Endpoint,
   cache_static_manifest: "priv/static/cache_manifest.json",
   http: [:inet6, port: 4000],
   server: true,
-  url: [port: 80]
+  url: [port: 443],
+  https: [port: 443],
+  force_ssl: [hsts: true]
 
 config :screenplay,
   alerts_fetch_module: Screenplay.Alerts.S3Fetch,
@@ -57,12 +59,9 @@ config :ueberauth, Ueberauth,
 #
 # We also recommend setting `force_ssl` in your endpoint, ensuring
 # no data is ever sent via http, always redirecting to https:
-
-unless System.get_env("PORT") do
-  config :screenplay, SiteWeb.Endpoint, url: [scheme: "https", port: 443]
-
-  config :screenplay, :secure_pipeline,
-    force_ssl: [host: nil, rewrite_on: [:x_forwarded_proto]]
-end
+#
+#     config :screenplay, ScreenplayWeb.Endpoint,
+#       force_ssl: [hsts: true]
+#
 
 # Check `Plug.SSL` for all available options in `force_ssl`.

--- a/config/test.exs
+++ b/config/test.exs
@@ -7,7 +7,6 @@ config :screenplay, ScreenplayWeb.Endpoint,
   server: false
 
 config :screenplay,
-  redirect_http?: false,
   alerts_fetch_module: Screenplay.Alerts.LocalFetch,
   local_alerts_path_spec: {:test, "alerts.json"},
   config_fetcher: Screenplay.Config.LocalFetch

--- a/lib/screenplay_web/controllers/auth_controller.ex
+++ b/lib/screenplay_web/controllers/auth_controller.ex
@@ -37,7 +37,7 @@ defmodule ScreenplayWeb.AuthController do
     |> Plug.Conn.put_session(:username, name || username)
     # Redirect to whatever page they came from
     # Commenting out this line breaks everything
-    # |> redirect(to: previous_path)
+    |> redirect(to: previous_path)
   end
 
   def callback(

--- a/lib/screenplay_web/controllers/auth_controller.ex
+++ b/lib/screenplay_web/controllers/auth_controller.ex
@@ -3,10 +3,10 @@ defmodule ScreenplayWeb.AuthController do
 
   plug Ueberauth
 
-  @spec request(Plug.Conn.t(), any) :: Plug.Conn.t()
-  def request(conn, %{"provider" => provider}) when provider != "cognito" do
-    send_resp(conn, 404, "Not Found")
-  end
+  # @spec request(Plug.Conn.t(), any) :: Plug.Conn.t()
+  # def request(conn, %{"provider" => provider}) when provider != "cognito" do
+  #   send_resp(conn, 404, "Not Found")
+  # end
 
   @spec callback(Plug.Conn.t(), any) :: Plug.Conn.t()
   def callback(conn, %{"provider" => provider}) when provider != "cognito" do
@@ -22,6 +22,7 @@ defmodule ScreenplayWeb.AuthController do
     current_time = System.system_time(:second)
 
     previous_path = Plug.Conn.get_session(conn, :previous_path)
+    IO.inspect(previous_path, label: "from path")
     Plug.Conn.delete_session(conn, :previous_path)
 
     conn
@@ -33,13 +34,23 @@ defmodule ScreenplayWeb.AuthController do
     )
     |> Plug.Conn.put_session(:username, name || username)
     # Redirect to whatever page they came from
-    |> redirect(to: previous_path)
+    # |> redirect(to: previous_path)
   end
 
   def callback(
-        conn = %{assigns: %{ueberauth_failure: %Ueberauth.Failure{}}},
+        %{assigns: %{ueberauth_failure: %Ueberauth.Failure{errors: errors}}} = conn,
         _params
       ) do
+    error_messages =
+      errors
+      |> Enum.flat_map(fn
+        %Ueberauth.Failure.Error{message: message} when is_binary(message) -> [message]
+        _ -> []
+      end)
+      |> Enum.join(", ")
+
+    _ = Logger.info("[ueberauth_failure] messages=\"#{error_messages}\"")
+
     send_resp(conn, 401, "unauthenticated")
   end
 

--- a/lib/screenplay_web/controllers/auth_controller.ex
+++ b/lib/screenplay_web/controllers/auth_controller.ex
@@ -5,10 +5,10 @@ defmodule ScreenplayWeb.AuthController do
 
   plug Ueberauth
 
-  # @spec request(Plug.Conn.t(), any) :: Plug.Conn.t()
-  # def request(conn, %{"provider" => provider}) when provider != "cognito" do
-  #   send_resp(conn, 404, "Not Found")
-  # end
+  @spec request(Plug.Conn.t(), any) :: Plug.Conn.t()
+  def request(conn, %{"provider" => provider}) when provider != "cognito" do
+    send_resp(conn, 404, "Not Found")
+  end
 
   @spec callback(Plug.Conn.t(), any) :: Plug.Conn.t()
   def callback(conn, %{"provider" => provider}) when provider != "cognito" do
@@ -24,7 +24,6 @@ defmodule ScreenplayWeb.AuthController do
     current_time = System.system_time(:second)
 
     previous_path = Plug.Conn.get_session(conn, :previous_path)
-    IO.inspect(previous_path, label: "from path")
     Plug.Conn.delete_session(conn, :previous_path)
 
     conn
@@ -36,7 +35,6 @@ defmodule ScreenplayWeb.AuthController do
     )
     |> Plug.Conn.put_session(:username, name || username)
     # Redirect to whatever page they came from
-    # Commenting out this line breaks everything
     |> redirect(to: previous_path)
   end
 

--- a/lib/screenplay_web/controllers/auth_controller.ex
+++ b/lib/screenplay_web/controllers/auth_controller.ex
@@ -1,6 +1,8 @@
 defmodule ScreenplayWeb.AuthController do
   use ScreenplayWeb, :controller
 
+  require Logger
+
   plug Ueberauth
 
   # @spec request(Plug.Conn.t(), any) :: Plug.Conn.t()
@@ -34,6 +36,7 @@ defmodule ScreenplayWeb.AuthController do
     )
     |> Plug.Conn.put_session(:username, name || username)
     # Redirect to whatever page they came from
+    # Commenting out this line breaks everything
     # |> redirect(to: previous_path)
   end
 

--- a/lib/screenplay_web/controllers/auth_controller.ex
+++ b/lib/screenplay_web/controllers/auth_controller.ex
@@ -39,7 +39,7 @@ defmodule ScreenplayWeb.AuthController do
   end
 
   def callback(
-        %{assigns: %{ueberauth_failure: %Ueberauth.Failure{errors: errors}}} = conn,
+        conn = %{assigns: %{ueberauth_failure: %Ueberauth.Failure{errors: errors}}},
         _params
       ) do
     error_messages =

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -69,7 +69,7 @@ defmodule ScreenplayWeb.Router do
 
     get("/:provider", AuthController, :request)
     get("/:provider/callback", AuthController, :callback)
-    get("/:provider/logout", AuthController, :logout)
+    # get("/:provider/logout", AuthController, :logout)
   end
 
   scope "/api", ScreenplayWeb.OutfrontTakeoverTool do

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -62,7 +62,6 @@ defmodule ScreenplayWeb.Router do
 
     get("/:provider", AuthController, :request)
     get("/:provider/callback", AuthController, :callback)
-    # get("/:provider/logout", AuthController, :logout)
   end
 
   scope "/api", ScreenplayWeb.OutfrontTakeoverTool do

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -16,9 +16,7 @@ defmodule ScreenplayWeb.Router do
   end
 
   pipeline :redirect_prod_http do
-    Logger.debug("running the redirect_prod_http pipeline")
     if Application.get_env(:screenplay, :redirect_http?) do
-      Logger.debug("running the redirect")
       plug(Plug.SSL, rewrite_on: [:x_forwarded_proto])
     end
   end

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -1,6 +1,8 @@
 defmodule ScreenplayWeb.Router do
   use ScreenplayWeb, :router
 
+  require Logger
+
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
@@ -14,7 +16,9 @@ defmodule ScreenplayWeb.Router do
   end
 
   pipeline :redirect_prod_http do
+    Logger.debug("running the redirect_prod_http pipeline")
     if Application.get_env(:screenplay, :redirect_http?) do
+      Logger.debug("running the redirect")
       plug(Plug.SSL, rewrite_on: [:x_forwarded_proto])
     end
   end

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -15,11 +15,11 @@ defmodule ScreenplayWeb.Router do
     plug :accepts, ["json"]
   end
 
-  pipeline :redirect_prod_http do
-    if Application.get_env(:screenplay, :redirect_http?) do
-      plug(Plug.SSL, rewrite_on: [:x_forwarded_proto])
-    end
-  end
+  # pipeline :redirect_prod_http do
+  #   if Application.get_env(:screenplay, :redirect_http?) do
+  #     plug(Plug.SSL, rewrite_on: [:x_forwarded_proto])
+  #   end
+  # end
 
   pipeline :auth do
     plug(ScreenplayWeb.AuthManager.Pipeline)
@@ -41,7 +41,7 @@ defmodule ScreenplayWeb.Router do
 
   scope "/", ScreenplayWeb.OutfrontTakeoverTool do
     pipe_through [
-      :redirect_prod_http,
+      # :redirect_prod_http,
       :browser,
       :auth,
       :ensure_auth,
@@ -53,7 +53,7 @@ defmodule ScreenplayWeb.Router do
   end
 
   scope "/", ScreenplayWeb do
-    pipe_through [:redirect_prod_http, :browser, :auth, :ensure_auth]
+    pipe_through [:browser, :auth, :ensure_auth]
 
     get("/dashboard", DashboardController, :index)
     get("/dashboard/alerts", DashboardController, :index)
@@ -61,13 +61,13 @@ defmodule ScreenplayWeb.Router do
   end
 
   scope "/api", ScreenplayWeb do
-    pipe_through [:redirect_prod_http, :browser, :auth, :ensure_auth]
+    pipe_through [:browser, :auth, :ensure_auth]
 
     get("/dashboard", DashboardApiController, :index)
   end
 
   scope "/auth", ScreenplayWeb do
-    pipe_through([:redirect_prod_http, :browser])
+    pipe_through([:browser])
 
     get("/:provider", AuthController, :request)
     get("/:provider/callback", AuthController, :callback)
@@ -76,7 +76,7 @@ defmodule ScreenplayWeb.Router do
 
   scope "/api", ScreenplayWeb.OutfrontTakeoverTool do
     pipe_through [
-      :redirect_prod_http,
+      # :redirect_prod_http,
       :api,
       :browser,
       :auth,

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -1,8 +1,6 @@
 defmodule ScreenplayWeb.Router do
   use ScreenplayWeb, :router
 
-  require Logger
-
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
@@ -14,12 +12,6 @@ defmodule ScreenplayWeb.Router do
   pipeline :api do
     plug :accepts, ["json"]
   end
-
-  # pipeline :redirect_prod_http do
-  #   if Application.get_env(:screenplay, :redirect_http?) do
-  #     plug(Plug.SSL, rewrite_on: [:x_forwarded_proto])
-  #   end
-  # end
 
   pipeline :auth do
     plug(ScreenplayWeb.AuthManager.Pipeline)
@@ -41,7 +33,6 @@ defmodule ScreenplayWeb.Router do
 
   scope "/", ScreenplayWeb.OutfrontTakeoverTool do
     pipe_through [
-      # :redirect_prod_http,
       :browser,
       :auth,
       :ensure_auth,
@@ -76,7 +67,6 @@ defmodule ScreenplayWeb.Router do
 
   scope "/api", ScreenplayWeb.OutfrontTakeoverTool do
     pipe_through [
-      # :redirect_prod_http,
       :api,
       :browser,
       :auth,


### PR DESCRIPTION
**Asana task**: [[Screenplay] Fix http / https routing](https://app.asana.com/0/1185117109217413/1203259339371911)

Setting the https port and setting force_ssl like so seems to resolve the redirect issue in a production test env. This follows part of the pattern suggested by the Phoenix boilerplate `prod.exs`, but some of the fields (keyfile / certfile) were not needed.
