### PR TITLE
polish: AlertDetails button styling

### DIFF
--- a/assets/css/dashboard/alert-details.scss
+++ b/assets/css/dashboard/alert-details.scss
@@ -9,11 +9,23 @@
     margin-right: 24px;
     background: $main-blue;
     border: 1px solid rgba(23, 31, 38, 0.3);
+    border-radius: 6px;
+
+    &:hover {
+      background: rgba(0, 117, 219, 0.6);
+      border: 1px solid rgba(23, 31, 38, 0.3);
+    }
   }
 
   &__external-link {
     margin-left: 24px;
-    background: unset;
+    background: $cool-gray-30;
     border: 1px solid rgba(23, 31, 38, 0.3);
+    border-radius: 6px;
+
+    &:hover {
+      background: rgba(23, 31, 38, 0.3);
+      border: 1px solid transparent;
+    }
   }
 }


### PR DESCRIPTION
Notion [task](https://www.notion.so/mbta-downtown-crossing/Edit-alert-button-hover-color-should-not-be-blue-15a93fa85b1f4ebf84a466f3be21f366)

Tweaked styling of the `Edit Alert` and `Back` buttons so they match designs. Design [link](https://www.figma.com/file/AXmojXuKz4TRVhznOIMuBJ/Screenplay-Design?node-id=943%3A20818&t=ZL4ohOrtaGF6eBCF-4).
