### PR TITLE
fix: Ensure alert update banner draws on top of everything

### DIFF
--- a/assets/css/alert-banner.scss
+++ b/assets/css/alert-banner.scss
@@ -7,7 +7,8 @@
   padding: 16px 221px 16px 50px;
   position: sticky;
   top: 0;
-  z-index: 999;
+  // lol z-index
+  z-index: 99999;
 
   &__icon-container {
     height: 24px;


### PR DESCRIPTION
**Asana task**: ad hoc

The alert update banner had the same z-index as the inline track segment graphics. This fixes that by giving it an ***even bigger z-index!!***
