### PR TITLE
polish: AlertCard route pill sizing

### DIFF
--- a/assets/css/alert-card.scss
+++ b/assets/css/alert-card.scss
@@ -25,18 +25,16 @@
     }
 
     &__pill-container {
-      min-width: 38px;
+      min-width: 42px;
       display: flex;
       flex-direction: column;
+      align-items: center;
     }
 
     &__pill {
       &:not(:first-child) {
         margin-top: 8px;
       }
-
-      width: 38px;
-      height: 20px;
     }
 
     &__effect {


### PR DESCRIPTION
Notion [task](https://www.notion.so/mbta-downtown-crossing/BL-and-Bus-pill-in-alert-list-are-a-different-size-59cdde9033764addaa5445a998ec89a4)

The BL and Bus pills have a shadow that is not on the other pills. Hardcoding pill sizing was making those two pills appear smaller than the others. With these CSS adjustments, we can keep the shadow while allowing the pills to be the same size as the rest.

![Screenshot 2022-12-22 at 1 56 51 PM](https://user-images.githubusercontent.com/10713153/209208764-3e1b242e-e5b2-4409-b8ce-c508ae11d9a1.png)