### PR TITLE
polish: DUP v2 ad loop text

### DIFF
--- a/assets/js/components/Dashboard/ScreenDetail.tsx
+++ b/assets/js/components/Dashboard/ScreenDetail.tsx
@@ -101,7 +101,7 @@ const ScreenCard = (props: ScreenDetailProps) => {
         >
           {translatedScreenType} {getScreenLocation}
         </div>
-        {screens[0].type === "dup" && (
+        {["dup", "dup_v2"].includes(screens[0].type) && (
           <div className="screen-detail__dup-ad-text">
             Cycle in the ad loop for 7.5 seconds every 45 seconds
           </div>


### PR DESCRIPTION
**Notion task**: [Screenplay displays v2 DUPs correctly](https://www.notion.so/mbta-downtown-crossing/Screenplay-displays-v2-DUPs-correctly-19abf681ecdd42c6ab1df7b13a2be6f0?pvs=4)

Added ad loop text to `dup_v2`.
