### PR TITLE
Fixed script to account for config changes in new bus signs.

### DIFF
--- a/scripts/fetch_places_and_screens.exs
+++ b/scripts/fetch_places_and_screens.exs
@@ -79,6 +79,16 @@ add_routes_to_stops = fn
     Map.put(stop, :routes, routes)
 end
 
+get_first_not_nil = fn sources ->
+  sources
+  |> Enum.map(fn %{"stop_id" => platform_id} ->
+    platform_to_stop_map[platform_id]
+  end)
+  |> Enum.uniq()
+  |> Enum.reject(&is_nil/1)
+  |> hd()
+end
+
 # Get live config from S3
 {:ok, file} = get_config.("mbta-ctd-config", "screens/screens-#{environment}.json")
 parsed = Jason.decode!(file)
@@ -395,12 +405,25 @@ parsed = signs_json_file |> String.replace("\n", "") |> Base.decode64!() |> Jaso
 stop_ids =
   parsed
   |> Enum.flat_map(fn
-    %{"source_config" => [both]} ->
-      Enum.map(both, fn %{"stop_id" => stop_id} -> stop_id end)
+    %{"source_config" => %{"sources" => sources}} ->
+      Enum.map(sources, fn %{"stop_id" => stop_id} -> stop_id end)
 
-    %{"source_config" => [top, bottom]} ->
-      Enum.map(top, fn %{"stop_id" => stop_id} -> stop_id end) ++
-        Enum.map(bottom, fn %{"stop_id" => stop_id} -> stop_id end)
+    %{"source_config" => [%{"sources" => sources}]} ->
+      Enum.map(sources, fn %{"stop_id" => stop_id} -> stop_id end)
+
+    %{"source_config" => [%{"sources" => top_sources}, %{"sources" => bottom_sources}]} ->
+      Enum.map(top_sources, fn %{"stop_id" => stop_id} -> stop_id end) ++
+        Enum.map(bottom_sources, fn %{"stop_id" => stop_id} -> stop_id end)
+
+    %{"sources" => sources} ->
+      Enum.map(sources, fn %{"stop_id" => stop_id} -> stop_id end)
+
+    %{
+      "top_sources" => top_sources,
+      "bottom_sources" => bottom_sources
+    } ->
+      Enum.map(top_sources, fn %{"stop_id" => stop_id} -> stop_id end) ++
+        Enum.map(bottom_sources, fn %{"stop_id" => stop_id} -> stop_id end)
   end)
   |> Enum.uniq()
 
@@ -430,20 +453,24 @@ labels = Jason.decode!(labels)
 pa_ess_screens =
   parsed
   |> Enum.group_by(
-    fn %{"source_config" => source_config} ->
-      case source_config do
-        [both] ->
-          Enum.map(both, fn %{"stop_id" => platform_id} -> platform_to_stop_map[platform_id] end)
+    fn
+      %{"source_config" => %{"sources" => sources}} ->
+        get_first_not_nil.(sources)
 
-        [top, bottom] ->
-          Enum.map(top, fn %{"stop_id" => platform_id} -> platform_to_stop_map[platform_id] end) ++
-            Enum.map(bottom, fn %{"stop_id" => platform_id} ->
-              platform_to_stop_map[platform_id]
-            end)
-      end
-      |> Enum.uniq()
-      |> Enum.reject(&is_nil/1)
-      |> hd()
+      %{"source_config" => [%{"sources" => sources}]} ->
+        get_first_not_nil.(sources)
+
+      %{"source_config" => [%{"sources" => top_sources}, %{"sources" => bottom_sources}]} ->
+        get_first_not_nil.(top_sources ++ bottom_sources)
+
+      %{"sources" => sources} ->
+        get_first_not_nil.(sources)
+
+      %{
+        "top_sources" => top_sources,
+        "bottom_sources" => bottom_sources
+      } ->
+        get_first_not_nil.(top_sources ++ bottom_sources)
     end,
     fn %{
          "id" => id,

--- a/scripts/fetch_places_and_screens.exs
+++ b/scripts/fetch_places_and_screens.exs
@@ -398,9 +398,6 @@ stop_ids =
     %{"source_config" => %{"sources" => sources}} ->
       Enum.map(sources, fn %{"stop_id" => stop_id} -> stop_id end)
 
-    %{"source_config" => [%{"sources" => sources}]} ->
-      Enum.map(sources, fn %{"stop_id" => stop_id} -> stop_id end)
-
     %{"source_config" => [%{"sources" => top_sources}, %{"sources" => bottom_sources}]} ->
       Enum.map(top_sources, fn %{"stop_id" => stop_id} -> stop_id end) ++
         Enum.map(bottom_sources, fn %{"stop_id" => stop_id} -> stop_id end)
@@ -455,9 +452,6 @@ pa_ess_screens =
   |> Enum.group_by(
     fn
       %{"source_config" => %{"sources" => sources}} ->
-        get_first_not_nil.(sources)
-
-      %{"source_config" => [%{"sources" => sources}]} ->
         get_first_not_nil.(sources)
 
       %{"source_config" => [%{"sources" => top_sources}, %{"sources" => bottom_sources}]} ->

--- a/scripts/fetch_places_and_screens.exs
+++ b/scripts/fetch_places_and_screens.exs
@@ -396,22 +396,21 @@ stop_ids =
   parsed
   |> Enum.flat_map(fn
     %{"source_config" => %{"sources" => sources}} ->
-      Enum.map(sources, fn %{"stop_id" => stop_id} -> stop_id end)
+      sources
 
     %{"source_config" => [%{"sources" => top_sources}, %{"sources" => bottom_sources}]} ->
-      Enum.map(top_sources, fn %{"stop_id" => stop_id} -> stop_id end) ++
-        Enum.map(bottom_sources, fn %{"stop_id" => stop_id} -> stop_id end)
+      top_sources ++ bottom_sources
 
     %{"sources" => sources} ->
-      Enum.map(sources, fn %{"stop_id" => stop_id} -> stop_id end)
+      sources
 
     %{
       "top_sources" => top_sources,
       "bottom_sources" => bottom_sources
     } ->
-      Enum.map(top_sources, fn %{"stop_id" => stop_id} -> stop_id end) ++
-        Enum.map(bottom_sources, fn %{"stop_id" => stop_id} -> stop_id end)
+      top_sources ++ bottom_sources
   end)
+  |> Enum.map(fn %{"stop_id" => stop_id} -> stop_id end)
   |> Enum.uniq()
 
 params = URI.encode_query(%{"filter[id]" => Enum.join(stop_ids, ",")})

--- a/scripts/fetch_places_and_screens.exs
+++ b/scripts/fetch_places_and_screens.exs
@@ -79,16 +79,6 @@ add_routes_to_stops = fn
     Map.put(stop, :routes, routes)
 end
 
-get_first_not_nil = fn sources ->
-  sources
-  |> Enum.map(fn %{"stop_id" => platform_id} ->
-    platform_to_stop_map[platform_id]
-  end)
-  |> Enum.uniq()
-  |> Enum.reject(&is_nil/1)
-  |> hd()
-end
-
 # Get live config from S3
 {:ok, file} = get_config.("mbta-ctd-config", "screens/screens-#{environment}.json")
 parsed = Jason.decode!(file)
@@ -445,6 +435,16 @@ platform_to_stop_map =
      ])}
   end)
   |> Enum.into(%{})
+
+get_first_not_nil = fn sources ->
+  sources
+  |> Enum.map(fn %{"stop_id" => platform_id} ->
+    platform_to_stop_map[platform_id]
+  end)
+  |> Enum.uniq()
+  |> Enum.reject(&is_nil/1)
+  |> hd()
+end
 
 {:ok, labels} = File.read("scripts/paess_labels.json")
 labels = Jason.decode!(labels)


### PR DESCRIPTION
**Asana task**: ad-hoc

Some config changes happened when the new bus signs were rolled out. The script needed some changes to allow us to get the data we needed to show the bus signs. 
