### PR TITLE
tweak: add Triptychs to places and screens script

### DIFF
--- a/scripts/fetch_places_and_screens.exs
+++ b/scripts/fetch_places_and_screens.exs
@@ -246,6 +246,13 @@ live_screens =
 
       {_id,
        %{
+         "app_id" => "triptych_v2",
+         "app_params" => %{"train_crowding" => %{"station_id" => stop_id}}
+       }} ->
+        stop_id
+
+      {_id,
+       %{
          "app_id" => app_id,
          "stop" => stop_id
        }}


### PR DESCRIPTION
**Asana task**: [Update Places and Screens JSON script](https://app.asana.com/0/1185117109217413/1205353331802631/f)

Eazy peazy. While this does correctly import triptychs into the data, the screen sims do not look good. Handled in another task.
