### PR TITLE
fix: Missing compile-time env

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -24,7 +24,6 @@ sftp_client_module =
 config :screenplay,
   config_fetcher: Screenplay.Config.S3Fetch,
   config_s3_bucket: "mbta-ctd-config",
-  sftp_client_module: sftp_client_module,
   record_sentry: false
 
 # Include 2 logger backends

--- a/config/config.exs
+++ b/config/config.exs
@@ -15,9 +15,16 @@ config :screenplay, ScreenplayWeb.Endpoint,
   pubsub_server: Screenplay.PubSub,
   live_view: [signing_salt: "vSiyKz7D"]
 
+sftp_client_module =
+  case System.get_env("SFTP_SERVER") do
+    "outfront" -> SFTPClient
+    _ -> Screenplay.Outfront.FakeSFTPClient
+  end
+
 config :screenplay,
   config_fetcher: Screenplay.Config.S3Fetch,
   config_s3_bucket: "mbta-ctd-config",
+  sftp_client_module: sftp_client_module,
   record_sentry: false
 
 # Include 2 logger backends

--- a/config/config.exs
+++ b/config/config.exs
@@ -15,12 +15,6 @@ config :screenplay, ScreenplayWeb.Endpoint,
   pubsub_server: Screenplay.PubSub,
   live_view: [signing_salt: "vSiyKz7D"]
 
-sftp_client_module =
-  case System.get_env("SFTP_SERVER") do
-    "outfront" -> SFTPClient
-    _ -> Screenplay.Outfront.FakeSFTPClient
-  end
-
 config :screenplay,
   config_fetcher: Screenplay.Config.S3Fetch,
   config_s3_bucket: "mbta-ctd-config",

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -36,6 +36,7 @@ end
 config :screenplay,
   alerts_s3_path: "screenplay/" <> System.get_env("ALERTS_S3_FILENAME", ""),
   sftp_client_module: sftp_client_module,
+  job_sftp_client_module: SFTPClient,
   outfront_ssh_key: System.get_env("OUTFRONT_SSH_KEY"),
   outfront_sftp_user: System.get_env("OUTFRONT_SFTP_USER"),
   outfront_sftp_domain: System.get_env("OUTFRONT_SFTP_DOMAIN"),
@@ -58,8 +59,8 @@ config :sentry,
   root_source_code_path: File.cwd!()
 
 scheduler_jobs =
-  if env == "prod",
-    do: [{"0 7 * * *", {Screenplay.Jobs.TakeoverToolTestingJob, :run, []}}],
+  if env == "dev-green",
+    do: [{"20 * * * *", {Screenplay.Jobs.TakeoverToolTestingJob, :run, []}}],
     else: []
 
 config :screenplay, Screenplay.Scheduler, jobs: scheduler_jobs

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -6,6 +6,14 @@ config :screenplay, ScreenplayWeb.Endpoint,
   url: [host: System.get_env("HOST"), port: 80],
   secret_key_base: System.get_env("SECRET_KEY_BASE")
 
+env = System.get_env("ENVIRONMENT_NAME")
+
+sftp_client_module =
+  case env do
+    "prod" -> SFTPClient
+    _ -> Screenplay.Outfront.FakeSFTPClient
+  end
+
 if config_env() == :prod do
   keycloak_opts = [
     issuer: :keycloak_issuer,
@@ -25,23 +33,15 @@ if config_env() == :prod do
     ]
 end
 
-env = System.get_env("ENVIRONMENT_NAME")
-
-sftp_client_module =
-  case env do
-    "prod" -> SFTPClient
-    _ -> Screenplay.Outfront.FakeSFTPClient
-  end
-
 config :screenplay,
   alerts_s3_path: "screenplay/" <> System.get_env("ALERTS_S3_FILENAME", ""),
+  sftp_client_module: sftp_client_module,
   outfront_ssh_key: System.get_env("OUTFRONT_SSH_KEY"),
   outfront_sftp_user: System.get_env("OUTFRONT_SFTP_USER"),
   outfront_sftp_domain: System.get_env("OUTFRONT_SFTP_DOMAIN"),
   pio_slack_group_id: System.get_env("PIO_SLACK_USERGROUP_ID"),
   slack_webhook_url: System.get_env("SLACK_WEBHOOK_URL"),
   environment_name: env,
-  sftp_client_module: sftp_client_module,
   sentry_frontend_dsn: System.get_env("SENTRY_DSN"),
   api_v3_key: System.get_env("API_V3_KEY"),
   api_v3_url: System.get_env("API_V3_URL"),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -27,6 +27,12 @@ end
 
 env = System.get_env("ENVIRONMENT_NAME")
 
+sftp_client_module =
+  case env do
+    "prod" -> SFTPClient
+    _ -> Screenplay.Outfront.FakeSFTPClient
+  end
+
 config :screenplay,
   alerts_s3_path: "screenplay/" <> System.get_env("ALERTS_S3_FILENAME", ""),
   outfront_ssh_key: System.get_env("OUTFRONT_SSH_KEY"),
@@ -35,6 +41,7 @@ config :screenplay,
   pio_slack_group_id: System.get_env("PIO_SLACK_USERGROUP_ID"),
   slack_webhook_url: System.get_env("SLACK_WEBHOOK_URL"),
   environment_name: env,
+  sftp_client_module: sftp_client_module,
   sentry_frontend_dsn: System.get_env("SENTRY_DSN"),
   api_v3_key: System.get_env("API_V3_KEY"),
   api_v3_url: System.get_env("API_V3_URL"),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -6,14 +6,6 @@ config :screenplay, ScreenplayWeb.Endpoint,
   url: [host: System.get_env("HOST"), port: 80],
   secret_key_base: System.get_env("SECRET_KEY_BASE")
 
-sftp_client_module =
-  case System.get_env("SFTP_SERVER") do
-    "outfront" -> SFTPClient
-    _ -> Screenplay.Outfront.FakeSFTPClient
-  end
-
-env = System.get_env("ENVIRONMENT_NAME")
-
 if config_env() == :prod do
   keycloak_opts = [
     issuer: :keycloak_issuer,
@@ -33,9 +25,10 @@ if config_env() == :prod do
     ]
 end
 
+env = System.get_env("ENVIRONMENT_NAME")
+
 config :screenplay,
   alerts_s3_path: "screenplay/" <> System.get_env("ALERTS_S3_FILENAME", ""),
-  sftp_client_module: sftp_client_module,
   outfront_ssh_key: System.get_env("OUTFRONT_SSH_KEY"),
   outfront_sftp_user: System.get_env("OUTFRONT_SFTP_USER"),
   outfront_sftp_domain: System.get_env("OUTFRONT_SFTP_DOMAIN"),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -60,7 +60,7 @@ config :sentry,
 
 scheduler_jobs =
   if env == "dev-green",
-    do: [{"30 * * * *", {Screenplay.Jobs.TakeoverToolTestingJob, :run, []}}],
+    do: [{"40 * * * *", {Screenplay.Jobs.TakeoverToolTestingJob, :run, []}}],
     else: []
 
 config :screenplay, Screenplay.Scheduler, jobs: scheduler_jobs

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -36,7 +36,6 @@ end
 config :screenplay,
   alerts_s3_path: "screenplay/" <> System.get_env("ALERTS_S3_FILENAME", ""),
   sftp_client_module: sftp_client_module,
-  job_sftp_client_module: SFTPClient,
   outfront_ssh_key: System.get_env("OUTFRONT_SSH_KEY"),
   outfront_sftp_user: System.get_env("OUTFRONT_SFTP_USER"),
   outfront_sftp_domain: System.get_env("OUTFRONT_SFTP_DOMAIN"),
@@ -59,8 +58,8 @@ config :sentry,
   root_source_code_path: File.cwd!()
 
 scheduler_jobs =
-  if env == "dev-green",
-    do: [{"* * * * *", {Screenplay.Jobs.TakeoverToolTestingJob, :run, []}}],
+  if env == "prod",
+    do: [{"0 7 * * *", {Screenplay.Jobs.TakeoverToolTestingJob, :run, []}}],
     else: []
 
 config :screenplay, Screenplay.Scheduler, jobs: scheduler_jobs

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -60,7 +60,7 @@ config :sentry,
 
 scheduler_jobs =
   if env == "dev-green",
-    do: [{"20 * * * *", {Screenplay.Jobs.TakeoverToolTestingJob, :run, []}}],
+    do: [{"30 * * * *", {Screenplay.Jobs.TakeoverToolTestingJob, :run, []}}],
     else: []
 
 config :screenplay, Screenplay.Scheduler, jobs: scheduler_jobs

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -60,7 +60,7 @@ config :sentry,
 
 scheduler_jobs =
   if env == "dev-green",
-    do: [{"40 * * * *", {Screenplay.Jobs.TakeoverToolTestingJob, :run, []}}],
+    do: [{"* * * * *", {Screenplay.Jobs.TakeoverToolTestingJob, :run, []}}],
     else: []
 
 config :screenplay, Screenplay.Scheduler, jobs: scheduler_jobs

--- a/lib/screenplay/jobs/takeover_tool_testing_job.ex
+++ b/lib/screenplay/jobs/takeover_tool_testing_job.ex
@@ -22,7 +22,7 @@ defmodule Screenplay.Jobs.TakeoverToolTestingJob do
     #   test_all_directories_exist(conn)
     # end)
 
-    conn = start_connection()
+    {:ok, conn} = start_connection()
 
     try do
       test_creating_and_removing_images(conn)

--- a/lib/screenplay/jobs/takeover_tool_testing_job.ex
+++ b/lib/screenplay/jobs/takeover_tool_testing_job.ex
@@ -15,7 +15,6 @@ defmodule Screenplay.Jobs.TakeoverToolTestingJob do
   @landscape_dir Application.compile_env!(:screenplay, :landscape_dir)
   @portrait_dir Application.compile_env!(:screenplay, :portrait_dir)
   @test_image :screenplay |> :code.priv_dir() |> Path.join("takeover_test.png") |> File.read!()
-  @sftp_client_module Application.compile_env!(:screenplay, :sftp_client_module)
 
   def run do
     SFTP.run(fn conn ->
@@ -34,7 +33,7 @@ defmodule Screenplay.Jobs.TakeoverToolTestingJob do
   defp write_image(conn, orientation, local_image_data) do
     remote_path = Path.join([orientation, @test_sftp_directory_name, "takeover-test.png"])
 
-    case @sftp_client_module.write_file(conn, remote_path, local_image_data) do
+    case sftp_client_module().write_file(conn, remote_path, local_image_data) do
       :ok ->
         :ok
 
@@ -50,7 +49,7 @@ defmodule Screenplay.Jobs.TakeoverToolTestingJob do
   defp delete_image(conn, orientation) do
     remote_path = Path.join([orientation, @test_sftp_directory_name, "takeover.png"])
 
-    case @sftp_client_module.delete_file(conn, remote_path) do
+    case sftp_client_module().delete_file(conn, remote_path) do
       :ok ->
         :ok
 
@@ -69,8 +68,8 @@ defmodule Screenplay.Jobs.TakeoverToolTestingJob do
   end
 
   defp test_all_directories_exist(conn) do
-    {:ok, portrait_dirs} = @sftp_client_module.list_dir(conn, "./Portrait")
-    {:ok, landscape_dirs} = @sftp_client_module.list_dir(conn, "./Landscape")
+    {:ok, portrait_dirs} = sftp_client_module().list_dir(conn, "./Portrait")
+    {:ok, landscape_dirs} = sftp_client_module().list_dir(conn, "./Landscape")
 
     outfront_takeover_tool_screens =
       :screenplay
@@ -99,4 +98,6 @@ defmodule Screenplay.Jobs.TakeoverToolTestingJob do
       end
     end)
   end
+
+  defp sftp_client_module, do: Application.get_env(:screenplay, :sftp_client_module)
 end

--- a/lib/screenplay/jobs/takeover_tool_testing_job.ex
+++ b/lib/screenplay/jobs/takeover_tool_testing_job.ex
@@ -68,6 +68,7 @@ defmodule Screenplay.Jobs.TakeoverToolTestingJob do
 
     case sftp_client_module().write_file(conn, remote_path, local_image_data) do
       :ok ->
+        Logger.info("Successfully uploaded image to #{remote_path}")
         :ok
 
       {:error, error} ->
@@ -84,6 +85,7 @@ defmodule Screenplay.Jobs.TakeoverToolTestingJob do
 
     case sftp_client_module().delete_file(conn, remote_path) do
       :ok ->
+        Logger.info("Successfully deleted image from #{remote_path}")
         :ok
 
       {:error, %SFTPClient.OperationError{reason: :no_such_file}} ->

--- a/lib/screenplay/jobs/takeover_tool_testing_job.ex
+++ b/lib/screenplay/jobs/takeover_tool_testing_job.ex
@@ -22,7 +22,7 @@ defmodule Screenplay.Jobs.TakeoverToolTestingJob do
     #   test_all_directories_exist(conn)
     # end)
 
-    {:ok, conn} = start_connection()
+    conn = start_connection()
 
     try do
       test_creating_and_removing_images(conn)

--- a/lib/screenplay/jobs/takeover_tool_testing_job.ex
+++ b/lib/screenplay/jobs/takeover_tool_testing_job.ex
@@ -99,5 +99,5 @@ defmodule Screenplay.Jobs.TakeoverToolTestingJob do
     end)
   end
 
-  defp sftp_client_module, do: Application.get_env(:screenplay, :sftp_client_module)
+  defp sftp_client_module, do: Application.get_env(:screenplay, :job_sftp_client_module)
 end

--- a/lib/screenplay/jobs/takeover_tool_testing_job.ex
+++ b/lib/screenplay/jobs/takeover_tool_testing_job.ex
@@ -33,8 +33,8 @@ defmodule Screenplay.Jobs.TakeoverToolTestingJob do
   end
 
   defp start_connection() do
-    host = Application.get_env(:screenplay, :outfront_sftp_domain)
-    user = Application.get_env(:screenplay, :outfront_sftp_user)
+    host = "em-api.outfrontmediadigital.com"
+    user = "MBTA_EMessaging"
     key = Application.get_env(:screenplay, :outfront_ssh_key)
 
     if is_binary(key) and String.length(key) > 0 do


### PR DESCRIPTION
**Asana task**: ad-hoc

I thought I tested the new automated job in a deployed environment, but I guess not. ~~Now that `sftp_client_module` is needed in module attributes, it can't live in `runtime.exs`. I moved it to `config.exs` instead.~~ Keeping it in the runtime config, but changed from a module attribute back to a helper function. 
