### PR TITLE
[minor fix] Give helpful pointers on the "unauth" page

### DIFF
--- a/lib/screenplay_web/templates/unauthorized/index.html.heex
+++ b/lib/screenplay_web/templates/unauthorized/index.html.heex
@@ -1,3 +1,3 @@
-If you are trying to access Screenplay in order to view realtime screen information, go to screenplay.mbta.com/dashboard.
+If you are trying to access Screenplay in order to view realtime screen information, add `/dashboard` to the url. (i.e., screenplay.mbta.com/dashboard).
 
 If you are trying to access the Outfront Takeover Tool, you are not authorized. If you believe you should have access, contact hpurcell@mbta.com.

--- a/lib/screenplay_web/templates/unauthorized/index.html.heex
+++ b/lib/screenplay_web/templates/unauthorized/index.html.heex
@@ -1,1 +1,3 @@
-You are not authorized. If you believe you should have access, contact hpurcell@mbta.com.
+If you are trying to access Screenplay in order to view realtime screen information, go to screenplay.mbta.com/dashboard.
+
+If you are trying to access the Outfront Takeover Tool, you are not authorized. If you believe you should have access, contact hpurcell@mbta.com.


### PR DESCRIPTION
There's been more Screenplay traffic lately, with a lot of folks requesting access to Screenplay. It's not needed, but the unauth page doesn't make that clear. Updated with pointers