### PR TITLE
Polish: Banner actively counts down based on latest alert change

### DIFF
--- a/assets/js/components/Dashboard/AlertBanner.tsx
+++ b/assets/js/components/Dashboard/AlertBanner.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import React, { ComponentType, useEffect, useState } from "react";
 import { ArrowRepeat } from "react-bootstrap-icons";
 import { formatEffect, translateRouteID } from "../../util";
 import { useParams } from "react-router-dom";
@@ -15,6 +15,28 @@ const AlertBanner: ComponentType = () => {
   if (!bannerAlert) return null;
 
   const { alert, closedAt } = bannerAlert as BannerAlert;
+
+  const [timeLeft, setTimeLeft] = useState(40);
+  
+  // Banner should expire 40s after the most recent alert change (closed/updated)
+  useEffect(() => {
+    const bannerExpireTime = (closedAt ? new Date(closedAt) : new Date(alert.updated_at)).getTime() + 40 * 1000
+    const now = new Date().getTime();
+    const secondsLeft = Math.floor(((bannerExpireTime - now) % (1000 * 60)) / 1000)
+
+    setTimeLeft(secondsLeft);
+  }, [bannerAlert])
+
+  // Every second, decrement the seconds left
+  useEffect(() => {
+    if (!timeLeft) return;
+
+    const intervalId = setInterval(() => {
+      setTimeLeft(timeLeft - 1)
+    }, 1000);
+
+    return () => { clearInterval(intervalId); }
+  }, [timeLeft]);
 
   const wasPosted = alert.created_at === alert.updated_at;
   const params = useParams();
@@ -54,7 +76,7 @@ const AlertBanner: ComponentType = () => {
               alert was just closed.`}
             </span>{" "}
             Closing an alert may cause others to appear on more screens. It
-            could take up to 40 seconds for any impacted screens to update.
+            could take up to {timeLeft} seconds for any impacted screens to update.
           </>
         );
       } else if (wasPosted) {
@@ -65,7 +87,7 @@ const AlertBanner: ComponentType = () => {
               alert was just posted.`}
             </span>{" "}
             Posting a new alert may cause others to appear on fewer screens. It
-            could take up to 40 seconds for any impacted screens to update.
+            could take up to {timeLeft} seconds for any impacted screens to update.
           </>
         );
       } else {
@@ -76,7 +98,7 @@ const AlertBanner: ComponentType = () => {
               alert was just edited.`}
             </span>{" "}
             Some edits may cause other alerts to appear on different screens
-            than before. It could take up to 40 seconds for any impacted screens
+            than before. It could take up to {timeLeft} seconds for any impacted screens
             to update.
           </>
         );
@@ -86,7 +108,7 @@ const AlertBanner: ComponentType = () => {
         return (
           <>
             <span className="bold">This alert was just posted.</span> It could
-            take up to 40 seconds for the alert to be shown all relevant
+            take up to {timeLeft} seconds for the alert to be shown all relevant
             screens, and for its list of places to be updated.
           </>
         );
@@ -97,7 +119,7 @@ const AlertBanner: ComponentType = () => {
               This alert was just edited in Alerts UI.
             </span>{" "}
             Some edits may cause this alert or others to appear on different
-            screens than before. It could take up to 40 seconds for any impacted
+            screens than before. It could take up to {timeLeft} seconds for any impacted
             screens to update.
           </>
         );

--- a/assets/js/components/Dashboard/AlertBanner.tsx
+++ b/assets/js/components/Dashboard/AlertBanner.tsx
@@ -68,6 +68,8 @@ const AlertBanner: ComponentType = () => {
 
     const affectedListString = getAffectedListString();
 
+    const plural = timeLeft === 1 ? "second" : "seconds";
+
     if (
       ["dashboard", "alerts"].includes(route) ||
       (params.id && params.id !== alert.id)
@@ -82,7 +84,7 @@ const AlertBanner: ComponentType = () => {
               alert was just closed.`}
             </span>{" "}
             Closing an alert may cause others to appear on more screens. It
-            could take up to {timeLeft} seconds for any impacted screens to
+            could take up to {timeLeft} {plural} for any impacted screens to
             update.
           </>
         );
@@ -94,7 +96,7 @@ const AlertBanner: ComponentType = () => {
               alert was just posted.`}
             </span>{" "}
             Posting a new alert may cause others to appear on fewer screens. It
-            could take up to {timeLeft} seconds for any impacted screens to
+            could take up to {timeLeft} {plural} for any impacted screens to
             update.
           </>
         );
@@ -106,8 +108,8 @@ const AlertBanner: ComponentType = () => {
               alert was just edited.`}
             </span>{" "}
             Some edits may cause other alerts to appear on different screens
-            than before. It could take up to {timeLeft} seconds for any impacted
-            screens to update.
+            than before. It could take up to {timeLeft} {plural} for any
+            impacted screens to update.
           </>
         );
       }
@@ -116,8 +118,8 @@ const AlertBanner: ComponentType = () => {
         return (
           <>
             <span className="bold">This alert was just posted.</span> It could
-            take up to {timeLeft} seconds for the alert to be shown all relevant
-            screens, and for its list of places to be updated.
+            take up to {timeLeft} {plural} for the alert to be shown all
+            relevant screens, and for its list of places to be updated.
           </>
         );
       } else {
@@ -127,7 +129,7 @@ const AlertBanner: ComponentType = () => {
               This alert was just edited in Alerts UI.
             </span>{" "}
             Some edits may cause this alert or others to appear on different
-            screens than before. It could take up to {timeLeft} seconds for any
+            screens than before. It could take up to {timeLeft} {plural} for any
             impacted screens to update.
           </>
         );

--- a/assets/js/components/Dashboard/AlertBanner.tsx
+++ b/assets/js/components/Dashboard/AlertBanner.tsx
@@ -17,25 +17,31 @@ const AlertBanner: ComponentType = () => {
   const { alert, closedAt } = bannerAlert as BannerAlert;
 
   const [timeLeft, setTimeLeft] = useState(40);
-  
+
   // Banner should expire 40s after the most recent alert change (closed/updated)
   useEffect(() => {
-    const bannerExpireTime = (closedAt ? new Date(closedAt) : new Date(alert.updated_at)).getTime() + 40 * 1000
+    const bannerExpireTime =
+      (closedAt ? new Date(closedAt) : new Date(alert.updated_at)).getTime() +
+      40 * 1000;
     const now = new Date().getTime();
-    const secondsLeft = Math.floor(((bannerExpireTime - now) % (1000 * 60)) / 1000)
+    const secondsLeft = Math.floor(
+      ((bannerExpireTime - now) % (1000 * 60)) / 1000
+    );
 
     setTimeLeft(secondsLeft);
-  }, [bannerAlert])
+  }, [bannerAlert]);
 
   // Every second, decrement the seconds left
   useEffect(() => {
     if (!timeLeft) return;
 
     const intervalId = setInterval(() => {
-      setTimeLeft(timeLeft - 1)
+      setTimeLeft(timeLeft - 1);
     }, 1000);
 
-    return () => { clearInterval(intervalId); }
+    return () => {
+      clearInterval(intervalId);
+    };
   }, [timeLeft]);
 
   const wasPosted = alert.created_at === alert.updated_at;
@@ -76,7 +82,8 @@ const AlertBanner: ComponentType = () => {
               alert was just closed.`}
             </span>{" "}
             Closing an alert may cause others to appear on more screens. It
-            could take up to {timeLeft} seconds for any impacted screens to update.
+            could take up to {timeLeft} seconds for any impacted screens to
+            update.
           </>
         );
       } else if (wasPosted) {
@@ -87,7 +94,8 @@ const AlertBanner: ComponentType = () => {
               alert was just posted.`}
             </span>{" "}
             Posting a new alert may cause others to appear on fewer screens. It
-            could take up to {timeLeft} seconds for any impacted screens to update.
+            could take up to {timeLeft} seconds for any impacted screens to
+            update.
           </>
         );
       } else {
@@ -98,8 +106,8 @@ const AlertBanner: ComponentType = () => {
               alert was just edited.`}
             </span>{" "}
             Some edits may cause other alerts to appear on different screens
-            than before. It could take up to {timeLeft} seconds for any impacted screens
-            to update.
+            than before. It could take up to {timeLeft} seconds for any impacted
+            screens to update.
           </>
         );
       }
@@ -119,8 +127,8 @@ const AlertBanner: ComponentType = () => {
               This alert was just edited in Alerts UI.
             </span>{" "}
             Some edits may cause this alert or others to appear on different
-            screens than before. It could take up to {timeLeft} seconds for any impacted
-            screens to update.
+            screens than before. It could take up to {timeLeft} seconds for any
+            impacted screens to update.
           </>
         );
       }


### PR DESCRIPTION
**Notion [task](https://www.notion.so/mbta-downtown-crossing/Screenplay-Alerts-Polish-d3f44e3eec4346a19f31f24f75fa1ae6?p=09b494315f4143f8b916673ae8eb2a31&pm=s)**

The banner should be visible and counting down until 40seconds after the alert change (closed/updated/posted). (It's likely that the countdown will never start at 40s because it takes several seconds for posts to appear in Screenplay.)

If a new change overrides the banner, the countdown is also updated.