### PR TITLE
Revert "Revert hp/http-redirect-bug (#169)"

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -67,7 +67,6 @@ config :phoenix, :stacktrace_depth, 20
 config :phoenix, :plug_init_mode, :runtime
 
 config :screenplay,
-  redirect_http?: false,
   sftp_host: System.get_env("SFTP_HOST"),
   sftp_user: System.get_env("SFTP_USER"),
   sftp_password: System.get_env("SFTP_PASSWORD"),

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -12,9 +12,10 @@ import Config
 config :screenplay, ScreenplayWeb.Endpoint,
   cache_static_manifest: "priv/static/cache_manifest.json",
   http: [:inet6, port: 4000],
-  redirect_http?: true,
   server: true,
-  url: [port: 80]
+  url: [port: 443],
+  https: [port: 443],
+  force_ssl: [hsts: true]
 
 config :screenplay,
   alerts_fetch_module: Screenplay.Alerts.S3Fetch,

--- a/config/test.exs
+++ b/config/test.exs
@@ -7,7 +7,6 @@ config :screenplay, ScreenplayWeb.Endpoint,
   server: false
 
 config :screenplay,
-  redirect_http?: false,
   alerts_fetch_module: Screenplay.Alerts.LocalFetch,
   local_alerts_path_spec: {:test, "alerts.json"},
   config_fetcher: Screenplay.Config.LocalFetch

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -13,12 +13,6 @@ defmodule ScreenplayWeb.Router do
     plug :accepts, ["json"]
   end
 
-  pipeline :redirect_prod_http do
-    if Application.get_env(:screenplay, :redirect_http?) do
-      plug(Plug.SSL, rewrite_on: [:x_forwarded_proto])
-    end
-  end
-
   pipeline :auth do
     plug(ScreenplayWeb.AuthManager.Pipeline)
   end
@@ -39,7 +33,6 @@ defmodule ScreenplayWeb.Router do
 
   scope "/", ScreenplayWeb.OutfrontTakeoverTool do
     pipe_through [
-      :redirect_prod_http,
       :browser,
       :auth,
       :ensure_auth,
@@ -51,7 +44,7 @@ defmodule ScreenplayWeb.Router do
   end
 
   scope "/", ScreenplayWeb do
-    pipe_through [:redirect_prod_http, :browser, :auth, :ensure_auth]
+    pipe_through [:browser, :auth, :ensure_auth]
 
     get("/dashboard", DashboardController, :index)
     get("/dashboard/alerts", DashboardController, :index)
@@ -59,22 +52,20 @@ defmodule ScreenplayWeb.Router do
   end
 
   scope "/api", ScreenplayWeb do
-    pipe_through [:redirect_prod_http, :browser, :auth, :ensure_auth]
+    pipe_through [:browser, :auth, :ensure_auth]
 
     get("/dashboard", DashboardApiController, :index)
   end
 
   scope "/auth", ScreenplayWeb do
-    pipe_through([:redirect_prod_http, :browser])
+    pipe_through([:browser])
 
     get("/:provider", AuthController, :request)
     get("/:provider/callback", AuthController, :callback)
-    get("/:provider/logout", AuthController, :logout)
   end
 
   scope "/api", ScreenplayWeb.OutfrontTakeoverTool do
     pipe_through [
-      :redirect_prod_http,
       :api,
       :browser,
       :auth,


### PR DESCRIPTION
This is a "remake" of the original branch, as it did not deploy properly when merged into `master`.

The error that occurred:
“could not start Cowboy2 adapter, missing option :key/:keyfile”

Full error with stacktrace (questionably helpful):
```
c57fa15277aa 16:04:04.843 [notice] Application screenplay exited: Screenplay.Application.start(:normal, []) returned an error: shutdown: failed to start child: ScreenplayWeb.Endpoint

c57fa15277aa ** (EXIT) an exception was raised:

c57fa15277aa ** (ArgumentError) could not start Cowboy2 adapter, missing option :key/:keyfile

c57fa15277aa (plug_cowboy 2.5.2) lib/plug/cowboy.ex:386: Plug.Cowboy.fail/1

c57fa15277aa (plug_cowboy 2.5.2) lib/plug/cowboy.ex:144: Plug.Cowboy.args/4

c57fa15277aa (plug_cowboy 2.5.2) lib/plug/cowboy.ex:238: Plug.Cowboy.child_spec/1

c57fa15277aa (phoenix 1.6.9) lib/phoenix/endpoint/cowboy2_adapter.ex:86: Phoenix.Endpoint.Cowboy2Adapter.child_spec/3

c57fa15277aa (phoenix 1.6.9) lib/phoenix/endpoint/cowboy2_adapter.ex:66: anonymous fn/5 in Phoenix.Endpoint.Cowboy2Adapter.child_specs/2

c57fa15277aa (elixir 1.13.4) lib/enum.ex:2396: Enum."-reduce/3-lists^foldl/2-0-"/3

c57fa15277aa (phoenix 1.6.9) lib/phoenix/endpoint/cowboy2_adapter.ex:56: Phoenix.Endpoint.Cowboy2Adapter.child_specs/2

c57fa15277aa (phoenix 1.6.9) lib/phoenix/endpoint/supervisor.ex:68: Phoenix.Endpoint.Supervisor.init/1

c57fa15277aa {"Kernel pid terminated",application_controller,"{application_start_failure,screenplay,{{shutdown,{failed_to_start_child,'Elixir.ScreenplayWeb.Endpoint',{#{'__exception__' => true,'__struct__' => 'Elixir.ArgumentError',message => <<\"could not start Cowboy2 adapter, missing option :key/:keyfile\">>},[{'Elixir.Plug.Cowboy',fail,1,[{file,\"lib/plug/cowboy.ex\"},{line,386}]},{'Elixir.Plug.Cowboy',args,4,[{file,\"lib/plug/cowboy.ex\"},{line,144}]},{'Elixir.Plug.Cowboy',child_spec,1,[{file,\"lib/plug/cowboy.ex\"},{line,238}]},{'Elixir.Phoenix.Endpoint.Cowboy2Adapter',child_spec,3,[{file,\"lib/phoenix/endpoint/cowboy2_adapter.ex\"},{line,86}]},{'Elixir.Phoenix.Endpoint.Cowboy2Adapter','-child_specs/2-fun-0-',5,[{file,\"lib/phoenix/endpoint/cowboy2_adapter.ex\"},{line,66}]},{'Elixir.Enum','-reduce/3-lists^foldl/2-0-',3,[{file,\"lib/enum.ex\"},{line,2396}]},{'Elixir.Phoenix.Endpoint.Cowboy2Adapter',child_specs,2,[{file,\"lib/phoenix/endpoint/cowboy2_adapter.ex\"},{line,56}]},{'Elixir.Phoenix.Endpoint.Supervisor',init,1,[{file,\"lib/phoenix/endpoint/supervisor.ex\"},{line,68}]}]}}},{'Elixir.Screenplay.Application',start,[normal,[]]}}}"}

c57fa15277aa Kernel pid terminated (application_controller) ({application_start_failure,screenplay,{{shutdown,{failed_to_start_child,'Elixir.ScreenplayWeb.Endpoint',{#{'__exception__' => true,'__struct__' => 'Elixir.ArgumentError',message => <<"could not start Cowboy2 adapter, missing option :key/:keyfile">>},[{'Elixir.Plug.Cowboy',fail,1,[{file,"lib/plug/cowboy.ex"},{line,386}]},{'Elixir.Plug.Cowboy',args,4,[{file,"lib/plug/cowboy.ex"},{line,144}]},{'Elixir.Plug.Cowboy',child_spec,1,[{file,"lib/plug/cowboy.ex"},{line,238}]},{'Elixir.Phoenix.Endpoint.Cowboy2Adapter',child_spec,3,[{file,"lib/phoenix/endpoint/cowboy2_adapter.ex"},{line,86}]},{'Elixir.Phoenix.Endpoint.Cowboy2Adapter','-child_specs/2-fun-0-',5,[{file,"lib/phoenix/endpoint/cowboy2_adapter.ex"},{line,66}]},{'Elixir.Enum','-reduce/3-lists^foldl/2-0-',3,[{file,"lib/enum.ex"},{line,2396}]},{'Elixir.Phoenix.Endpoint.Cowboy2Adapter',child_specs,2,[{file,"lib/phoenix/endpoint/cowboy2_adapter.ex"},{line,56}]},{'Elixir.Phoenix.Endpoint.Supervisor',init,1,[{file,"lib/p
```

Original description:
**Asana task**: [[Screenplay] Fix http / https routing](https://app.asana.com/0/1185117109217413/1203259339371911)

Setting the https port and setting force_ssl like so seems to resolve the redirect issue in a production test env. This follows part of the pattern suggested by the Phoenix boilerplate `prod.exs`, but some of the fields (keyfile / certfile) were not needed.

