### PR TITLE
polish: SL pill logic for alerts

### DIFF
--- a/lib/screenplay/alerts/parser.ex
+++ b/lib/screenplay/alerts/parser.ex
@@ -96,8 +96,12 @@ defmodule Screenplay.Alerts.Parser do
 
   defp get_affected_list(%{"routes" => %{"data" => routes}}, included) do
     route_map =
-      Enum.map(included, fn %{"id" => id, "attributes" => %{"type" => route_type}} ->
-        {id, route_type}
+      Enum.map(included, fn
+        %{"id" => id, "attributes" => %{"short_name" => "SL" <> _}} ->
+          {id, "silver"}
+
+        %{"id" => id, "attributes" => %{"type" => route_type}} ->
+          {id, route_type}
       end)
       |> Enum.into(%{})
 
@@ -105,10 +109,11 @@ defmodule Screenplay.Alerts.Parser do
       Enum.map(routes, fn %{"id" => id} ->
         case Map.get(route_map, id) do
           nil -> nil
+          route_type when route_type in [0, 1] -> String.downcase(id)
           2 -> "cr"
           3 -> "bus"
           4 -> "ferry"
-          _ -> String.downcase(id)
+          route_type -> String.downcase(route_type)
         end
       end)
       |> Enum.reject(&is_nil/1)


### PR DESCRIPTION
Notion [task](https://www.notion.so/mbta-downtown-crossing/Silver-Line-alerts-are-showing-a-Bus-Icon-not-SL-icon-3ca16897394a4df689c22925b05746f5)

SL was being displayed as Bus on `AlertCard`s. I had to adjust the logic slightly because SL wants to believe it's actually Bus (it's `route_type` is the same as Bus)... 
