### PR TITLE
polish: group alerts by screen count

### DIFF
--- a/assets/js/components/Dashboard/AlertsPage.tsx
+++ b/assets/js/components/Dashboard/AlertsPage.tsx
@@ -237,7 +237,7 @@ const AlertsList: ComponentType<AlertsListProps> = ({
   return (
     <>
       <Container fluid>
-        <Row className="filterable-list__header-row">
+        <Row className="filterable-list__header-row justify-content-end">
           <Col lg={3} className="d-flex justify-content-end pe-3">
             <FilterDropdown
               list={MODES_AND_LINES}

--- a/assets/js/components/Dashboard/AlertsPage.tsx
+++ b/assets/js/components/Dashboard/AlertsPage.tsx
@@ -91,6 +91,54 @@ const AlertsList: ComponentType<AlertsListProps> = ({
     }
   };
 
+  const renderAlerts = () => {
+    const allAlerts = filterAlerts();
+    const alertsOnScreens = allAlerts
+      .filter((alert: Alert) => screensByAlertMap[alert.id].length)
+      .sort((a: Alert, b: Alert) => compareAlerts(a, b))
+      .map((alert: Alert) => getAlertCardFromAlert(alert));
+
+    const alertsNotOnScreens = allAlerts
+      .filter((alert: Alert) => !screensByAlertMap[alert.id].length)
+      .sort((a: Alert, b: Alert) => compareAlerts(a, b))
+      .map((alert: Alert) => getAlertCardFromAlert(alert));
+
+    return alertsOnScreens.concat(alertsNotOnScreens);
+  };
+
+  const getAlertCardFromAlert = (alert: Alert) => {
+    const screensByAlert = screensByAlertMap[alert.id];
+    let numPlaces = 0;
+    let numScreens = 0;
+
+    if (screensByAlert) {
+      numScreens = screensByAlert.length;
+      numPlaces = placesWithSelectedAlert(
+        alert,
+        places,
+        screensByAlertMap
+      ).length;
+    }
+
+    let showAnimationOnMount = false;
+    if (prevAlertIds?.length) {
+      showAnimationOnMount = !prevAlertIds.includes(alert.id);
+    }
+
+    return (
+      <AlertCard
+        key={alert.id}
+        alert={alert}
+        selectAlert={() => {
+          navigate(`/alerts/${alert.id}`);
+        }}
+        numberOfScreens={numScreens}
+        numberOfPlaces={numPlaces}
+        showAnimationOnMount={showAnimationOnMount}
+      />
+    );
+  };
+
   const filterAlerts = () => {
     let filteredAlerts = alerts;
     if (screenTypeFilterValue !== SCREEN_TYPES[0]) {
@@ -217,42 +265,7 @@ const AlertsList: ComponentType<AlertsListProps> = ({
           </Col>
         </Row>
       </Container>
-      {filterAlerts()
-        .sort((a: Alert, b: Alert) =>
-          sortDirection === 0 ? compareAlerts(a, b) : compareAlerts(b, a)
-        )
-        .map((alert: Alert) => {
-          const screensByAlert = screensByAlertMap[alert.id];
-          let numPlaces = 0;
-          let numScreens = 0;
-
-          if (screensByAlert) {
-            numScreens = screensByAlert.length;
-            numPlaces = placesWithSelectedAlert(
-              alert,
-              places,
-              screensByAlertMap
-            ).length;
-          }
-
-          let showAnimationOnMount = false;
-          if (prevAlertIds?.length) {
-            showAnimationOnMount = !prevAlertIds.includes(alert.id);
-          }
-
-          return (
-            <AlertCard
-              key={alert.id}
-              alert={alert}
-              selectAlert={() => {
-                navigate(`/alerts/${alert.id}`);
-              }}
-              numberOfScreens={numScreens}
-              numberOfPlaces={numPlaces}
-              showAnimationOnMount={showAnimationOnMount}
-            />
-          );
-        })}
+      {renderAlerts()}
     </>
   );
 };

--- a/assets/js/components/Dashboard/AlertsPage.tsx
+++ b/assets/js/components/Dashboard/AlertsPage.tsx
@@ -1,11 +1,9 @@
 import React, { ComponentType } from "react";
 import FilterDropdown from "./FilterDropdown";
 import { Col, Container, Row } from "react-bootstrap";
-import { ArrowDown, ArrowUp } from "react-bootstrap-icons";
 import "../../../css/screenplay.scss";
 import {
   MODES_AND_LINES,
-  SORT_LABELS,
   SCREEN_TYPES,
   STATUSES,
   SILVER_LINE_ROUTES,
@@ -18,7 +16,6 @@ import AlertCard from "./AlertCard";
 import { useNavigate } from "react-router-dom";
 import { placesWithSelectedAlert } from "../../util";
 import {
-  DirectionID,
   useAlertsListContext,
   useAlertsListDispatchContext,
   useScreenplayContext,
@@ -58,24 +55,11 @@ const AlertsList: ComponentType<AlertsListProps> = ({
   places,
   screensByAlertMap,
 }: AlertsListProps) => {
-  const {
-    sortDirection,
-    modeLineFilterValue,
-    screenTypeFilterValue,
-    statusFilterValue,
-  } = useAlertsListContext();
+  const { modeLineFilterValue, screenTypeFilterValue, statusFilterValue } =
+    useAlertsListContext();
   const dispatch = useAlertsListDispatchContext();
   const navigate = useNavigate();
   const prevAlertIds = usePrevious(alerts)?.map((alert) => alert.id);
-
-  const alertSortLabel = SORT_LABELS["Alerts"][sortDirection];
-
-  const sortLabelOnClick = () => {
-    dispatch({
-      type: "SET_SORT_DIRECTION",
-      sortDirection: (1 - sortDirection) as DirectionID,
-    });
-  };
 
   const handleAlertModeOrLineSelect = (value: string) => {
     const selectedFilter = MODES_AND_LINES.find(({ label }) => label === value);
@@ -206,20 +190,6 @@ const AlertsList: ComponentType<AlertsListProps> = ({
     <>
       <Container fluid>
         <Row className="filterable-list__header-row">
-          <Col lg={3}>
-            <div
-              className="filterable-list__sort-label d-flex align-items-center"
-              onClick={sortLabelOnClick}
-              data-testid="sort-label"
-            >
-              {alertSortLabel}
-              {sortDirection === 0 ? (
-                <ArrowDown className="bootstrap-line-icon" />
-              ) : (
-                <ArrowUp className="bootstrap-line-icon" />
-              )}
-            </div>
-          </Col>
           <Col lg={3} className="d-flex justify-content-end pe-3">
             <FilterDropdown
               list={MODES_AND_LINES}

--- a/assets/js/hooks/useScreenplayContext.tsx
+++ b/assets/js/hooks/useScreenplayContext.tsx
@@ -35,15 +35,10 @@ type ReducerAction =
       bannerAlert: BannerAlert | undefined;
     };
 
-type AlertsListReducerAction =
-  | { type: "SET_SORT_DIRECTION"; sortDirection: DirectionID }
-  | {
-      type:
-        | "SET_MODE_LINE_FILTER"
-        | "SET_SCREEN_TYPE_FILTER"
-        | "SET_STATUS_FILTER";
-      filterValue: FilterValue;
-    };
+type AlertsListReducerAction = {
+  type: "SET_MODE_LINE_FILTER" | "SET_SCREEN_TYPE_FILTER" | "SET_STATUS_FILTER";
+  filterValue: FilterValue;
+};
 
 type PlacesListReducerAction =
   | { type: "SET_SORT_DIRECTION"; sortDirection: DirectionID }
@@ -163,11 +158,6 @@ const alertsReducer = (
   action: AlertsListReducerAction
 ) => {
   switch (action.type) {
-    case "SET_SORT_DIRECTION":
-      return {
-        ...state,
-        sortDirection: action.sortDirection as DirectionID,
-      };
     case "SET_MODE_LINE_FILTER":
       return {
         ...state,

--- a/assets/tests/components/alertsPage.test.tsx
+++ b/assets/tests/components/alertsPage.test.tsx
@@ -81,18 +81,4 @@ describe("Alerts Page", () => {
       });
     });
   });
-
-  describe("sorting", () => {
-    test("sort label when clicked", async () => {
-      const { getByTestId } = renderWithScreenplayProvider(<AlertsPage />);
-
-      await act(async () => {
-        expect(getByTestId("sort-label").textContent?.trim()).toBe("END");
-        fireEvent.click(getByTestId("sort-label"));
-        await waitFor(() => {
-          expect(getByTestId("sort-label").textContent?.trim()).toBe("END");
-        });
-      });
-    });
-  });
 });


### PR DESCRIPTION
**Asana task**: [ad-hoc-ish](https://mbta.slack.com/archives/C02SXM166N8/p1674761551378159)

For the `AlertsPage`, we now group alerts in two "sections": one has alerts on screens, the other has alerts not on screens. Within the sections, we are still sorting alerts by end date. With this change, we also are removing custom sorting on this page. For now, alerts will always be sorted in the specific way described above.
