### PR TITLE
fix: Takeover tool SFTP path

### DIFF
--- a/lib/screenplay/outfront/sftp.ex
+++ b/lib/screenplay/outfront/sftp.ex
@@ -183,7 +183,7 @@ defmodule Screenplay.Outfront.SFTP do
 
   defp get_outfront_path_for_image(station, orientation) do
     station_directory = get_outfront_directory_for_station(station)
-    Path.join(["emergency-messaging", orientation, station_directory, "takeover.png"])
+    Path.join([orientation, station_directory, "takeover.png"])
   end
 
   defp get_outfront_directory_for_station(station) do


### PR DESCRIPTION
**Asana task**: [[Emergency Takeover] Investigate SFTP connection failure](https://app.asana.com/0/1185117109217413/1206038792589622/f)

Confirmed with OFM that the path was changed in the last year. `emergency-messaging` is now the root of the server so it does not need to be in the path. 
