### PR TITLE
tweak: Report A Problem URL

### DIFF
--- a/assets/js/components/Dashboard/ReportAProblemButton.tsx
+++ b/assets/js/components/Dashboard/ReportAProblemButton.tsx
@@ -3,10 +3,16 @@ import { Button } from "react-bootstrap";
 import { FlagFill } from "react-bootstrap-icons";
 
 const ReportAProblemButton = (): JSX.Element => {
+  const isAdmin = document.querySelector("meta[name=is-admin]");
+
+  const link = isAdmin
+    ? "https://mbta.slack.com/channels/screens-team-pios"
+    : "https://mbta.slack.com/channels/screens";
+
   return (
     <div className="report-a-problem-button">
       <Button
-        href="https://mbta.slack.com/channels/screens"
+        href={link}
         onClick={(e: SyntheticEvent) => e.stopPropagation()}
         target="_blank"
       >

--- a/assets/js/components/Dashboard/ReportAProblemButton.tsx
+++ b/assets/js/components/Dashboard/ReportAProblemButton.tsx
@@ -12,6 +12,7 @@ const ReportAProblemButton = (): JSX.Element => {
   return (
     <div className="report-a-problem-button">
       <Button
+        data-testid="report-a-problem"
         href={link}
         onClick={(e: SyntheticEvent) => e.stopPropagation()}
         target="_blank"

--- a/assets/tests/components/reportAProblemButton.test.tsx
+++ b/assets/tests/components/reportAProblemButton.test.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import ReportAProblemButton from "../../js/components/Dashboard/ReportAProblemButton";
+
+describe("ReportAProblemButton", () => {
+  test("uses correct URL for non-admin users", async () => {
+    const { getByTestId } = render(<ReportAProblemButton />);
+
+    await waitFor(() =>
+      expect(getByTestId("report-a-problem")).toHaveAttribute(
+        "href",
+        "https://mbta.slack.com/channels/screens"
+      )
+    );
+  });
+
+  test("uses correct URL for admins", async () => {
+    const meta = document.createElement("meta");
+    meta.setAttribute("name", "is-admin");
+    document.head.appendChild(meta);
+
+    const { getByTestId } = render(<ReportAProblemButton />);
+
+    await waitFor(() =>
+      expect(getByTestId("report-a-problem")).toHaveAttribute(
+        "href",
+        "https://mbta.slack.com/channels/screens-team-pios"
+      )
+    );
+  });
+});

--- a/lib/screenplay_web/controllers/dashboard_controller.ex
+++ b/lib/screenplay_web/controllers/dashboard_controller.ex
@@ -1,33 +1,7 @@
 defmodule ScreenplayWeb.DashboardController do
   use ScreenplayWeb, :controller
 
-  alias Screenplay.Util
-
-  plug(:env_vars)
-
   def index(conn, _params) do
-    render(conn, "index.html", clarity_tag: System.get_env("CLARITY_TAG"))
-  end
-
-  defp env_vars(conn, _) do
-    username =
-      conn
-      |> get_session("username")
-      |> Util.trim_username()
-
-    dsn =
-      if Application.get_env(:screenplay, :record_sentry, false) do
-        Application.get_env(:screenplay, :sentry_frontend_dsn)
-      else
-        ""
-      end
-
-    conn
-    |> assign(:username, username)
-    |> assign(:environment_name, Application.get_env(:screenplay, :environment_name, "dev"))
-    |> assign(:sentry_frontend_dsn, dsn)
-    |> assign(:alerts_ui_url, Application.get_env(:screenplay, :alerts_ui_url))
-    |> assign(:screens_url, Application.get_env(:screenplay, :screens_url))
-    |> assign(:signs_ui_url, Application.get_env(:screenplay, :signs_ui_url))
+    render(conn, "index.html")
   end
 end

--- a/lib/screenplay_web/plugs/metadata.ex
+++ b/lib/screenplay_web/plugs/metadata.ex
@@ -33,5 +33,13 @@ defmodule ScreenplayWeb.Plugs.Metadata do
     |> assign(:alerts_ui_url, Application.get_env(:screenplay, :alerts_ui_url))
     |> assign(:screens_url, Application.get_env(:screenplay, :screens_url))
     |> assign(:signs_ui_url, Application.get_env(:screenplay, :signs_ui_url))
+    |> assign(:is_admin, is_admin?(conn))
+  end
+
+  defp is_admin?(conn) do
+    claims = Guardian.Plug.current_claims(conn)
+
+    not is_nil(claims) and
+      ScreenplayWeb.AuthManager.claims_access_level(claims) == :admin
   end
 end

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -7,6 +7,9 @@ defmodule ScreenplayWeb.Router do
     plug(:fetch_flash)
     plug(:protect_from_forgery)
     plug(:put_secure_browser_headers)
+  end
+
+  pipeline :metadata do
     plug(ScreenplayWeb.Plugs.Metadata)
   end
 
@@ -52,7 +55,7 @@ defmodule ScreenplayWeb.Router do
   end
 
   scope "/", ScreenplayWeb do
-    pipe_through([:redirect_prod_http, :browser, :auth, :ensure_auth])
+    pipe_through([:redirect_prod_http, :browser, :auth, :ensure_auth, :metadata])
 
     get("/dashboard", DashboardController, :index)
     get("/alerts/*id", AlertsController, :index)

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -47,7 +47,8 @@ defmodule ScreenplayWeb.Router do
       :browser,
       :auth,
       :ensure_auth,
-      :ensure_screenplay_admin_group
+      :ensure_screenplay_admin_group,
+      :metadata
     ])
 
     get("/", PageController, :takeover_redirect)

--- a/lib/screenplay_web/templates/layout/app.html.heex
+++ b/lib/screenplay_web/templates/layout/app.html.heex
@@ -22,6 +22,9 @@
     <%= if @alerts_ui_url do %>
         <meta name="alerts-ui-url" content={@alerts_ui_url}>
     <% end %>
+    <%= if @is_admin do %>
+        <meta name="is-admin" content={@is_admin}>
+    <% end %>
     <%= csrf_meta_tag() %>
     <title>Screenplay</title>
     <link rel="stylesheet" href={Routes.static_path(@conn, "/css/app.css")}/>


### PR DESCRIPTION
**Asana task**: [[Screenplay] For PIOs, "report a problem" button goes to new private slack channel](https://app.asana.com/0/1185117109217413/1203365549546187/f)

PIOs now have a new private Slack channel to use when communicating with our team. This PR changes the Report a Problem button to redirect to it if the logged in user is an admin. The only Screenplay admins are PIOs (and maybe a couple of our team members) so it is safe to assume that an admin has access to the private channel. If you are not an admin, the button continues to redirect you to #screens.