### PR TITLE
polish: Sticky AlertBanner

### DIFF
--- a/assets/css/alert-banner.scss
+++ b/assets/css/alert-banner.scss
@@ -6,7 +6,7 @@
   padding: 16px 221px 16px 50px;
   position: sticky;
   top: 0;
-  z-index: 2;
+  z-index: 999;
 
   &__icon-container {
     height: 24px;

--- a/assets/css/alert-banner.scss
+++ b/assets/css/alert-banner.scss
@@ -4,6 +4,9 @@
   background-color: #095292;
   align-items: center;
   padding: 16px 221px 16px 50px;
+  position: sticky;
+  top: 0;
+  z-index: 2;
 
   &__icon-container {
     height: 24px;


### PR DESCRIPTION
Notion [task](https://www.notion.so/mbta-downtown-crossing/Banner-doesn-t-stick-when-page-is-scrolled-f93f13fd55124e9980d263dbd2ea840c)

Made the `AlertBanner` always stick to the top of the screen so it is visible after scrolling.
