### PR TITLE
fix: Takeover Tool station list

### DIFF
--- a/assets/js/constants/stations.ts
+++ b/assets/js/constants/stations.ts
@@ -191,7 +191,7 @@ const STATIONS_BY_LINE: StationsByLine = {
     },
     {
       name: "Massachusetts Avenue",
-      portrait: false,
+      portrait: true,
       landscape: false,
     },
     {
@@ -249,7 +249,7 @@ const STATIONS_BY_LINE: StationsByLine = {
     {
       name: "Maverick",
       portrait: true,
-      landscape: false,
+      landscape: true,
     },
     {
       name: "Airport",


### PR DESCRIPTION
**Asana task**: [Add new DUP stations to OFM Takeover Tool](https://app.asana.com/0/1185117109217413/1206435733263383/f)

In the list of stations and the OFM screen orientations they have, Maverick and Mass Ave were outdated. I confirmed that the Portrait folder exists on the SFTP server for Mass Ave. Maverick is missing a Landscape folder. Ana has reached out to OFM asking them to create that folder. 
