### PR TITLE
feat: Screens Admin auth

### DIFF
--- a/assets/js/components/Dashboard/ScreenDetailActionBar.tsx
+++ b/assets/js/components/Dashboard/ScreenDetailActionBar.tsx
@@ -81,9 +81,11 @@ const ScreenDetailActionBar = (
     );
   };
 
-  const isAdmin = document.querySelector("meta[name=is-admin]");
+  const isEmergencyAdmin = document.querySelector(
+    "meta[name=is-emergency-admin]"
+  );
 
-  const adminLink = isAdmin
+  const reportAProblemURL = isEmergencyAdmin
     ? "https://mbta.slack.com/channels/screens-team-pios"
     : "https://mbta.slack.com/channels/screens";
 
@@ -120,7 +122,7 @@ const ScreenDetailActionBar = (
           </Dropdown.Item>
           <Dropdown.Item
             className="three-dots-vertical-dropdown__item"
-            href={adminLink}
+            href={reportAProblemURL}
             onClick={(e: SyntheticEvent) => e.stopPropagation()}
             target="_blank"
           >
@@ -138,7 +140,7 @@ const ScreenDetailActionBar = (
           url={props.screenUrl}
           queueToastExpiration={queueToastExpiration}
         />
-        <ReportAProblemButton url={adminLink} />
+        <ReportAProblemButton url={reportAProblemURL} />
       </div>
     );
   }

--- a/assets/js/components/Dashboard/Sidebar.tsx
+++ b/assets/js/components/Dashboard/Sidebar.tsx
@@ -19,6 +19,8 @@ const Sidebar: ComponentType = () => {
     .querySelector("meta[name=username]")
     ?.getAttribute("content");
 
+  const isScreensAdmin = document.querySelector("meta[name=is-screens-admin]");
+
   return !pathname.includes("emergency-takeover") ? (
     <div className="sidebar-container">
       {/*
@@ -43,20 +45,24 @@ const Sidebar: ComponentType = () => {
             <span className="nav-link__name">Posted Alerts</span>
           </Button>
         </Link>
-        <Link className="sidebar-link" to="/pending">
-          <Button className={pathname === "pending" ? "selected" : ""}>
-            <ClockFill size={20} className="sidebar-link__icon" />
-            <span className="nav-link__name">Pending</span>
-          </Button>
-        </Link>
-        <Link className="sidebar-link" to="/configure-screens">
-          <Button
-            className={pathname === "configure-screens" ? "selected" : ""}
-          >
-            <PlusLg size={20} className="sidebar-link__icon" />
-            <span className="nav-link__name">Configure</span>
-          </Button>
-        </Link>
+        {isScreensAdmin && (
+          <>
+            <Link className="sidebar-link" to="/pending">
+              <Button className={pathname === "pending" ? "selected" : ""}>
+                <ClockFill size={20} className="sidebar-link__icon" />
+                <span className="nav-link__name">Pending</span>
+              </Button>
+            </Link>
+            <Link className="sidebar-link" to="/configure-screens">
+              <Button
+                className={pathname === "configure-screens" ? "selected" : ""}
+              >
+                <PlusLg size={20} className="sidebar-link__icon" />
+                <span className="nav-link__name">Configure</span>
+              </Button>
+            </Link>
+          </>
+        )}
         {/* This button slightly different to trigger a reload */}
         <Button href="/" className="takeover-button">
           <ExclamationTriangleFill size={20} className="sidebar-link__icon" />

--- a/assets/tests/components/reportAProblemButton.test.tsx
+++ b/assets/tests/components/reportAProblemButton.test.tsx
@@ -18,7 +18,7 @@ describe("ReportAProblemButton", () => {
 
   test("uses correct URL for admins", async () => {
     const meta = document.createElement("meta");
-    meta.setAttribute("name", "is-admin");
+    meta.setAttribute("name", "is-emergency-admin");
     document.head.appendChild(meta);
 
     const { getByTestId } = render(

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -88,7 +88,9 @@ config :screenplay,
 
 config :ueberauth, Ueberauth,
   providers: [
-    keycloak: {Screenplay.Ueberauth.Strategy.Fake, [roles: ["screenplay-emergency-admin"]]}
+    keycloak:
+      {Screenplay.Ueberauth.Strategy.Fake,
+       [roles: ["screenplay-emergency-admin", "screens-admin"]]}
   ]
 
 config :ueberauth_oidcc,

--- a/lib/screenplay_web/auth_manager/auth_manager.ex
+++ b/lib/screenplay_web/auth_manager/auth_manager.ex
@@ -3,7 +3,7 @@ defmodule ScreenplayWeb.AuthManager do
 
   use Guardian, otp_app: :screenplay
 
-  @type access_level :: :none | :read_only | :emergency_admin | :screens_config_admin
+  @type access_level :: :none | :read_only | :emergency_admin | :screens_admin
 
   @screenplay_admin_role "screenplay-emergency-admin"
   @screens_admin "screens-admin"
@@ -24,21 +24,25 @@ defmodule ScreenplayWeb.AuthManager do
 
   def resource_from_claims(_), do: {:error, :invalid_claims}
 
-  @spec claims_access_level(Guardian.Token.claims()) :: access_level()
+  @spec claims_access_level(Guardian.Token.claims()) :: list(access_level())
   def claims_access_level(%{"roles" => roles}) when not is_nil(roles) do
-    cond do
-      @screenplay_admin_role in roles ->
-        :emergency_admin
+    access_levels =
+      []
+      |> append_if(@screenplay_admin_role in roles, :emergency_admin)
+      |> append_if(@screens_admin in roles, :screens_admin)
 
-      @screens_admin in roles ->
-        :screens_config_admin
-
-      true ->
-        :read_only
+    if access_levels == [] do
+      [:read_only]
+    else
+      access_levels
     end
   end
 
   def claims_access_level(_claims) do
-    :read_only
+    [:read_only]
+  end
+
+  defp append_if(list, condition, item) do
+    if condition, do: list ++ [item], else: list
   end
 end

--- a/lib/screenplay_web/auth_manager/auth_manager.ex
+++ b/lib/screenplay_web/auth_manager/auth_manager.ex
@@ -3,7 +3,7 @@ defmodule ScreenplayWeb.AuthManager do
 
   use Guardian, otp_app: :screenplay
 
-  @type access_level :: :none | :read_only | :emergency_admin | :screens_config_admmin
+  @type access_level :: :none | :read_only | :emergency_admin | :screens_config_admin
 
   @screenplay_admin_role "screenplay-emergency-admin"
   @screens_admin "screens-admin"
@@ -31,7 +31,7 @@ defmodule ScreenplayWeb.AuthManager do
         :emergency_admin
 
       @screens_admin in roles ->
-        :screens_config_admmin
+        :screens_config_admin
 
       true ->
         :read_only

--- a/lib/screenplay_web/auth_manager/ensure_screenplay_admin_group.ex
+++ b/lib/screenplay_web/auth_manager/ensure_screenplay_admin_group.ex
@@ -11,7 +11,7 @@ defmodule ScreenplayWeb.EnsureScreenplayAdminGroup do
 
   def call(conn, _opts) do
     with claims <- Guardian.Plug.current_claims(conn),
-         true <- ScreenplayWeb.AuthManager.claims_access_level(claims) == :emergency_admin do
+         true <- :emergency_admin in ScreenplayWeb.AuthManager.claims_access_level(claims) do
       conn
     else
       _ ->

--- a/lib/screenplay_web/auth_manager/ensure_screens_admin_group.ex
+++ b/lib/screenplay_web/auth_manager/ensure_screens_admin_group.ex
@@ -3,9 +3,8 @@ defmodule ScreenplayWeb.EnsureScreensAdminGroup do
   Verify that the user has permission to access Permanent Configuration.
   """
 
-  import Plug.Conn
-
-  alias ScreenplayWeb.Router.Helpers
+  import Plug.Conn, only: [halt: 1]
+  import Phoenix.Controller, only: [redirect: 2]
 
   def init(options), do: options
 
@@ -16,7 +15,7 @@ defmodule ScreenplayWeb.EnsureScreensAdminGroup do
     else
       _ ->
         conn
-        |> Phoenix.Controller.redirect(to: Helpers.unauthorized_path(conn, :index))
+        |> redirect(to: "/dashboard")
         |> halt()
     end
   end

--- a/lib/screenplay_web/auth_manager/ensure_screens_admin_group.ex
+++ b/lib/screenplay_web/auth_manager/ensure_screens_admin_group.ex
@@ -1,0 +1,23 @@
+defmodule ScreenplayWeb.EnsureScreensAdminGroup do
+  @moduledoc """
+  Verify that the user has permission to access Permanent Configuration.
+  """
+
+  import Plug.Conn
+
+  alias ScreenplayWeb.Router.Helpers
+
+  def init(options), do: options
+
+  def call(conn, _opts) do
+    with claims <- Guardian.Plug.current_claims(conn),
+         true <- :screens_admin in ScreenplayWeb.AuthManager.claims_access_level(claims) do
+      conn
+    else
+      _ ->
+        conn
+        |> Phoenix.Controller.redirect(to: Helpers.unauthorized_path(conn, :index))
+        |> halt()
+    end
+  end
+end

--- a/lib/screenplay_web/plugs/metadata.ex
+++ b/lib/screenplay_web/plugs/metadata.ex
@@ -32,12 +32,12 @@ defmodule ScreenplayWeb.Plugs.Metadata do
     |> assign(:alerts_ui_url, Application.get_env(:screenplay, :alerts_ui_url))
     |> assign(:screens_url, Application.get_env(:screenplay, :screens_url))
     |> assign(:signs_ui_url, Application.get_env(:screenplay, :signs_ui_url))
-    |> assign(:is_admin, admin?(conn))
+    |> assign(:is_emergency_admin, emergency_admin?(conn))
     |> assign(:is_screens_admin, screens_admin?(conn))
     |> assign(:fullstory_org_id, Application.get_env(:screenplay, :fullstory_org_id))
   end
 
-  defp admin?(conn) do
+  defp emergency_admin?(conn) do
     claims = Guardian.Plug.current_claims(conn)
 
     :emergency_admin in ScreenplayWeb.AuthManager.claims_access_level(claims)

--- a/lib/screenplay_web/plugs/metadata.ex
+++ b/lib/screenplay_web/plugs/metadata.ex
@@ -33,13 +33,19 @@ defmodule ScreenplayWeb.Plugs.Metadata do
     |> assign(:screens_url, Application.get_env(:screenplay, :screens_url))
     |> assign(:signs_ui_url, Application.get_env(:screenplay, :signs_ui_url))
     |> assign(:is_admin, admin?(conn))
+    |> assign(:is_screens_admin, screens_admin?(conn))
     |> assign(:fullstory_org_id, Application.get_env(:screenplay, :fullstory_org_id))
   end
 
   defp admin?(conn) do
     claims = Guardian.Plug.current_claims(conn)
 
-    not is_nil(claims) and
-      ScreenplayWeb.AuthManager.claims_access_level(claims) == :emergency_admin
+    :emergency_admin in ScreenplayWeb.AuthManager.claims_access_level(claims)
+  end
+
+  defp screens_admin?(conn) do
+    claims = Guardian.Plug.current_claims(conn)
+
+    :screens_admin in ScreenplayWeb.AuthManager.claims_access_level(claims)
   end
 end

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -35,6 +35,10 @@ defmodule ScreenplayWeb.Router do
     plug(ScreenplayWeb.EnsureScreenplayAdminGroup)
   end
 
+  pipeline :ensure_screens_admin do
+    plug(ScreenplayWeb.EnsureScreensAdminGroup)
+  end
+
   # Load balancer health check
   # Exempt from auth checks and SSL redirects
   scope "/", ScreenplayWeb do
@@ -60,9 +64,21 @@ defmodule ScreenplayWeb.Router do
 
     get("/dashboard", DashboardController, :index)
     get("/alerts/*id", AlertsController, :index)
+    get("/unauthorized", UnauthorizedController, :index)
+  end
+
+  scope "/", ScreenplayWeb do
+    pipe_through([
+      :redirect_prod_http,
+      :browser,
+      :auth,
+      :ensure_auth,
+      :ensure_screens_admin,
+      :metadata
+    ])
+
     get("/pending", ConfigController, :index)
     get("/configure-screens/*app_id", ConfigController, :index)
-    get("/unauthorized", UnauthorizedController, :index)
   end
 
   scope "/api", ScreenplayWeb do
@@ -103,7 +119,8 @@ defmodule ScreenplayWeb.Router do
       :api,
       :browser,
       :auth,
-      :ensure_auth
+      :ensure_auth,
+      :ensure_screens_admin
     ])
 
     post("/put", ConfigController, :put)

--- a/lib/screenplay_web/templates/layout/app.html.heex
+++ b/lib/screenplay_web/templates/layout/app.html.heex
@@ -20,8 +20,8 @@
     <%= if @alerts_ui_url do %>
         <meta name="alerts-ui-url" content={@alerts_ui_url}>
     <% end %>
-    <%= if @is_admin do %>
-        <meta name="is-admin" content={@is_admin}>
+    <%= if @is_emergency_admin do %>
+        <meta name="is-emergency-admin" content={@is_emergency_admin}>
     <% end %>
     <%= if @is_screens_admin do %>
         <meta name="is-screens-admin" content={@is_screens_admin}>

--- a/lib/screenplay_web/templates/layout/app.html.heex
+++ b/lib/screenplay_web/templates/layout/app.html.heex
@@ -23,6 +23,9 @@
     <%= if @is_admin do %>
         <meta name="is-admin" content={@is_admin}>
     <% end %>
+    <%= if @is_screens_admin do %>
+        <meta name="is-screens-admin" content={@is_screens_admin}>
+    <% end %>
     <%= if @fullstory_org_id do %>
         <meta name="fullstory-org-id" content={@fullstory_org_id}>
     <% end %>

--- a/test/screenplay_web/controllers/alerts_controller_test.exs
+++ b/test/screenplay_web/controllers/alerts_controller_test.exs
@@ -2,7 +2,7 @@ defmodule ScreenplayWeb.Controllers.AlertsControllerTest do
   use ScreenplayWeb.ConnCase
 
   describe "index/2" do
-    @tag :authenticated_admin
+    @tag :authenticated_emergency_admin
     test "responds 200 to authenticated admin requests", %{conn: conn} do
       conn = get(conn, "/alerts")
       assert %{status: 200} = conn

--- a/test/screenplay_web/controllers/dashboard_api_controller_test.exs
+++ b/test/screenplay_web/controllers/dashboard_api_controller_test.exs
@@ -2,7 +2,7 @@ defmodule ScreenplayWeb.Controllers.DashboardApiControllerTest do
   use ScreenplayWeb.ConnCase
 
   describe "index/2" do
-    @tag :authenticated_admin
+    @tag :authenticated_emergency_admin
     test "responds 200 to authenticated admin requests", %{conn: conn} do
       conn = get(conn, "/dashboard")
       assert %{status: 200} = conn

--- a/test/screenplay_web/controllers/dashboard_controller_test.exs
+++ b/test/screenplay_web/controllers/dashboard_controller_test.exs
@@ -2,7 +2,7 @@ defmodule ScreenplayWeb.Controllers.DashboardControllerTest do
   use ScreenplayWeb.ConnCase
 
   describe "index/2" do
-    @tag :authenticated_admin
+    @tag :authenticated_emergency_admin
     test "responds 200 to authenticated admin requests", %{conn: conn} do
       conn = get(conn, "/dashboard")
       assert %{status: 200} = conn

--- a/test/screenplay_web/controllers/outfront_takeover_tool/page_controller_test.exs
+++ b/test/screenplay_web/controllers/outfront_takeover_tool/page_controller_test.exs
@@ -2,7 +2,7 @@ defmodule ScreenplayWeb.OutfrontTakeoverTool.PageControllerTest do
   use ScreenplayWeb.ConnCase
 
   describe "index/2" do
-    @tag :authenticated_admin
+    @tag :authenticated_emergency_admin
     test "responds 200 to authenticated admin requests", %{conn: conn} do
       conn = get(conn, "/emergency-takeover")
       assert %{status: 200} = conn
@@ -21,7 +21,7 @@ defmodule ScreenplayWeb.OutfrontTakeoverTool.PageControllerTest do
   end
 
   describe "takeover_redirect/2" do
-    @tag :authenticated_admin
+    @tag :authenticated_emergency_admin
     test "redirects admin to /emergency-takeover", %{conn: conn} do
       conn = get(conn, "/")
       assert redirected_to(conn) =~ "/emergency-takeover"

--- a/test/screenplay_web/ensure_screenplay_admin_group_test.exs
+++ b/test/screenplay_web/ensure_screenplay_admin_group_test.exs
@@ -8,7 +8,7 @@ defmodule ScreenplayWeb.EnsureScreenplayAdminGroupTest do
   end
 
   describe "call/2" do
-    @tag :authenticated_admin
+    @tag :authenticated_emergency_admin
     test "does nothing when user is in the outfront admin group", %{conn: conn} do
       assert conn == ScreenplayWeb.EnsureScreenplayAdminGroup.call(conn, [])
     end

--- a/test/screenplay_web/ensure_screens_admin_group_test.exs
+++ b/test/screenplay_web/ensure_screens_admin_group_test.exs
@@ -1,0 +1,23 @@
+defmodule ScreenplayWeb.EnsureScreensAdminGroupTest do
+  use ScreenplayWeb.ConnCase
+
+  describe "init/1" do
+    test "passes options through unchanged" do
+      assert ScreenplayWeb.EnsureScreenplayAdminGroup.init([]) == []
+    end
+  end
+
+  describe "call/2" do
+    @tag :authenticated_screens_admin
+    test "does nothing when user is in the screens admin group", %{conn: conn} do
+      assert conn == ScreenplayWeb.EnsureScreensAdminGroup.call(conn, [])
+    end
+
+    @tag :authenticated
+    test "redirects to Dashboard when user is not in the screens admin group", %{conn: conn} do
+      conn = ScreenplayWeb.EnsureScreensAdminGroup.call(conn, [])
+
+      assert redirected_to(conn) =~ "/dashboard"
+    end
+  end
+end

--- a/test/screenplay_web/ensure_screens_admin_group_test.exs
+++ b/test/screenplay_web/ensure_screens_admin_group_test.exs
@@ -3,7 +3,7 @@ defmodule ScreenplayWeb.EnsureScreensAdminGroupTest do
 
   describe "init/1" do
     test "passes options through unchanged" do
-      assert ScreenplayWeb.EnsureScreenplayAdminGroup.init([]) == []
+      assert ScreenplayWeb.EnsureScreensAdminGroup.init([]) == []
     end
   end
 

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -36,7 +36,7 @@ defmodule ScreenplayWeb.ConnCase do
   setup tags do
     {conn, user} =
       cond do
-        tags[:authenticated_admin] ->
+        tags[:authenticated_emergency_admin] ->
           user = "test_user"
 
           conn =

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -49,6 +49,19 @@ defmodule ScreenplayWeb.ConnCase do
 
           {conn, user}
 
+        tags[:authenticated_screens_admin] ->
+          user = "test_user"
+
+          conn =
+            Phoenix.ConnTest.build_conn()
+            |> Plug.Test.init_test_session(%{})
+            |> Guardian.Plug.sign_in(ScreenplayWeb.AuthManager, user, %{
+              "roles" => ["screens-admin"]
+            })
+            |> Plug.Conn.put_session(:username, user)
+
+          {conn, user}
+
         tags[:authenticated] ->
           user = "test_user"
 


### PR DESCRIPTION
**Asana task**: ad-hoc

In this PR, we ensure users are in the new auth group, `screens-admin`, before accessing either `/pending` or `/configure-screens`. An unauthorized user will not see the buttons in the sidebar and will be redirected to `/dashboard` when trying to access the URLs directly.
