### PR TITLE
polish: AlertCard animation

### DIFF
--- a/assets/js/components/Dashboard/AlertCard.tsx
+++ b/assets/js/components/Dashboard/AlertCard.tsx
@@ -25,7 +25,7 @@ const AlertCard = (props: AlertCardProps): JSX.Element => {
   const { showAnimation } = useUpdateAnimation(
     [
       alert.header,
-      JSON.stringify(alert.active_period),
+      alert.active_period[0].start,
       numberOfPlaces,
       numberOfScreens,
     ],


### PR DESCRIPTION
Notion [task](https://www.notion.so/mbta-downtown-crossing/Don-t-show-highlight-animation-when-alert-duration-changes-ef478a2f0045443092be5ee8cbb40b47)

When alerts are created with an end date of `Until later today`, the end date is changed by the API once a minute of two. This is causing animations to happen too frequently for those alerts. Because we have no way of determining if an alert was created using `Until later today`, the best thing to do is only consider start date in the animation hook. 
