### PR TITLE
feat: Sentry replay integration

### DIFF
--- a/assets/js/app.tsx
+++ b/assets/js/app.tsx
@@ -35,6 +35,9 @@ if (sentryDsn) {
   Sentry.init({
     dsn: sentryDsn,
     environment: environment,
+    integrations: [Sentry.replayIntegration()],
+    replaysSessionSampleRate: 0.1,
+    replaysOnErrorSampleRate: 1.0,
   });
 
   if (username) {

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -2013,62 +2013,94 @@
         "@babel/runtime": "^7.6.2"
       }
     },
-    "@sentry/browser": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.14.0.tgz",
-      "integrity": "sha512-AdLmqeOXvCVYgJAgMUUby+TRh+yIeZO16NPpZWQPGggXIjnhSzoN4liyXJvQ7Mhm326GboFUKjQwqpCEviQcyg==",
+    "@sentry-internal/feedback": {
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.108.0.tgz",
+      "integrity": "sha512-8JcgZEnk1uWrXJhsd3iRvFtEiVeaWOEhN0NZwhwQXHfvODqep6JtrkY1yCIyxbpA37aZmrPc2JhyotRERGfUjg==",
       "requires": {
-        "@sentry/core": "7.14.0",
-        "@sentry/types": "7.14.0",
-        "@sentry/utils": "7.14.0",
-        "tslib": "^1.9.3"
+        "@sentry/core": "7.108.0",
+        "@sentry/types": "7.108.0",
+        "@sentry/utils": "7.108.0"
+      }
+    },
+    "@sentry-internal/replay-canvas": {
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.108.0.tgz",
+      "integrity": "sha512-R5tvjGqWUV5vSk0N1eBgVW7wIADinrkfDEBZ9FyKP2mXHBobsyNGt30heJDEqYmVqluRqjU2NuIRapsnnrpGnA==",
+      "requires": {
+        "@sentry/core": "7.108.0",
+        "@sentry/replay": "7.108.0",
+        "@sentry/types": "7.108.0",
+        "@sentry/utils": "7.108.0"
+      }
+    },
+    "@sentry-internal/tracing": {
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.108.0.tgz",
+      "integrity": "sha512-zuK5XsTsb+U+hgn3SPetYDAogrXsM16U/LLoMW7+TlC6UjlHGYQvmX3o+M2vntejoU1QZS8m1bCAZSMWEypAEw==",
+      "requires": {
+        "@sentry/core": "7.108.0",
+        "@sentry/types": "7.108.0",
+        "@sentry/utils": "7.108.0"
+      }
+    },
+    "@sentry/browser": {
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.108.0.tgz",
+      "integrity": "sha512-FNpzsdTvGvdHJMUelqEouUXMZU7jC+dpN7CdT6IoHVVFEkoAgrjMVUhXZoQ/dmCkdKWHmFSQhJ8Fm6V+e9Aq0A==",
+      "requires": {
+        "@sentry-internal/feedback": "7.108.0",
+        "@sentry-internal/replay-canvas": "7.108.0",
+        "@sentry-internal/tracing": "7.108.0",
+        "@sentry/core": "7.108.0",
+        "@sentry/replay": "7.108.0",
+        "@sentry/types": "7.108.0",
+        "@sentry/utils": "7.108.0"
       }
     },
     "@sentry/core": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.14.0.tgz",
-      "integrity": "sha512-Hgn7De6CiCFnz868/Lrtei+9rj7/TIwhbDe3J+NeH+2ffXYn4VI8FxrlR/p2XfIq9iCfmG80EQXDtSh+Kh7mOw==",
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.108.0.tgz",
+      "integrity": "sha512-I/VNZCFgLASxHZaD0EtxZRM34WG9w2gozqgrKGNMzAymwmQ3K9g/1qmBy4e6iS3YRptb7J5UhQkZQHrcwBbjWQ==",
       "requires": {
-        "@sentry/hub": "7.14.0",
-        "@sentry/types": "7.14.0",
-        "@sentry/utils": "7.14.0",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/hub": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.14.0.tgz",
-      "integrity": "sha512-O+pxsipeiURC6Mxuivz1pX3yHlkQCI2yjP38bISxUZv1NIijHuxiDmgqrrcCJltiIfyY2+f9LAezKVCAXnPFuw==",
-      "requires": {
-        "@sentry/types": "7.14.0",
-        "@sentry/utils": "7.14.0",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.108.0",
+        "@sentry/utils": "7.108.0"
       }
     },
     "@sentry/react": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.14.0.tgz",
-      "integrity": "sha512-PEHqqr6o0ZfrNhFYe1lLTNY1+vV5bEuZaG0i8s+Jo4OHozh689CeH+lGZSjvFxCpaexC+FskpiGAzcXTeurpaA==",
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.108.0.tgz",
+      "integrity": "sha512-C60arh5/gtO42eMU9l34aWlKDLZUO+1j1goaEf/XRSwUcyJS9tbJrs+mT4nbKxUsEG714It2gRbfSEvh1eXmCg==",
       "requires": {
-        "@sentry/browser": "7.14.0",
-        "@sentry/types": "7.14.0",
-        "@sentry/utils": "7.14.0",
-        "hoist-non-react-statics": "^3.3.2",
-        "tslib": "^1.9.3"
+        "@sentry/browser": "7.108.0",
+        "@sentry/core": "7.108.0",
+        "@sentry/types": "7.108.0",
+        "@sentry/utils": "7.108.0",
+        "hoist-non-react-statics": "^3.3.2"
+      }
+    },
+    "@sentry/replay": {
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.108.0.tgz",
+      "integrity": "sha512-jo8fDOzcZJclP1+4n9jUtVxTlBFT9hXwxhAMrhrt70FV/nfmCtYQMD3bzIj79nwbhUtFP6pN39JH1o7Xqt1hxQ==",
+      "requires": {
+        "@sentry-internal/tracing": "7.108.0",
+        "@sentry/core": "7.108.0",
+        "@sentry/types": "7.108.0",
+        "@sentry/utils": "7.108.0"
       }
     },
     "@sentry/types": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.14.0.tgz",
-      "integrity": "sha512-9iFZS9Hr5hAoL+M9oUH2dY9burOaQh+CHGH66fortuTp++YDWKdbPEeKcz8hRJaUyBBn53rdxiBmAyHsrlE6KA=="
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.108.0.tgz",
+      "integrity": "sha512-bKtHITmBN3kqtqE5eVvL8mY8znM05vEodENwRpcm6TSrrBjC2RnwNWVwGstYDdHpNfFuKwC8mLY9bgMJcENo8g=="
     },
     "@sentry/utils": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.14.0.tgz",
-      "integrity": "sha512-q9em4ZBcaUk7J1WULiltZVEcbyCE0wwAIjqRaoNmHVe4FeK++uAPo2ULZM1kQgN8syZnQ1jcfLktIKkWfnE2cg==",
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.108.0.tgz",
+      "integrity": "sha512-a45yEFD5qtgZaIFRAcFkG8C8lnDzn6t4LfLXuV4OafGAy/3ZAN3XN8wDnrruHkiUezSSANGsLg3bXaLW/JLvJw==",
       "requires": {
-        "@sentry/types": "7.14.0",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.108.0"
       }
     },
     "@sinclair/typebox": {
@@ -14745,7 +14777,8 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "tsutils": {
       "version": "3.21.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@fullstory/browser": "^1.6.2",
     "@heroicons/react": "^1.0.4",
-    "@sentry/react": "^7.14.0",
+    "@sentry/react": "^7.108.0",
     "bootstrap": "^5.1.0",
     "date-fns": "^2.23.0",
     "moment": "^2.29.4",


### PR DESCRIPTION
**Asana task**: ad-hoc

I noticed that Screenplay has some errors that give very little info. Setting up source mapping will help us see readable stacktraces in Sentry, but it requires a secret that I'll need to track down. Replay setup was super easy so didn't think we needed to wait. 

Sample replay can be found [here](https://mbtace.sentry.io/replays/c0c3526f8db84b9e96d0b9002ff0d58a/?environment=dev-green&project=6061951&query=&referrer=%2Freplays%2F&statsPeriod=7d&yAxis=count%28%29). Note that all text is masked by default. We can use our own masking by adding the CSS class `sentry-mask` to any element, but I'm not sure that's 100% necessary at this point. 