### PR TITLE
refactor: PlaceRow component

### DIFF
--- a/assets/css/place-row.scss
+++ b/assets/css/place-row.scss
@@ -85,9 +85,6 @@
     font-weight: 400;
     font-size: 16px;
     line-height: 24px;
-    .spacer {
-      padding: 0 8px;
-    }
   }
 
   .place-row__mode-line-icon {

--- a/assets/css/place-row.scss
+++ b/assets/css/place-row.scss
@@ -103,3 +103,7 @@
     margin-bottom: 4px;
   }
 }
+
+.form-check-input {
+  display: block !important;
+}

--- a/assets/css/screenplay.scss
+++ b/assets/css/screenplay.scss
@@ -1,3 +1,8 @@
+$form-check-input-checked-color: #0f1417;
+$form-check-input-checked-bg-color: #8ecdff;
+$form-check-input-bg: #0f1417;
+$form-check-input-border: 1px solid #8b9198;
+
 @import "~bootstrap/scss/bootstrap";
 @import "variables.scss";
 @import "dashboard.scss";

--- a/assets/js/components/Dashboard/PlaceRow.tsx
+++ b/assets/js/components/Dashboard/PlaceRow.tsx
@@ -71,8 +71,7 @@ interface PlaceRowProps {
 }
 
 /**
- * Component used to display each place and their screen simulations.
- * Assumes it is displayed in an Accordion component from react-bootstrap.
+ * Component used to display summary info about a place and its screens.
  */
 const PlaceRow = ({
   place,

--- a/assets/js/components/Dashboard/PlaceRow.tsx
+++ b/assets/js/components/Dashboard/PlaceRow.tsx
@@ -41,7 +41,7 @@ const AccordionToggle = ({
 
 interface SelectBoxToggleProps {
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
-  disabled: boolean;
+  disabled?: boolean;
 }
 
 const SelectBoxToggle = ({
@@ -63,7 +63,7 @@ interface PlaceRowProps {
   filteredLine?: string | null;
   defaultSort?: boolean;
   showAnimation?: boolean;
-  disabled: boolean;
+  disabled?: boolean;
   children?: ReactElement;
   variant: "accordion" | "select-box";
   checkboxValue?: boolean;

--- a/assets/js/components/Dashboard/PlaceRow.tsx
+++ b/assets/js/components/Dashboard/PlaceRow.tsx
@@ -3,9 +3,9 @@ import {
   Col,
   Container,
   Row,
-  useAccordionButton,
   AccordionContext,
   Fade,
+  Form,
 } from "react-bootstrap";
 import { ChevronDown, ChevronRight } from "react-bootstrap-icons";
 import classNames from "classnames";
@@ -14,17 +14,62 @@ import { Screen } from "../../models/screen";
 import MapSegment from "./MapSegment";
 import STATION_ORDER_BY_LINE from "../../constants/stationOrder";
 import { classWithModifier } from "../../util";
-import { useUpdateAnimation } from "../../hooks/useUpdateAnimation";
+
+interface AccordionToggleProps {
+  eventKey: string;
+  hidden?: boolean;
+}
+
+const AccordionToggle = ({
+  eventKey,
+  hidden,
+}: AccordionToggleProps): JSX.Element => {
+  const { activeEventKey } = useContext(AccordionContext);
+  const isOpen = activeEventKey?.includes(eventKey) || false;
+  const Chevron = isOpen ? ChevronDown : ChevronRight;
+
+  return (
+    <div
+      className={classNames("place-row__toggle", {
+        "hidden-toggle": hidden,
+      })}
+    >
+      <Chevron size={16} className="bootstrap-line-icon" />
+    </div>
+  );
+};
+
+interface SelectBoxToggleProps {
+  checked?: boolean;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  disabled: boolean;
+}
+
+const SelectBoxToggle = ({
+  checked,
+  onChange,
+  disabled,
+}: SelectBoxToggleProps): JSX.Element => {
+  return (
+    <div className="place-row__toggle">
+      <Form.Check disabled={disabled} checked={checked} onChange={onChange} />
+    </div>
+  );
+};
 
 interface PlaceRowProps {
   place: Place;
   eventKey: string;
-  onClick: (eventKey: string) => void;
+  onClick?: React.MouseEventHandler;
   className?: string;
   filteredLine?: string | null;
   defaultSort?: boolean;
-  canShowAnimation?: boolean;
+  showAnimation?: boolean;
+  disabled: boolean;
   children?: ReactElement;
+  variant: "accordion" | "select-box";
+  checkboxValue?: boolean;
+  checkboxOnChange?: React.ChangeEventHandler<HTMLInputElement>;
 }
 
 /**
@@ -38,16 +83,16 @@ const PlaceRow = ({
   className,
   filteredLine,
   defaultSort,
-  canShowAnimation,
+  showAnimation,
+  disabled,
   children,
+  variant,
+  checkboxValue,
+  checkboxOnChange,
 }: PlaceRowProps): JSX.Element => {
   const { routes, name, description, screens } = place;
-  const { activeEventKey } = useContext(AccordionContext);
-  const rowOnClick = useAccordionButton(eventKey, () => onClick(eventKey));
-  const isOpen = activeEventKey?.includes(eventKey);
   const hasScreens =
     screens.length > 0 && screens.filter((screen) => !screen.hidden).length > 0;
-  const { showAnimation } = useUpdateAnimation([], null, canShowAnimation);
 
   const typeMap: Record<string, string> = {
     pa_ess: "PA",
@@ -175,32 +220,29 @@ const PlaceRow = ({
   return (
     <div
       className={classNames("place-row", className, {
-        open: isOpen,
-        disabled: !hasScreens,
+        disabled: disabled,
       })}
       data-testid="place-row"
     >
       <Fade appear in={showAnimation}>
         <div className="update-animation"></div>
       </Fade>
-      <div onClick={hasScreens ? rowOnClick : () => undefined}>
+      <div onClick={onClick}>
         <Container fluid>
           <Row
             className="align-items-center text-white"
             data-testid="place-row-header"
           >
             <Col lg={5} className="d-flex align-items-center">
-              <div
-                className={classNames("place-row__toggle", {
-                  "hidden-toggle": !hasScreens,
-                })}
-              >
-                {isOpen ? (
-                  <ChevronDown size={16} className="bootstrap-line-icon" />
-                ) : (
-                  <ChevronRight size={16} className="bootstrap-line-icon" />
-                )}
-              </div>
+              {variant === "accordion" ? (
+                <AccordionToggle eventKey={eventKey} hidden={!hasScreens} />
+              ) : (
+                <SelectBoxToggle
+                  checked={checkboxValue}
+                  onChange={checkboxOnChange}
+                  disabled={disabled}
+                />
+              )}
               {filteredLine && (
                 <div
                   className={classNames(

--- a/assets/js/components/Dashboard/PlaceRow.tsx
+++ b/assets/js/components/Dashboard/PlaceRow.tsx
@@ -275,7 +275,11 @@ const PlaceRow = ({
             </Col>
           </Row>
         </Container>
-        {children && children}
+        {/*
+        Needed to allow Accordion functionality to work. With this way of rendering Accordion.Collapse,
+        this component can leave out all references to Accordion while maintaining original functionality.
+        */}
+        {variant === "accordion" && children}
       </div>
     </div>
   );

--- a/assets/js/components/Dashboard/PlaceRow.tsx
+++ b/assets/js/components/Dashboard/PlaceRow.tsx
@@ -40,19 +40,17 @@ const AccordionToggle = ({
 };
 
 interface SelectBoxToggleProps {
-  checked?: boolean;
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
   disabled: boolean;
 }
 
 const SelectBoxToggle = ({
-  checked,
   onChange,
   disabled,
 }: SelectBoxToggleProps): JSX.Element => {
   return (
     <div className="place-row__toggle">
-      <Form.Check disabled={disabled} checked={checked} onChange={onChange} />
+      <Form.Check disabled={disabled} onChange={onChange} />
     </div>
   );
 };
@@ -87,7 +85,6 @@ const PlaceRow = ({
   disabled,
   children,
   variant,
-  checkboxValue,
   checkboxOnChange,
 }: PlaceRowProps): JSX.Element => {
   const { routes, name, description, screens } = place;
@@ -238,7 +235,6 @@ const PlaceRow = ({
                 <AccordionToggle eventKey={eventKey} hidden={!hasScreens} />
               ) : (
                 <SelectBoxToggle
-                  checked={checkboxValue}
                   onChange={checkboxOnChange}
                   disabled={disabled}
                 />

--- a/assets/js/components/Dashboard/PlaceRowAccordion.tsx
+++ b/assets/js/components/Dashboard/PlaceRowAccordion.tsx
@@ -22,7 +22,6 @@ interface PlaceRowAccordionProps {
   dispatch: React.Dispatch<PlacesListReducerAction>;
   activeEventKeys: string[];
   sortDirection: DirectionID;
-  isFiltered?: boolean;
   filteredLine?: string | null;
   className?: string;
 }

--- a/assets/js/components/Dashboard/PlaceRowAccordion.tsx
+++ b/assets/js/components/Dashboard/PlaceRowAccordion.tsx
@@ -3,8 +3,8 @@ import PlaceRow from "./PlaceRow";
 import { Place } from "../../models/place";
 import { Screen } from "../../models/screen";
 import {
+  DirectionID,
   PlacesListReducerAction,
-  PlacesListState,
 } from "../../hooks/useScreenplayContext";
 import {
   Accordion,
@@ -14,26 +14,28 @@ import {
 import ScreenDetail from "./ScreenDetail";
 import { sortScreens } from "../../util";
 import { useUpdateAnimation } from "../../hooks/useUpdateAnimation";
+import classNames from "classnames";
 
 interface PlaceRowAccordionProps {
   place: Place;
   canShowAnimation?: boolean;
   dispatch: React.Dispatch<PlacesListReducerAction>;
-  stateValues: PlacesListState;
-  isFiltered: boolean;
-  filteredLine: string | null;
-  className: string;
+  activeEventKeys: string[];
+  sortDirection: DirectionID;
+  isFiltered?: boolean;
+  filteredLine?: string | null;
+  className?: string;
 }
 
 const PlaceRowAccordion: ComponentType<PlaceRowAccordionProps> = ({
   place,
   canShowAnimation,
   dispatch,
-  stateValues,
   filteredLine,
-  className,
+  sortDirection,
+  activeEventKeys,
+  className = "",
 }: PlaceRowAccordionProps) => {
-  const { sortDirection, activeEventKeys } = stateValues;
   const handleClickAccordion = (eventKey: string) => {
     if (activeEventKeys?.includes(eventKey)) {
       dispatch({
@@ -104,7 +106,7 @@ const PlaceRowAccordion: ComponentType<PlaceRowAccordionProps> = ({
         place={place}
         eventKey={place.id}
         onClick={rowOnClick}
-        className={isOpen ? className + " open" : className}
+        className={isOpen ? classNames(className, "open") : className}
         filteredLine={filteredLine}
         defaultSort={sortDirection === 0}
         showAnimation={showAnimation}

--- a/assets/js/components/Dashboard/PlaceRowAccordion.tsx
+++ b/assets/js/components/Dashboard/PlaceRowAccordion.tsx
@@ -1,0 +1,135 @@
+import React, { ComponentType, useContext } from "react";
+import PlaceRow from "./PlaceRow";
+import { Place } from "../../models/place";
+import { Screen } from "../../models/screen";
+import {
+  PlacesListReducerAction,
+  PlacesListState,
+} from "../../hooks/useScreenplayContext";
+import {
+  Accordion,
+  AccordionContext,
+  useAccordionButton,
+} from "react-bootstrap";
+import ScreenDetail from "./ScreenDetail";
+import { sortScreens } from "../../util";
+import { useUpdateAnimation } from "../../hooks/useUpdateAnimation";
+
+interface PlaceRowAccordionProps {
+  place: Place;
+  canShowAnimation?: boolean;
+  dispatch: React.Dispatch<PlacesListReducerAction>;
+  stateValues: PlacesListState;
+  isFiltered: boolean;
+  filteredLine: string | null;
+  className: string;
+}
+
+const PlaceRowAccordion: ComponentType<PlaceRowAccordionProps> = ({
+  place,
+  canShowAnimation,
+  dispatch,
+  stateValues,
+  filteredLine,
+  className,
+}: PlaceRowAccordionProps) => {
+  const { sortDirection, activeEventKeys } = stateValues;
+  const handleClickAccordion = (eventKey: string) => {
+    if (activeEventKeys?.includes(eventKey)) {
+      dispatch({
+        type: "SET_ACTIVE_EVENT_KEYS",
+        eventKeys: activeEventKeys.filter((e: string) => e !== eventKey),
+      });
+    } else {
+      dispatch({
+        type: "SET_ACTIVE_EVENT_KEYS",
+        eventKeys: [...activeEventKeys, eventKey],
+      });
+    }
+  };
+
+  const filterAndGroupScreens = (screens: Screen[]) => {
+    const visibleScreens = screens.filter((screen) => !screen.hidden);
+    const solariScreens = visibleScreens.filter(
+      (screen) => screen.type === "solari"
+    );
+    const paEssScreens = visibleScreens.filter(
+      (screen) => screen.type === "pa_ess"
+    );
+    const groupedScreens = visibleScreens
+      .filter((screen) => screen.type !== "solari" && screen.type !== "pa_ess")
+      .map((screen) => [screen]);
+
+    groupedScreens.push(solariScreens);
+
+    if (paEssScreens.length > 0) {
+      groupPaEssScreensbyRoute(paEssScreens, groupedScreens);
+    }
+
+    return groupedScreens;
+  };
+
+  const groupPaEssScreensbyRoute = (
+    paEssScreens: Screen[],
+    groupedScreens: Screen[][]
+  ) => {
+    const paEssGroupedByRoute = new Map<string, Screen[]>();
+    paEssScreens.map((paEssScreen) => {
+      if (paEssScreen.station_code) {
+        const routeLetter = paEssScreen.station_code.charAt(0);
+
+        paEssGroupedByRoute.has(routeLetter)
+          ? paEssGroupedByRoute.get(routeLetter)?.push(paEssScreen)
+          : paEssGroupedByRoute.set(routeLetter, [paEssScreen]);
+      }
+    });
+    paEssGroupedByRoute.forEach((screens) => {
+      groupedScreens.push(screens);
+    });
+  };
+
+  const hasScreens =
+    place.screens.length > 0 &&
+    place.screens.filter((screen) => !screen.hidden).length > 0;
+  const rowOnClick = hasScreens
+    ? useAccordionButton(place.id, () => handleClickAccordion(place.id))
+    : undefined;
+  const { activeEventKey } = useContext(AccordionContext);
+  const isOpen = activeEventKey?.includes(place.id);
+  const { showAnimation } = useUpdateAnimation([], null, canShowAnimation);
+
+  return (
+    <>
+      <PlaceRow
+        place={place}
+        eventKey={place.id}
+        onClick={rowOnClick}
+        className={isOpen ? className + " open" : className}
+        filteredLine={filteredLine}
+        defaultSort={sortDirection === 0}
+        showAnimation={showAnimation}
+        disabled={!hasScreens}
+        variant="accordion"
+      >
+        <Accordion.Collapse eventKey={place.id}>
+          <div className="place-row__screen-preview-container">
+            {hasScreens &&
+              filterAndGroupScreens(sortScreens(place.screens)).map(
+                (screens, index) => {
+                  return (
+                    <ScreenDetail
+                      key={`${place.id}.screendetail.${index}`}
+                      screens={screens}
+                      eventKey={place.id}
+                    />
+                  );
+                }
+              )}
+          </div>
+        </Accordion.Collapse>
+      </PlaceRow>
+    </>
+  );
+};
+
+export default PlaceRowAccordion;

--- a/assets/js/components/Dashboard/PlacesPage.tsx
+++ b/assets/js/components/Dashboard/PlacesPage.tsx
@@ -299,7 +299,6 @@ const PlacesList: ComponentType<PlacesListProps> = ({
               dispatch={dispatch}
               activeEventKeys={activeEventKeys}
               sortDirection={sortDirection}
-              isFiltered={isFiltered}
               filteredLine={isOnlyFilteredByRoute ? getFilteredLine() : null}
               className={isFiltered || isAlertPlacesList ? "filtered" : ""}
             />

--- a/assets/js/components/Dashboard/PlacesPage.tsx
+++ b/assets/js/components/Dashboard/PlacesPage.tsx
@@ -297,7 +297,8 @@ const PlacesList: ComponentType<PlacesListProps> = ({
                 !prevPlaceIds.includes(place.id)
               }
               dispatch={dispatch}
-              stateValues={stateValues}
+              activeEventKeys={activeEventKeys}
+              sortDirection={sortDirection}
               isFiltered={isFiltered}
               filteredLine={isOnlyFilteredByRoute ? getFilteredLine() : null}
               className={isFiltered || isAlertPlacesList ? "filtered" : ""}

--- a/assets/js/components/Dashboard/PlacesPage.tsx
+++ b/assets/js/components/Dashboard/PlacesPage.tsx
@@ -66,7 +66,7 @@ const PlacesPage: ComponentType = () => {
   );
 };
 
-interface CustomAccordionRowProps {
+interface PlaceRowAccordionProps {
   place: Place;
   canShowAnimation?: boolean;
   dispatch: React.Dispatch<PlacesListReducerAction>;
@@ -75,14 +75,14 @@ interface CustomAccordionRowProps {
   filteredLine: string | null;
   className: string;
 }
-const CustomAccordionRow: ComponentType<CustomAccordionRowProps> = ({
+const PlaceRowAccordion: ComponentType<PlaceRowAccordionProps> = ({
   place,
   canShowAnimation,
   dispatch,
   stateValues,
   filteredLine,
   className,
-}: CustomAccordionRowProps) => {
+}: PlaceRowAccordionProps) => {
   const { sortDirection, activeEventKeys } = stateValues;
   const handleClickAccordion = (eventKey: string) => {
     if (activeEventKeys?.includes(eventKey)) {
@@ -415,7 +415,7 @@ const PlacesList: ComponentType<PlacesListProps> = ({
             (showScreenlessPlaces || !filteredPlacesHaveScreenlessPlaces);
 
           return (
-            <CustomAccordionRow
+            <PlaceRowAccordion
               key={place.id}
               place={place}
               canShowAnimation={

--- a/assets/js/components/Dashboard/PlacesPage.tsx
+++ b/assets/js/components/Dashboard/PlacesPage.tsx
@@ -1,8 +1,15 @@
-import React, { ComponentType } from "react";
+import React, { ComponentType, useContext } from "react";
 import PlaceRow from "./PlaceRow";
 import PlacesActionBar from "./PlacesActionBar";
 import FilterDropdown from "./FilterDropdown";
-import { Accordion, Col, Container, Row } from "react-bootstrap";
+import {
+  Accordion,
+  AccordionContext,
+  Col,
+  Container,
+  Row,
+  useAccordionButton,
+} from "react-bootstrap";
 import { ArrowDown, ArrowUp } from "react-bootstrap-icons";
 import { Place } from "../../models/place";
 import { Screen } from "../../models/screen";
@@ -24,6 +31,7 @@ import { DirectionID } from "../../models/direction_id";
 import { usePrevious } from "../../hooks/usePrevious";
 import ScreenDetail from "./ScreenDetail";
 import { sortScreens } from "../../util";
+import { useUpdateAnimation } from "../../hooks/useUpdateAnimation";
 
 const getSortLabel = (
   modeLineFilterValue: { label: string },
@@ -55,6 +63,122 @@ const PlacesPage: ComponentType = () => {
         />
       </div>
     </div>
+  );
+};
+
+interface CustomAccordionRowProps {
+  place: Place;
+  canShowAnimation?: boolean;
+  dispatch: React.Dispatch<PlacesListReducerAction>;
+  stateValues: PlacesListState;
+  isFiltered: boolean;
+  filteredLine: string | null;
+  className: string;
+}
+const CustomAccordionRow: ComponentType<CustomAccordionRowProps> = ({
+  place,
+  canShowAnimation,
+  dispatch,
+  stateValues,
+  filteredLine,
+  className,
+}: CustomAccordionRowProps) => {
+  const { sortDirection, activeEventKeys } = stateValues;
+  const handleClickAccordion = (eventKey: string) => {
+    if (activeEventKeys?.includes(eventKey)) {
+      dispatch({
+        type: "SET_ACTIVE_EVENT_KEYS",
+        eventKeys: activeEventKeys.filter((e: string) => e !== eventKey),
+      });
+    } else {
+      dispatch({
+        type: "SET_ACTIVE_EVENT_KEYS",
+        eventKeys: [...activeEventKeys, eventKey],
+      });
+    }
+  };
+
+  const filterAndGroupScreens = (screens: Screen[]) => {
+    const visibleScreens = screens.filter((screen) => !screen.hidden);
+    const solariScreens = visibleScreens.filter(
+      (screen) => screen.type === "solari"
+    );
+    const paEssScreens = visibleScreens.filter(
+      (screen) => screen.type === "pa_ess"
+    );
+    const groupedScreens = visibleScreens
+      .filter((screen) => screen.type !== "solari" && screen.type !== "pa_ess")
+      .map((screen) => [screen]);
+
+    groupedScreens.push(solariScreens);
+
+    if (paEssScreens.length > 0) {
+      groupPaEssScreensbyRoute(paEssScreens, groupedScreens);
+    }
+
+    return groupedScreens;
+  };
+
+  const groupPaEssScreensbyRoute = (
+    paEssScreens: Screen[],
+    groupedScreens: Screen[][]
+  ) => {
+    const paEssGroupedByRoute = new Map<string, Screen[]>();
+    paEssScreens.map((paEssScreen) => {
+      if (paEssScreen.station_code) {
+        const routeLetter = paEssScreen.station_code.charAt(0);
+
+        paEssGroupedByRoute.has(routeLetter)
+          ? paEssGroupedByRoute.get(routeLetter)?.push(paEssScreen)
+          : paEssGroupedByRoute.set(routeLetter, [paEssScreen]);
+      }
+    });
+    paEssGroupedByRoute.forEach((screens) => {
+      groupedScreens.push(screens);
+    });
+  };
+
+  const hasScreens =
+    place.screens.length > 0 &&
+    place.screens.filter((screen) => !screen.hidden).length > 0;
+  const rowOnClick = hasScreens
+    ? useAccordionButton(place.id, () => handleClickAccordion(place.id))
+    : undefined;
+  const { activeEventKey } = useContext(AccordionContext);
+  const isOpen = activeEventKey?.includes(place.id);
+  const { showAnimation } = useUpdateAnimation([], null, canShowAnimation);
+
+  return (
+    <>
+      <PlaceRow
+        place={place}
+        eventKey={place.id}
+        onClick={rowOnClick}
+        className={isOpen ? className + " open" : className}
+        filteredLine={filteredLine}
+        defaultSort={sortDirection === 0}
+        showAnimation={showAnimation}
+        disabled={!hasScreens}
+        variant="accordion"
+      >
+        <Accordion.Collapse eventKey={place.id}>
+          <div className="place-row__screen-preview-container">
+            {hasScreens &&
+              filterAndGroupScreens(sortScreens(place.screens)).map(
+                (screens, index) => {
+                  return (
+                    <ScreenDetail
+                      key={`${place.id}.screendetail.${index}`}
+                      screens={screens}
+                      eventKey={place.id}
+                    />
+                  );
+                }
+              )}
+          </div>
+        </Accordion.Collapse>
+      </PlaceRow>
+    </>
   );
 };
 
@@ -129,20 +253,6 @@ const PlacesList: ComponentType<PlacesListProps> = ({
       type: "SET_SORT_DIRECTION",
       sortDirection: (1 - sortDirection) as DirectionID,
     });
-  };
-
-  const handleClickAccordion = (eventKey: string) => {
-    if (activeEventKeys.includes(eventKey)) {
-      dispatch({
-        type: "SET_ACTIVE_EVENT_KEYS",
-        eventKeys: activeEventKeys.filter((e: string) => e !== eventKey),
-      });
-    } else {
-      dispatch({
-        type: "SET_ACTIVE_EVENT_KEYS",
-        eventKeys: [...activeEventKeys, eventKey],
-      });
-    }
   };
 
   const sortLabel = getSortLabel(modeLineFilterValue, sortDirection);
@@ -238,52 +348,6 @@ const PlacesList: ComponentType<PlacesListProps> = ({
     statusFilterValue !== STATUSES[0] ||
     screenTypeFilterValue !== SCREEN_TYPES[0];
 
-  const isOnlyFilteredByRoute =
-    modeLineFilterValue !== MODES_AND_LINES[0] &&
-    statusFilterValue === STATUSES[0] &&
-    screenTypeFilterValue === SCREEN_TYPES[0] &&
-    (showScreenlessPlaces || !filteredPlacesHaveScreenlessPlaces);
-
-  const filterAndGroupScreens = (screens: Screen[]) => {
-    const visibleScreens = screens.filter((screen) => !screen.hidden);
-    const solariScreens = visibleScreens.filter(
-      (screen) => screen.type === "solari"
-    );
-    const paEssScreens = visibleScreens.filter(
-      (screen) => screen.type === "pa_ess"
-    );
-    const groupedScreens = visibleScreens
-      .filter((screen) => screen.type !== "solari" && screen.type !== "pa_ess")
-      .map((screen) => [screen]);
-
-    groupedScreens.push(solariScreens);
-
-    if (paEssScreens.length > 0) {
-      groupPaEssScreensbyRoute(paEssScreens, groupedScreens);
-    }
-
-    return groupedScreens;
-  };
-
-  const groupPaEssScreensbyRoute = (
-    paEssScreens: Screen[],
-    groupedScreens: Screen[][]
-  ) => {
-    const paEssGroupedByRoute = new Map<string, Screen[]>();
-    paEssScreens.map((paEssScreen) => {
-      if (paEssScreen.station_code) {
-        const routeLetter = paEssScreen.station_code.charAt(0);
-
-        paEssGroupedByRoute.has(routeLetter)
-          ? paEssGroupedByRoute.get(routeLetter)?.push(paEssScreen)
-          : paEssGroupedByRoute.set(routeLetter, [paEssScreen]);
-      }
-    });
-    paEssGroupedByRoute.forEach((screens) => {
-      groupedScreens.push(screens);
-    });
-  };
-
   return (
     <>
       <Container fluid>
@@ -344,42 +408,27 @@ const PlacesList: ComponentType<PlacesListProps> = ({
       )}
       <Accordion flush alwaysOpen activeKey={activeEventKeys}>
         {sortedFilteredPlaces.map((place: Place) => {
-          const hasScreens =
-            place.screens.length > 0 &&
-            place.screens.filter((screen) => !screen.hidden).length > 0;
+          const isOnlyFilteredByRoute =
+            modeLineFilterValue !== MODES_AND_LINES[0] &&
+            statusFilterValue === STATUSES[0] &&
+            screenTypeFilterValue === SCREEN_TYPES[0] &&
+            (showScreenlessPlaces || !filteredPlacesHaveScreenlessPlaces);
 
           return (
-            <PlaceRow
+            <CustomAccordionRow
               key={place.id}
               place={place}
-              eventKey={place.id}
-              onClick={handleClickAccordion}
-              className={isFiltered || isAlertPlacesList ? "filtered" : ""}
-              filteredLine={isOnlyFilteredByRoute ? getFilteredLine() : null}
-              defaultSort={sortDirection === 0}
               canShowAnimation={
                 showAnimationForNewPlaces &&
                 prevPlaceIds !== undefined &&
                 !prevPlaceIds.includes(place.id)
               }
-            >
-              <Accordion.Collapse eventKey={place.id}>
-                <div className="place-row__screen-preview-container">
-                  {hasScreens &&
-                    filterAndGroupScreens(sortScreens(place.screens)).map(
-                      (screens, index) => {
-                        return (
-                          <ScreenDetail
-                            key={`${place.id}.screendetail.${index}`}
-                            screens={screens}
-                            eventKey={place.id}
-                          />
-                        );
-                      }
-                    )}
-                </div>
-              </Accordion.Collapse>
-            </PlaceRow>
+              dispatch={dispatch}
+              stateValues={stateValues}
+              isFiltered={isFiltered}
+              filteredLine={isOnlyFilteredByRoute ? getFilteredLine() : null}
+              className={isFiltered || isAlertPlacesList ? "filtered" : ""}
+            />
           );
         })}
       </Accordion>

--- a/assets/js/components/Dashboard/ScreenDetail.tsx
+++ b/assets/js/components/Dashboard/ScreenDetail.tsx
@@ -1,13 +1,14 @@
-import React, { SyntheticEvent } from "react";
+import React, { SyntheticEvent, useContext } from "react";
 import { Screen } from "../../models/screen";
 import ScreenDetailHeader from "./ScreenDetailHeader";
 import { SCREEN_TYPES } from "../../constants/constants";
 import PaessDetailContainer from "./PaessDetailContainer";
 import classNames from "classnames";
+import { AccordionContext } from "react-bootstrap";
 
 interface ScreenDetailProps {
   screens: Screen[];
-  isOpen: boolean;
+  eventKey: string;
   isMultipleScreens?: boolean;
 }
 
@@ -32,7 +33,7 @@ const ScreenDetail = (props: ScreenDetailProps): JSX.Element => {
 };
 
 const ScreenCard = (props: ScreenDetailProps) => {
-  const { screens, isOpen, isMultipleScreens } = props;
+  const { screens, eventKey, isMultipleScreens } = props;
   const isPaess = screens.every((screen) => screen.type === "pa_ess");
   const isSolari = screens.every((screen) => screen.type === "solari");
   const isTriptych = screens.every((screen) => screen.type === "triptych_v2");
@@ -106,6 +107,9 @@ const ScreenCard = (props: ScreenDetailProps) => {
 
     return "";
   };
+
+  const { activeEventKey } = useContext(AccordionContext);
+  const isOpen = activeEventKey?.includes(eventKey);
 
   return (
     <div

--- a/assets/js/util.ts
+++ b/assets/js/util.ts
@@ -6,6 +6,7 @@ import CANNED_MESSAGES from "./constants/messages";
 import STATIONS_BY_LINE from "./constants/stations";
 import { Alert } from "./models/alert";
 import { Place } from "./models/place";
+import { Screen } from "./models/screen";
 import { ScreensByAlert } from "./models/screensByAlert";
 
 export const color = (line: string) => {
@@ -173,4 +174,25 @@ export const placesWithSelectedAlert = (
         }))
         .filter((place) => place.screens.length > 0)
     : [];
+};
+
+export const sortScreens = (screenList: Screen[]) => {
+  const screenTypeOrder = [
+    "dup",
+    "dup_v2",
+    "bus_shelter_v2",
+    "bus_eink",
+    "bus_eink_v2",
+    "gl_eink_single",
+    "gl_eink_double",
+    "gl_eink_v2",
+    "pre_fare_v2",
+    "triptych_v2",
+    "solari",
+    "pa_ess",
+  ];
+
+  return screenList.sort((a, b) =>
+    screenTypeOrder.indexOf(a.type) >= screenTypeOrder.indexOf(b.type) ? 1 : -1
+  );
 };

--- a/assets/tests/components/placeRow.test.tsx
+++ b/assets/tests/components/placeRow.test.tsx
@@ -3,7 +3,6 @@ import { fireEvent, render } from "@testing-library/react";
 import PlaceRow from "../../js/components/Dashboard/PlaceRow";
 import { Accordion } from "react-bootstrap";
 import { Place } from "../../js/models/place";
-import { ScreenplayProvider } from "../../js/hooks/useScreenplayContext";
 
 beforeAll(() => {
   const app = document.createElement("div");
@@ -12,46 +11,6 @@ beforeAll(() => {
 });
 
 describe("PlaceRow", () => {
-  test("opens when clicked", async () => {
-    const place: Place = {
-      id: "place-stop1",
-      name: "Place Name1",
-      routes: ["CR", "Red", "Green-B"],
-      status: "Auto",
-      screens: [
-        { id: "1111", type: "dup", disabled: false },
-        { id: "2222", type: "solari", disabled: false },
-        { id: "3333", type: "bus_shelter_v2", disabled: false },
-      ],
-    };
-
-    const handleClick = jest.fn();
-
-    const { getByTestId, getByAltText, queryByAltText } = render(
-      <ScreenplayProvider>
-        <Accordion>
-          <PlaceRow
-            place={place}
-            eventKey="0"
-            onClick={handleClick}
-            defaultSort
-          />
-        </Accordion>
-      </ScreenplayProvider>
-    );
-
-    expect(getByTestId("place-row").className).toBe("place-row");
-    fireEvent.click(getByTestId("place-row-header"));
-    expect(handleClick).toHaveBeenCalled();
-    expect(getByTestId("place-row").className).toBe("place-row open");
-    expect(getByTestId("place-screen-types").textContent).toBe(
-      "DUP·Bus Shelter·Solari"
-    );
-    expect(getByTestId("place-status").textContent).toBe("Auto");
-    expect(getByAltText("Green-B")).toBeInTheDocument();
-    expect(queryByAltText("Green")).toBeNull();
-  });
-
   test("shows no screens", async () => {
     const place: Place = {
       id: "place-stop1",
@@ -70,6 +29,8 @@ describe("PlaceRow", () => {
           eventKey="0"
           onClick={handleClick}
           defaultSort
+          disabled
+          variant="accordion"
         />
       </Accordion>
     );

--- a/assets/tests/components/placeRowAccordion.test.tsx
+++ b/assets/tests/components/placeRowAccordion.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react";
+import PlaceRowAccordion from "../../js/components/Dashboard/PlaceRowAccordion";
+import { Accordion } from "react-bootstrap";
+import { Place } from "../../js/models/place";
+import { ScreenplayProvider } from "../../js/hooks/useScreenplayContext";
+
+beforeAll(() => {
+  const app = document.createElement("div");
+  app.id = "app";
+  document.body.appendChild(app);
+});
+
+describe("PlaceRowAccordion", () => {
+  test("opens when clicked", async () => {
+    const place: Place = {
+      id: "place-stop1",
+      name: "Place Name1",
+      routes: ["CR", "Red", "Green-B"],
+      status: "Auto",
+      screens: [
+        { id: "1111", type: "dup", disabled: false },
+        { id: "2222", type: "solari", disabled: false },
+        { id: "3333", type: "bus_shelter_v2", disabled: false },
+      ],
+    };
+
+    const dispatch = jest.fn();
+
+    const { getByTestId } = render(
+      <ScreenplayProvider>
+        <Accordion>
+          <PlaceRowAccordion
+            place={place}
+            dispatch={dispatch}
+            activeEventKeys={[]}
+            sortDirection={0}
+          />
+        </Accordion>
+      </ScreenplayProvider>
+    );
+
+    expect(getByTestId("place-row").className).toBe("place-row");
+    fireEvent.click(getByTestId("place-row-header"));
+    expect(getByTestId("place-row").className).toBe("place-row open");
+  });
+});


### PR DESCRIPTION
**Asana task**: [Update place row component](https://app.asana.com/0/1185117109217413/1205552592584843/f)

There are 4 primary goals for these updates

1. Change `disabled` logic so it is read from `props`
2. Add a `select-box` variant
3. Move as much `Accordion` logic out as possible so the component is more reusable
4. Maintain all existing functionality 

The original `PlaceRow` component made the assumption that it would always be used in an `Accordion`. That is no longer the case in Permanent Configuration. We now need the ability to use this component without any accordion logic. This was a lot more work than I anticipated, mostly due to issues with hooks and deciding where accordion logic needed to live.

The solution I went with is moving all accordion logic into the `PlacesList`. This component is where the top level `Accordion` component lives, so it makes sense that all the other logic lives in the same place. `PlacesList` now displays a list of `PlaceRowAccordion`s, which is a wrapper of the main `PlaceRow`. This wrapper handles all of the accordion logic that `PlaceRow` used to be responsible for. 

~~**I know tests are failing, but I wanted to get the first round of review started while I worked on fixing them.~~
Got tests sorted out. Should be good to go now.