### PR TITLE
polish: Change station/stations to place/places

### DIFF
--- a/assets/js/components/Dashboard/PlacesActionBar.tsx
+++ b/assets/js/components/Dashboard/PlacesActionBar.tsx
@@ -90,7 +90,7 @@ const ActionBarStats: React.ComponentType<StatsProps> = ({
       >
         {placeCount}
       </span>{" "}
-      {placeCount == 1 ? "station" : "stations"} ·{" "}
+      {placeCount == 1 ? "place" : "places"} ·{" "}
       <span
         className="places-action-bar__stats__number"
         data-testid="places-action-bar-stats-screen-count"


### PR DESCRIPTION
[Notion Task](https://www.notion.so/mbta-downtown-crossing/Mismatched-wording-for-Places-8e4f1201930d4632b24463cd2ff578fa)

Use place/places instead of station/stations on the places action bar

![Screenshot 2022-12-22 at 11 50 18 AM](https://user-images.githubusercontent.com/16074540/209187545-86f15e82-caf6-403d-8957-7011b96bce72.png)
