### PR TITLE
Polish: the alerts for banner & list are filtered on the backend

### DIFF
--- a/assets/js/components/Dashboard/AlertBanner.tsx
+++ b/assets/js/components/Dashboard/AlertBanner.tsx
@@ -38,9 +38,7 @@ const AlertBanner: ComponentType<AlertBannerProps> = ({
     ) {
       return "Green Line";
     } else if (
-      alert.affected_list.every((routeId: string) =>
-        routeId.startsWith("sl")
-      )
+      alert.affected_list.every((routeId: string) => routeId.startsWith("sl"))
     ) {
       return "Silver Line";
     } else {
@@ -79,8 +77,7 @@ const AlertBanner: ComponentType<AlertBannerProps> = ({
               alert was just closed.`}
             </span>{" "}
             Closing an alert may cause others to appear on more screens. It
-            could take up to 40 seconds for any impacted screens to
-            update.
+            could take up to 40 seconds for any impacted screens to update.
           </>
         );
       } else if (wasPosted) {
@@ -91,8 +88,7 @@ const AlertBanner: ComponentType<AlertBannerProps> = ({
               alert was just posted.`}
             </span>{" "}
             Posting a new alert may cause others to appear on fewer screens. It
-            could take up to 40 seconds for any impacted screens to
-            update.
+            could take up to 40 seconds for any impacted screens to update.
           </>
         );
       } else {
@@ -103,8 +99,8 @@ const AlertBanner: ComponentType<AlertBannerProps> = ({
               alert was just edited.`}
             </span>{" "}
             Some edits may cause other alerts to appear on different screens
-            than before. It could take up to 40 seconds for any
-            impacted screens to update.
+            than before. It could take up to 40 seconds for any impacted screens
+            to update.
           </>
         );
       }
@@ -113,8 +109,8 @@ const AlertBanner: ComponentType<AlertBannerProps> = ({
         return (
           <>
             <span className="bold">This alert was just posted.</span> It could
-            take up to 40 seconds for the alert to be shown all
-            relevant screens, and for its list of places to be updated.
+            take up to 40 seconds for the alert to be shown all relevant
+            screens, and for its list of places to be updated.
           </>
         );
       } else {
@@ -124,8 +120,8 @@ const AlertBanner: ComponentType<AlertBannerProps> = ({
               This alert was just edited in Alerts UI.
             </span>{" "}
             Some edits may cause this alert or others to appear on different
-            screens than before. It could take up to 40 seconds for any
-            impacted screens to update.
+            screens than before. It could take up to 40 seconds for any impacted
+            screens to update.
           </>
         );
       }

--- a/assets/js/components/Dashboard/AlertBanner.tsx
+++ b/assets/js/components/Dashboard/AlertBanner.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, useEffect, useState } from "react";
+import React, { ComponentType } from "react";
 import { ArrowRepeat, CheckCircleFill } from "react-bootstrap-icons";
 import { formatEffect, translateRouteID } from "../../util";
 import { useParams } from "react-router-dom";
@@ -23,33 +23,7 @@ const AlertBanner: ComponentType<AlertBannerProps> = ({
   const { bannerAlert } = useScreenplayContext();
   if (!bannerAlert) return null;
 
-  const { alert, type, startedAt } = bannerAlert as BannerAlert;
-
-  const [timeLeft, setTimeLeft] = useState(40);
-
-  // Banner should expire 40s after the most recent alert change (closed/updated)
-  useEffect(() => {
-    const bannerExpireTime = new Date(startedAt).getTime() + 40 * 1000;
-    const now = new Date().getTime();
-    const secondsLeft = Math.floor(
-      ((bannerExpireTime - now) % (1000 * 60)) / 1000
-    );
-
-    setTimeLeft(secondsLeft);
-  }, [bannerAlert]);
-
-  // Every second, decrement the seconds left
-  useEffect(() => {
-    if (!timeLeft) return;
-
-    const intervalId = setInterval(() => {
-      setTimeLeft(timeLeft - 1);
-    }, 1000);
-
-    return () => {
-      clearInterval(intervalId);
-    };
-  }, [timeLeft]);
+  const { alert, type } = bannerAlert as BannerAlert;
 
   const wasPosted = alert.created_at === alert.updated_at;
   const params = useParams();
@@ -63,6 +37,12 @@ const AlertBanner: ComponentType<AlertBannerProps> = ({
       )
     ) {
       return "Green Line";
+    } else if (
+      alert.affected_list.every((routeId: string) =>
+        routeId.startsWith("sl")
+      )
+    ) {
+      return "Silver Line";
     } else {
       return "";
     }
@@ -85,8 +65,6 @@ const AlertBanner: ComponentType<AlertBannerProps> = ({
 
     const affectedListString = getAffectedListString();
 
-    const plural = timeLeft === 1 ? "second" : "seconds";
-
     if (
       ["dashboard", "alerts"].includes(route) ||
       (params.id && params.id !== alert.id)
@@ -101,7 +79,7 @@ const AlertBanner: ComponentType<AlertBannerProps> = ({
               alert was just closed.`}
             </span>{" "}
             Closing an alert may cause others to appear on more screens. It
-            could take up to {timeLeft} {plural} for any impacted screens to
+            could take up to 40 seconds for any impacted screens to
             update.
           </>
         );
@@ -113,7 +91,7 @@ const AlertBanner: ComponentType<AlertBannerProps> = ({
               alert was just posted.`}
             </span>{" "}
             Posting a new alert may cause others to appear on fewer screens. It
-            could take up to {timeLeft} {plural} for any impacted screens to
+            could take up to 40 seconds for any impacted screens to
             update.
           </>
         );
@@ -125,7 +103,7 @@ const AlertBanner: ComponentType<AlertBannerProps> = ({
               alert was just edited.`}
             </span>{" "}
             Some edits may cause other alerts to appear on different screens
-            than before. It could take up to {timeLeft} {plural} for any
+            than before. It could take up to 40 seconds for any
             impacted screens to update.
           </>
         );
@@ -135,7 +113,7 @@ const AlertBanner: ComponentType<AlertBannerProps> = ({
         return (
           <>
             <span className="bold">This alert was just posted.</span> It could
-            take up to {timeLeft} {plural} for the alert to be shown all
+            take up to 40 seconds for the alert to be shown all
             relevant screens, and for its list of places to be updated.
           </>
         );
@@ -146,7 +124,7 @@ const AlertBanner: ComponentType<AlertBannerProps> = ({
               This alert was just edited in Alerts UI.
             </span>{" "}
             Some edits may cause this alert or others to appear on different
-            screens than before. It could take up to {timeLeft} {plural} for any
+            screens than before. It could take up to 40 seconds for any
             impacted screens to update.
           </>
         );

--- a/assets/js/components/Dashboard/Dashboard.tsx
+++ b/assets/js/components/Dashboard/Dashboard.tsx
@@ -91,8 +91,7 @@ const Dashboard: ComponentType = () => {
 
   const getFirstClosedAlert = (oldAlerts: Alert[], newAlerts: Alert[]) => {
     const newAlertIds = newAlerts.map((alert) => alert.id);
-    return oldAlerts
-      .filter((alert) => !newAlertIds.includes(alert.id))[0]
+    return oldAlerts.filter((alert) => !newAlertIds.includes(alert.id))[0];
   };
 
   const getPostedOrEditedAlert = (alerts: Alert[]) => {

--- a/assets/js/components/Dashboard/Dashboard.tsx
+++ b/assets/js/components/Dashboard/Dashboard.tsx
@@ -10,7 +10,6 @@ import {
 import { useInterval } from "../../hooks/useInterval";
 import { fetchAlerts, fetchPlaces } from "../../utils/api";
 import AlertBanner from "./AlertBanner";
-import { isSignificantAlert } from "../../util";
 
 const Dashboard: ComponentType = () => {
   const { alerts, bannerAlert } = useScreenplayContext();
@@ -93,8 +92,7 @@ const Dashboard: ComponentType = () => {
   const getFirstClosedAlert = (oldAlerts: Alert[], newAlerts: Alert[]) => {
     const newAlertIds = newAlerts.map((alert) => alert.id);
     return oldAlerts
-      .filter((alert) => !newAlertIds.includes(alert.id))
-      .find((alert) => alert && isSignificantAlert(alert));
+      .filter((alert) => !newAlertIds.includes(alert.id))[0]
   };
 
   const getPostedOrEditedAlert = (alerts: Alert[]) => {
@@ -108,7 +106,6 @@ const Dashboard: ComponentType = () => {
           const updatedAt = new Date(alert.updated_at);
 
           return (
-            isSignificantAlert(alert) &&
             updatedAt.getTime() > fortySecondsAgo.getTime() &&
             updatedAt.getTime() < now.getTime()
           );

--- a/assets/js/util.ts
+++ b/assets/js/util.ts
@@ -61,7 +61,7 @@ export const translateRouteID = (id: string) => {
     case "sl4":
     case "sl5":
     case "slw":
-      return "Silver Line"
+      return "Silver Line";
     case "green":
     case "green-b":
     case "green-c":
@@ -174,4 +174,3 @@ export const placesWithSelectedAlert = (
         .filter((place) => place.screens.length > 0)
     : [];
 };
-

--- a/assets/js/util.ts
+++ b/assets/js/util.ts
@@ -55,8 +55,13 @@ export const translateRouteID = (id: string) => {
       return "Orange Line";
     case "blue":
       return "Blue Line";
-    case "silver":
-      return "Silver Line";
+    case "sl1":
+    case "sl2":
+    case "sl3":
+    case "sl4":
+    case "sl5":
+    case "slw":
+      return "Silver Line"
     case "green":
     case "green-b":
     case "green-c":
@@ -170,21 +175,3 @@ export const placesWithSelectedAlert = (
     : [];
 };
 
-const SIGNIFICANT_ALERT_EFFECTS: {
-  [mode: string]: string[];
-} = {
-  subway: ["SHUTTLE", "STATION_CLOSURE", "SUSPENSION", "DELAY"],
-  bus: ["STOP_CLOSURE", "DETOUR", "STOP_MOVE", "SNOW_ROUTE", "SUSPENSION"],
-};
-
-export const isSignificantAlert = (alert: Alert) => {
-  const mode = getModeFromAffectedList(alert.affected_list);
-
-  if (!Object.keys(SIGNIFICANT_ALERT_EFFECTS).includes(mode)) return;
-
-  if (alert.effect === "DELAY" && mode === "subway") {
-    return Number(alert.severity) > 3;
-  } else {
-    return SIGNIFICANT_ALERT_EFFECTS[mode].includes(alert.effect);
-  }
-};

--- a/lib/screenplay/util.ex
+++ b/lib/screenplay/util.ex
@@ -10,4 +10,20 @@ defmodule Screenplay.Util do
     username
     |> String.replace("ActiveDirectory_MBTA\\", "")
   end
+
+  def happening_now?(%{active_period: aps}, now \\ DateTime.utc_now()) do
+    Enum.any?(aps, &in_active_period(&1, now))
+  end
+
+  def in_active_period({nil, end_t}, t) do
+    DateTime.compare(t, end_t) in [:lt, :eq]
+  end
+
+  def in_active_period({start_t, nil}, t) do
+    DateTime.compare(t, start_t) in [:gt, :eq]
+  end
+
+  def in_active_period({start_t, end_t}, t) do
+    DateTime.compare(t, start_t) in [:gt, :eq] && DateTime.compare(t, end_t) in [:lt, :eq]
+  end
 end

--- a/lib/screenplay_web/controllers/alerts_api_controller.ex
+++ b/lib/screenplay_web/controllers/alerts_api_controller.ex
@@ -48,7 +48,7 @@ defmodule ScreenplayWeb.AlertsApiController do
     })
   end
 
-  @spec is_significant_alert?(Alert) :: boolean()
+  @spec is_significant_alert?(Alert.t()) :: boolean()
   def is_significant_alert?(alert = %{affected_list: affected_list}) do
     mode = primary_affected_mode(affected_list)
 

--- a/lib/screenplay_web/controllers/alerts_api_controller.ex
+++ b/lib/screenplay_web/controllers/alerts_api_controller.ex
@@ -49,7 +49,7 @@ defmodule ScreenplayWeb.AlertsApiController do
   end
 
   @spec is_significant_alert?(Alert) :: boolean
-  def is_significant_alert?(%{affected_list: affected_list} = alert) do
+  def is_significant_alert?(alert = %{affected_list: affected_list}) do
     mode = primary_affected_mode(affected_list)
 
     cond do

--- a/lib/screenplay_web/controllers/alerts_api_controller.ex
+++ b/lib/screenplay_web/controllers/alerts_api_controller.ex
@@ -3,12 +3,36 @@ defmodule ScreenplayWeb.AlertsApiController do
 
   alias Screenplay.Alerts.Alert
   alias Screenplay.Alerts.ScreensByAlert
+  alias Screenplay.Util
+
+  @subway_ids [
+    "red",
+    "orange",
+    "blue",
+    "green",
+    "green-b",
+    "green-c",
+    "green-d",
+    "green-e",
+  ]
+
+  @significant_alert_effects %{
+    :subway => ["SHUTTLE", "STATION_CLOSURE", "SUSPENSION", "DELAY"],
+    :bus => ["STOP_CLOSURE", "DETOUR", "STOP_MOVE", "SNOW_ROUTE", "SUSPENSION"]
+  }
 
   def index(conn, _params) do
+    # We get all alerts from the API; unfortunately can't filter it down by effect (doesn't exist) or datetime (buggy)
     {:ok, alerts} = Alert.fetch()
 
-    alert_ids = Enum.map(alerts, & &1.id)
+    # Filter down by relevance to Screenplay
+    relevant_alerts = Enum.filter(alerts, fn alert -> is_significant_alert?(alert) and Util.happening_now?(alert) end)
 
+    # Makes it a list of ids only
+    alert_ids = Enum.map(relevant_alerts, & &1.id)
+
+    # Then we use those ids to read a from the screens endpoint to get screen counts.
+    # But why get by ids instead of just reading everything in that field of the cache?
     screens_by_alerts =
       case ScreensByAlert.get_screens_by_alert(alert_ids) do
         {:ok, screens_by_alerts} -> screens_by_alerts
@@ -16,8 +40,31 @@ defmodule ScreenplayWeb.AlertsApiController do
       end
 
     json(conn, %{
-      alerts: Enum.map(alerts, &Alert.to_full_map/1),
+      alerts: Enum.map(relevant_alerts, &Alert.to_full_map/1),
       screens_by_alert: screens_by_alerts
     })
+  end
+
+  @spec is_significant_alert?(Alert) :: boolean
+  def is_significant_alert?(%{affected_list: affected_list} = alert) do
+    mode = primary_affected_mode(affected_list)
+
+    cond do
+      is_nil(mode) -> false
+      alert.effect === "DELAY" and mode === :subway -> alert.severity > 3
+      true -> alert.effect in @significant_alert_effects[mode]
+    end
+  end
+
+  def primary_affected_mode(affected_list) do
+    if Enum.any?(affected_list, fn mode -> mode in @subway_ids end) do
+      :subway
+    else
+      case affected_list do
+        ["bus" | _] -> :bus
+        ["sl" <> _ | _] -> :bus
+        _ -> nil
+      end
+    end
   end
 end

--- a/lib/screenplay_web/controllers/alerts_api_controller.ex
+++ b/lib/screenplay_web/controllers/alerts_api_controller.ex
@@ -13,7 +13,7 @@ defmodule ScreenplayWeb.AlertsApiController do
     "green-b",
     "green-c",
     "green-d",
-    "green-e",
+    "green-e"
   ]
 
   @significant_alert_effects %{
@@ -26,7 +26,10 @@ defmodule ScreenplayWeb.AlertsApiController do
     {:ok, alerts} = Alert.fetch()
 
     # Filter down by relevance to Screenplay
-    relevant_alerts = Enum.filter(alerts, fn alert -> is_significant_alert?(alert) and Util.happening_now?(alert) end)
+    relevant_alerts =
+      Enum.filter(alerts, fn alert ->
+        is_significant_alert?(alert) and Util.happening_now?(alert)
+      end)
 
     # Makes it a list of ids only
     alert_ids = Enum.map(relevant_alerts, & &1.id)

--- a/lib/screenplay_web/controllers/alerts_api_controller.ex
+++ b/lib/screenplay_web/controllers/alerts_api_controller.ex
@@ -48,7 +48,7 @@ defmodule ScreenplayWeb.AlertsApiController do
     })
   end
 
-  @spec is_significant_alert?(Alert) :: boolean
+  @spec is_significant_alert?(Alert) :: boolean()
   def is_significant_alert?(alert = %{affected_list: affected_list}) do
     mode = primary_affected_mode(affected_list)
 

--- a/lib/screenplay_web/controllers/alerts_api_controller.ex
+++ b/lib/screenplay_web/controllers/alerts_api_controller.ex
@@ -59,7 +59,7 @@ defmodule ScreenplayWeb.AlertsApiController do
     end
   end
 
-  def primary_affected_mode(affected_list) do
+  defp primary_affected_mode(affected_list) do
     if Enum.any?(affected_list, fn mode -> mode in @subway_ids end) do
       :subway
     else


### PR DESCRIPTION
[Notion](https://www.notion.so/mbta-downtown-crossing/Screenplay-Alerts-Polish-d3f44e3eec4346a19f31f24f75fa1ae6?p=369ad44cc004411b8d9a173ae80b07ff&pm=s)

Both the banner and alert list should be filtered down by alert effect (only the effects that appear as alerts on screens) and whether it is happening now.

Additional changes: banner should not count down. Also, the banner should correctly identify SL alerts.