### PR TITLE
[WIP] POC for using ETag to verify screens config version

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -19,7 +19,7 @@ sftp_client_module =
     _ -> Screenplay.Outfront.FakeSFTPClient
   end
 
-env = System.get_env("ENVIRONMENT_NAME")
+env = System.get_env("ENVIRONMENT_NAME", "dev")
 
 config :screenplay,
   alerts_s3_path: "screenplay/" <> System.get_env("ALERTS_S3_FILENAME", ""),

--- a/lib/screenplay/config/config.ex
+++ b/lib/screenplay/config/config.ex
@@ -1,12 +1,43 @@
 defmodule Screenplay.Config.PermanentConfig do
   @moduledoc false
+  alias Screenplay.Config.S3Fetch
 
-  def add_new_screen do
+  @spec add_new_screen(binary(), map(), binary()) :: :error | :ok
+  def add_new_screen(screen_id, screen, etag) do
+    case get_current_config(etag) do
+      {:ok, config} ->
+        config
+        |> Map.put(screen_id, Jason.decode!(screen))
+        |> S3Fetch.put_screens_config()
+
+      _ ->
+        :error
+    end
   end
 
   def edit_screen do
   end
 
-  def delete_screen do
+  @spec delete_screen(binary(), binary()) :: :error | :ok
+  def delete_screen(screen_id, etag) do
+    case get_current_config(etag) do
+      {:ok, config} ->
+        config
+        |> Map.delete(screen_id)
+        |> S3Fetch.put_screens_config()
+
+      _ ->
+        :error
+    end
+  end
+
+  defp get_current_config(etag) do
+    with {:ok, config, current_etag} <- S3Fetch.get_screens_config() do
+      if etag == current_etag,
+        do: {:ok, config},
+        else: :error
+    else
+      _ -> :error
+    end
   end
 end

--- a/lib/screenplay/config/config.ex
+++ b/lib/screenplay/config/config.ex
@@ -2,7 +2,8 @@ defmodule Screenplay.Config.PermanentConfig do
   @moduledoc false
   alias Screenplay.Config.S3Fetch
 
-  @spec add_new_screen(binary(), map(), binary()) :: :error | :ok
+  @spec add_new_screen(binary(), map(), binary()) ::
+          {:error, :etag_mismatch | :config_not_fetched | :config_not_written} | :ok
   def add_new_screen(screen_id, screen, etag) do
     case get_current_config(etag) do
       {:ok, config} ->
@@ -10,12 +11,13 @@ defmodule Screenplay.Config.PermanentConfig do
         |> Map.put(screen_id, Jason.decode!(screen))
         |> S3Fetch.put_screens_config()
 
-      _ ->
-        :error
+      error ->
+        error
     end
   end
 
-  @spec delete_screen(binary(), binary()) :: :error | :ok
+  @spec delete_screen(binary(), binary()) ::
+          {:error, :etag_mismatch | :config_not_fetched | :config_not_written} | :ok
   def delete_screen(screen_id, etag) do
     case get_current_config(etag) do
       {:ok, config} ->
@@ -23,8 +25,8 @@ defmodule Screenplay.Config.PermanentConfig do
         |> Map.delete(screen_id)
         |> S3Fetch.put_screens_config()
 
-      _ ->
-        :error
+      error ->
+        error
     end
   end
 
@@ -33,8 +35,11 @@ defmodule Screenplay.Config.PermanentConfig do
       {:ok, config, ^etag} ->
         {:ok, config}
 
+      :error ->
+        {:error, :config_not_fetched}
+
       _ ->
-        :error
+        {:error, :etag_mismatch}
     end
   end
 end

--- a/lib/screenplay/config/config.ex
+++ b/lib/screenplay/config/config.ex
@@ -15,9 +15,6 @@ defmodule Screenplay.Config.PermanentConfig do
     end
   end
 
-  def edit_screen do
-  end
-
   @spec delete_screen(binary(), binary()) :: :error | :ok
   def delete_screen(screen_id, etag) do
     case get_current_config(etag) do
@@ -33,7 +30,8 @@ defmodule Screenplay.Config.PermanentConfig do
 
   defp get_current_config(etag) do
     case S3Fetch.get_screens_config() do
-      {:ok, config, ^etag} -> {:ok, config}
+      {:ok, config, ^etag} ->
+        {:ok, config}
 
       _ ->
         :error

--- a/lib/screenplay/config/config.ex
+++ b/lib/screenplay/config/config.ex
@@ -33,10 +33,7 @@ defmodule Screenplay.Config.PermanentConfig do
 
   defp get_current_config(etag) do
     case S3Fetch.get_screens_config() do
-      {:ok, config, current_etag} ->
-        if etag == current_etag,
-          do: {:ok, config},
-          else: :error
+      {:ok, config, ^etag} -> {:ok, config}
 
       _ ->
         :error

--- a/lib/screenplay/config/config.ex
+++ b/lib/screenplay/config/config.ex
@@ -32,12 +32,14 @@ defmodule Screenplay.Config.PermanentConfig do
   end
 
   defp get_current_config(etag) do
-    with {:ok, config, current_etag} <- S3Fetch.get_screens_config() do
-      if etag == current_etag,
-        do: {:ok, config},
-        else: :error
-    else
-      _ -> :error
+    case S3Fetch.get_screens_config() do
+      {:ok, config, current_etag} ->
+        if etag == current_etag,
+          do: {:ok, config},
+          else: :error
+
+      _ ->
+        :error
     end
   end
 end

--- a/lib/screenplay/config/s3_fetch.ex
+++ b/lib/screenplay/config/s3_fetch.ex
@@ -18,7 +18,7 @@ defmodule Screenplay.Config.S3Fetch do
     end
   end
 
-  def get_screens_config() do
+  def get_screens_config do
     with {:ok, screens_contents, etag} <- do_get(:screens),
          {:ok, screens_json} <- Jason.decode(screens_contents) do
       {:ok, screens_json, etag}

--- a/lib/screenplay/config/s3_fetch.ex
+++ b/lib/screenplay/config/s3_fetch.ex
@@ -35,7 +35,7 @@ defmodule Screenplay.Config.S3Fetch do
   end
 
   defp config_path_for_environment(file_spec) do
-    base_path = "screenplay/#{Application.get_env(:screenplay, :environment_name, "dev")}"
+    base_path = "screenplay/#{Application.get_env(:screenplay, :environment_name)}"
 
     case file_spec do
       :config -> "#{base_path}/places_and_screens.json"

--- a/lib/screenplay/config/s3_fetch.ex
+++ b/lib/screenplay/config/s3_fetch.ex
@@ -6,13 +6,22 @@ defmodule Screenplay.Config.S3Fetch do
   @behaviour Screenplay.Config.Fetch
 
   def get_config do
-    with {:ok, config_contents} <- do_get(:config),
-         {:ok, location_contents} <- do_get(:screen_locations),
-         {:ok, place_description_contents} <- do_get(:place_descriptions),
+    with {:ok, config_contents, _} <- do_get(:config),
+         {:ok, location_contents, _} <- do_get(:screen_locations),
+         {:ok, place_description_contents, _} <- do_get(:place_descriptions),
          {:ok, config_json} <- Jason.decode(config_contents),
          {:ok, location_json} <- Jason.decode(location_contents),
          {:ok, place_description_json} <- Jason.decode(place_description_contents) do
       {:ok, config_json, location_json, place_description_json}
+    else
+      _ -> :error
+    end
+  end
+
+  def get_screens_config() do
+    with {:ok, screens_contents, etag} <- do_get(:screens),
+         {:ok, screens_json} <- Jason.decode(screens_contents) do
+      {:ok, screens_json, etag}
     else
       _ -> :error
     end
@@ -25,8 +34,13 @@ defmodule Screenplay.Config.S3Fetch do
     get_operation = ExAws.S3.get_object(bucket, path)
 
     case ExAws.request(get_operation) do
-      {:ok, %{body: body, status_code: 200}} ->
-        {:ok, body}
+      {:ok, %{body: body, headers: headers, status_code: 200}} ->
+        etag =
+          headers
+          |> Enum.into(%{})
+          |> Map.get("ETag")
+
+        {:ok, body, etag}
 
       {:error, err} ->
         Logger.error(err)
@@ -38,9 +52,32 @@ defmodule Screenplay.Config.S3Fetch do
     base_path = "screenplay/#{Application.get_env(:screenplay, :environment_name)}"
 
     case file_spec do
-      :config -> "#{base_path}/places_and_screens.json"
-      :screen_locations -> "#{base_path}/screen_locations.json"
-      :place_descriptions -> "#{base_path}/place_descriptions.json"
+      :config ->
+        "#{base_path}/places_and_screens.json"
+
+      :screen_locations ->
+        "#{base_path}/screen_locations.json"
+
+      :place_descriptions ->
+        "#{base_path}/place_descriptions.json"
+
+      :screens ->
+        "screens/screens-#{Application.get_env(:screenplay, :environment_name)}.json"
+    end
+  end
+
+  def put_screens_config(config) do
+    bucket = Application.get_env(:screenplay, :config_s3_bucket)
+    path = config_path_for_environment(:screens)
+
+    put_operation = ExAws.S3.put_object(bucket, path, Jason.encode!(config, pretty: true))
+
+    case ExAws.request(put_operation) do
+      {:ok, %{status_code: 200}} ->
+        :ok
+
+      _ ->
+        :error
     end
   end
 end

--- a/lib/screenplay/config/s3_fetch.ex
+++ b/lib/screenplay/config/s3_fetch.ex
@@ -77,7 +77,7 @@ defmodule Screenplay.Config.S3Fetch do
         :ok
 
       _ ->
-        :error
+        {:error, :config_not_written}
     end
   end
 end

--- a/lib/screenplay_web/controllers/config_controller.ex
+++ b/lib/screenplay_web/controllers/config_controller.ex
@@ -13,11 +13,6 @@ defmodule ScreenplayWeb.ConfigController do
     end
   end
 
-  def edit(conn, _params) do
-    PermanentConfig.edit_screen()
-    conn
-  end
-
   def delete(conn, %{"screen_id" => screen_id, "etag" => etag}) do
     case PermanentConfig.delete_screen(screen_id, etag) do
       :ok ->

--- a/lib/screenplay_web/controllers/config_controller.ex
+++ b/lib/screenplay_web/controllers/config_controller.ex
@@ -3,9 +3,14 @@ defmodule ScreenplayWeb.ConfigController do
 
   alias Screenplay.Config.PermanentConfig
 
-  def add(conn, _params) do
-    PermanentConfig.add_new_screen()
-    conn
+  def add(conn, %{"screen_id" => screen_id, "screen" => screen, "etag" => etag}) do
+    case PermanentConfig.add_new_screen(screen_id, screen, etag) do
+      :ok ->
+        send_resp(conn, 200, "OK")
+
+      :error ->
+        send_resp(conn, 400, "Unable to add new screen")
+    end
   end
 
   def edit(conn, _params) do
@@ -13,8 +18,13 @@ defmodule ScreenplayWeb.ConfigController do
     conn
   end
 
-  def delete(conn, _params) do
-    PermanentConfig.delete_screen()
-    conn
+  def delete(conn, %{"screen_id" => screen_id, "etag" => etag}) do
+    case PermanentConfig.delete_screen(screen_id, etag) do
+      :ok ->
+        send_resp(conn, 200, "OK")
+
+      :error ->
+        send_resp(conn, 400, "Unable to delete screen")
+    end
   end
 end

--- a/lib/screenplay_web/controllers/config_controller.ex
+++ b/lib/screenplay_web/controllers/config_controller.ex
@@ -8,8 +8,14 @@ defmodule ScreenplayWeb.ConfigController do
       :ok ->
         send_resp(conn, 200, "OK")
 
-      :error ->
-        send_resp(conn, 400, "Unable to add new screen")
+      {:error, :etag_mismatch} ->
+        send_resp(conn, 400, "Config version mismatch")
+
+      {:error, :config_not_fetched} ->
+        send_resp(conn, 400, "S3 Operation Failed: Get")
+
+      {:error, :config_not_written} ->
+        send_resp(conn, 400, "S3 Operation Failed: Put")
     end
   end
 
@@ -18,8 +24,14 @@ defmodule ScreenplayWeb.ConfigController do
       :ok ->
         send_resp(conn, 200, "OK")
 
-      :error ->
-        send_resp(conn, 400, "Unable to delete screen")
+      {:error, :etag_mismatch} ->
+        send_resp(conn, 400, "Config version mismatch")
+
+      {:error, :config_not_fetched} ->
+        send_resp(conn, 400, "S3 Operation Failed: Get")
+
+      {:error, :config_not_written} ->
+        send_resp(conn, 400, "S3 Operation Failed: Put")
     end
   end
 end

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -106,7 +106,6 @@ defmodule ScreenplayWeb.Router do
     ])
 
     post("/add", ConfigController, :add)
-    post("/edit", ConfigController, :edit)
     post("/delete", ConfigController, :delete)
   end
 


### PR DESCRIPTION
**Asana task**: [S3: Use ETag to verify latest version is being edited ](https://app.asana.com/0/1185117109217413/1205700210661288/f)

Description
This is a basic POC for how we can use the `ETag` field returned from calls to S3 to understand if the config has changed since a user began preparing to add (or remove) a screen's config.

Currently, the logic simply allows or disallows an update based on the given and current value of the ETag but I'm not 100% sure if that's the direction we want to take things. 

The current approach also still allows for a race condition if two clients tried to make updates to the screens config at the same time. Not sure how much we need to worry about that at this point given our limited user pool, but we could ensure requests are handled serially by passing the operations to a GenServer and taking advantage of the nature of its message queue.