### PR TITLE
feat: Fetch station list for config pages

### DIFF
--- a/assets/js/components/App.tsx
+++ b/assets/js/components/App.tsx
@@ -37,11 +37,11 @@ class AppRoutes extends React.Component {
             <Route path="alerts" element={<AlertsPage />}></Route>
             <Route path="alerts/:id" element={<AlertDetails />}></Route>
             <Route path="pending" element={<PendingScreensPage />}></Route>
+            <Route
+              path="configure-screens"
+              element={<ConfigureScreensPage />}
+            />
           </Route>
-          <Route
-            path="configure-screens"
-            element={<ConfigureScreensPage />}
-          ></Route>
         </Routes>
       </React.Suspense>
     );

--- a/assets/js/components/Dashboard/PermanentConfiguration/ConfigureScreensPage.tsx
+++ b/assets/js/components/Dashboard/PermanentConfiguration/ConfigureScreensPage.tsx
@@ -18,6 +18,10 @@ const ConfigureScreensPage: ComponentType = () => {
           place.routes.some((route) => route.startsWith("Green"))
         );
         break;
+      default:
+        throw new Error(
+          `getPlacesList not implemented for screen type ${screenType}`
+        );
     }
 
     return filteredPlaces;

--- a/assets/js/components/Dashboard/PermanentConfiguration/ConfigureScreensPage.tsx
+++ b/assets/js/components/Dashboard/PermanentConfiguration/ConfigureScreensPage.tsx
@@ -3,9 +3,25 @@ import { Col, Container, Row } from "react-bootstrap";
 import AppBar from "./AppBar";
 import ButtonImage from "./ButtonImage";
 import "../../../../css/screenplay.scss";
+import { Place } from "../../../models/place";
+import { useScreenplayContext } from "../../../hooks/useScreenplayContext";
 
 const ConfigureScreensPage: ComponentType = () => {
   const [selectedScreenType, setSelectedScreenType] = useState<string>();
+  const { places } = useScreenplayContext();
+
+  const getPlacesList = (screenType: string) => {
+    let filteredPlaces: Place[] = [];
+    switch (screenType) {
+      case "gl-eink":
+        filteredPlaces = places.filter((place) =>
+          place.routes.some((route) => route.startsWith("Green"))
+        );
+        break;
+    }
+
+    return filteredPlaces;
+  };
 
   const selectScreenType = (screenType: string) =>
     setSelectedScreenType(screenType);
@@ -13,7 +29,7 @@ const ConfigureScreensPage: ComponentType = () => {
   let layout;
   switch (selectedScreenType) {
     case "gl-eink":
-      layout = <GlEinkConfigPage />;
+      layout = <GlEinkConfigPage places={getPlacesList("gl-eink")} />;
       break;
     default:
       layout = (
@@ -96,8 +112,21 @@ const SelectScreenTypeComponent: ComponentType<SelectScreenTypeComponentProps> =
     );
   };
 
-const GlEinkConfigPage: ComponentType = () => {
-  return <div>GL-Eink</div>;
+interface SubwayConfigPageProps {
+  places: Place[];
+}
+
+const GlEinkConfigPage: ComponentType<SubwayConfigPageProps> = ({
+  places,
+}: SubwayConfigPageProps) => {
+  return (
+    <>
+      <div>GL-Eink</div>
+      {places.map((place) => (
+        <div key={place.id}>{place.name}</div>
+      ))}
+    </>
+  );
 };
 
 export default ConfigureScreensPage;

--- a/assets/js/components/Dashboard/Sidebar.tsx
+++ b/assets/js/components/Dashboard/Sidebar.tsx
@@ -12,6 +12,8 @@ import TSquare from "../../../static/images/t-square.svg";
 
 const Sidebar: ComponentType = () => {
   const pathname = useLocation().pathname.replace(/\//g, "");
+  if (pathname.includes("configure-screens")) return null;
+
   // @ts-ignore Suppressing "object could be null" warning
   const username = document
     .querySelector("meta[name=username]")


### PR DESCRIPTION
**Asana task**: [Fetch stations logic](https://app.asana.com/0/1185117109217413/1205973195471517/f)

Added a function for fetching station list need on future config pages. Subway will be easy because we hold all subway stations in app state. We simply need to get that list and filter it down. 
