### PR TITLE
tweak: PreFare iframe container height.

### DIFF
--- a/assets/css/screen-detail.scss
+++ b/assets/css/screen-detail.scss
@@ -119,9 +119,12 @@
     // so height adjusted to fit
     width: 100%;
 
-    &--bus_shelter_v2,
-    &--pre_fare_v2 {
+    &--bus_shelter_v2 {
       height: 379px;
+    }
+
+    &--pre_fare_v2 {
+      height: 470px;
     }
 
     &--bus_eink_v2,


### PR DESCRIPTION
**Asana task**: [[Pre-Fare Alerts] "New look" in Screenplay](https://app.asana.com/0/1185117109217413/1205259333913109/f)

This change won't be needed until https://github.com/mbta/screens/pull/1837 is merged. With the new designs for PreFare, the simulation source is a little taller. To keep the vertical scrollbar from showing, I increased the height a touch.