### PR TITLE
fix: Fullstory meta name

### DIFF
--- a/lib/screenplay_web/templates/layout/app.html.heex
+++ b/lib/screenplay_web/templates/layout/app.html.heex
@@ -24,7 +24,7 @@
         <meta name="is-admin" content={@is_admin}>
     <% end %>
     <%= if @fullstory_org_id do %>
-        <meta name="fullstory_org_id" content={@fullstory_org_id}>
+        <meta name="fullstory-org-id" content={@fullstory_org_id}>
     <% end %>
     <%= csrf_meta_tag() %>
     <title>Screenplay</title>


### PR DESCRIPTION
**Asana task**: ad-hoc

Name was using underscores instead of hyphens like we use on the others.
