### PR TITLE
polish: Use local state on AlertDetails

### DIFF
--- a/assets/js/components/Dashboard/AlertDetails.tsx
+++ b/assets/js/components/Dashboard/AlertDetails.tsx
@@ -10,7 +10,15 @@ import {
   SlashCircleFill,
 } from "react-bootstrap-icons";
 import { formatEffect, placesWithSelectedAlert } from "../../util";
-import { useScreenplayContext } from "../../hooks/useScreenplayContext";
+import {
+  DirectionID,
+  useScreenplayContext,
+} from "../../hooks/useScreenplayContext";
+import {
+  MODES_AND_LINES,
+  SCREEN_TYPES,
+  STATUSES,
+} from "../../constants/constants";
 
 const AlertDetails: ComponentType = () => {
   const screenplayContext = useScreenplayContext();
@@ -26,6 +34,44 @@ const AlertDetails: ComponentType = () => {
   const navigate = useNavigate();
 
   const [showModal, setShowModal] = useState(false);
+  const [sortDirection, setSortDirection] = useState(0 as DirectionID);
+  const [modeLineFilterValue, setModeLineFilterValue] = useState(
+    MODES_AND_LINES[0]
+  );
+  const [screenTypeFilterValue, setScreenTypeFilterValue] = useState(
+    SCREEN_TYPES[0]
+  );
+  const [statusFilterValue, setStatusFilterValue] = useState(STATUSES[0]);
+  const [activeEventKeys, setActiveEventKeys] = useState([]);
+
+  const dispatch = (action: any) => {
+    switch (action.type) {
+      case "SET_SORT_DIRECTION":
+        setSortDirection(action.sortDirection);
+        break;
+      case "SET_MODE_LINE_FILTER":
+        setModeLineFilterValue(action.filterValue);
+        setActiveEventKeys([]);
+        break;
+      case "SET_SCREEN_TYPE_FILTER":
+        setScreenTypeFilterValue(action.filterValue);
+        setActiveEventKeys([]);
+        break;
+      case "SET_STATUS_FILTER":
+        setStatusFilterValue(action.filterValue);
+        setActiveEventKeys([]);
+        break;
+      case "SET_ACTIVE_EVENT_KEYS":
+        setActiveEventKeys(action.eventKeys);
+        break;
+      case "RESET_STATE":
+        setSortDirection(0 as DirectionID);
+        setModeLineFilterValue(MODES_AND_LINES[0]);
+        setScreenTypeFilterValue(SCREEN_TYPES[0]);
+        setStatusFilterValue(STATUSES[0]);
+        setActiveEventKeys([]);
+    }
+  };
 
   useEffect(() => {
     const selectedAlert = screenplayContext.alerts.length
@@ -74,9 +120,17 @@ const AlertDetails: ComponentType = () => {
                 places,
                 screensByAlertMap
               )}
+              dispatch={dispatch}
               noModeFilter
               isAlertPlacesList
               showAnimationForNewPlaces
+              stateValues={{
+                sortDirection,
+                modeLineFilterValue,
+                screenTypeFilterValue,
+                statusFilterValue,
+                activeEventKeys,
+              }}
             />
           </div>
         )}

--- a/assets/js/components/Dashboard/AlertsPage.tsx
+++ b/assets/js/components/Dashboard/AlertsPage.tsx
@@ -175,7 +175,7 @@ const AlertsList: ComponentType<AlertsListProps> = ({
 
       return screensWithAlert
         ? screensWithAlert.find((screen_id) =>
-            ids.includes(screenMetaData[screen_id].type)
+            ids.includes(screenMetaData[screen_id]?.type)
           )
         : false;
     });

--- a/assets/js/hooks/useScreenplayContext.tsx
+++ b/assets/js/hooks/useScreenplayContext.tsx
@@ -260,4 +260,6 @@ export {
   useAlertsPageContext,
   useAlertsPageDispatchContext,
   ScreenplayProvider,
+  FilterValue,
+  DirectionID,
 };


### PR DESCRIPTION
Notion [task](https://www.notion.so/mbta-downtown-crossing/Expanded-station-rows-should-not-persist-between-different-alert-details-pages-f89d161f1df64393bef4ded06473f087)

Because `AlertDetails` and `PlacesPage` both use `PlacesList`, we are inadvertently dispatching state change for `PlacesPage` from `AlertDetails`. `AlertDetails` state does not need to persist at all, so I refactored `PlacesList` to take in state related functions/values as props. This allows a component to control where state is stored (in the Screenplay context or locally). 

I tested this and everything works, but it feels very messy. Any suggestions for better ways to do this are encouraged. 