### PR TITLE
polish: Trim backslashes in route conditionals

### DIFF
--- a/assets/js/components/Dashboard/AlertBanner.tsx
+++ b/assets/js/components/Dashboard/AlertBanner.tsx
@@ -36,7 +36,7 @@ const AlertBanner: ComponentType = () => {
   const aOrAn = (route: string) => (route === "Orange Line" ? "An" : "A");
 
   const getBannerText = () => {
-    const route = params["*"] || "";
+    const route = (params["*"] || "").replace(/\//g, "");
 
     const affectedListString = getAffectedListString();
 

--- a/assets/js/components/Dashboard/Sidebar.tsx
+++ b/assets/js/components/Dashboard/Sidebar.tsx
@@ -9,7 +9,7 @@ import {
 import TSquare from "../../../static/images/t-square.svg";
 
 const Sidebar: ComponentType = () => {
-  const pathname = useLocation().pathname;
+  const pathname = useLocation().pathname.replace(/\//g, "");
   // @ts-ignore Suppressing "object could be null" warning
   const username = document
     .querySelector("meta[name=username]")
@@ -28,13 +28,13 @@ const Sidebar: ComponentType = () => {
       {/* TODO: Both the Link and the Button allow for tab selection. Only one should. */}
       <nav>
         <Link className="sidebar-link" to="/dashboard">
-          <Button className={pathname === "/dashboard" ? "selected" : ""}>
+          <Button className={pathname === "dashboard" ? "selected" : ""}>
             <CollectionFill size={20} />
             <span className="nav-link__name">Places</span>
           </Button>
         </Link>
         <Link className="sidebar-link" to="/alerts">
-          <Button className={pathname === "/alerts" ? "selected" : ""}>
+          <Button className={pathname === "alerts" ? "selected" : ""}>
             <ExclamationTriangleFill size={20} />
             <span className="nav-link__name">Posted Alerts</span>
           </Button>


### PR DESCRIPTION
Notion [task](https://www.notion.so/mbta-downtown-crossing/Trim-backslashes-from-route-conditionals-8f805cbc156e44b8aebe8fdd2ca5153b)

For some conditionals, we are looking for certain routes for special styling or text. This logic is thrown off when there is a trailing `/` on the URL. Because that being present is still a valid URL, I trimmed all backslashes in routes before doing any comparisons.
