### PR TITLE
fix: state initialization causing mounting issue

### DIFF
--- a/assets/js/components/OutfrontTakeoverTool/OutfrontTakeoverTool.tsx
+++ b/assets/js/components/OutfrontTakeoverTool/OutfrontTakeoverTool.tsx
@@ -71,18 +71,18 @@ class OutfrontTakeoverTool extends React.Component<
       stationScreenOrientationList: {},
     };
 
-    this.toggleAlertWizard = this.toggleAlertWizard.bind(this);
-    this.openModal = this.openModal.bind(this);
-    this.toggleModal = this.toggleModal.bind(this);
-  }
-
-  componentDidMount() {
     fetch(`${BASE_URL}/stations_and_screen_orientations`)
       .then((response) => response.json())
       .then((result) =>
         this.setState({ stationScreenOrientationList: result })
       );
 
+    this.toggleAlertWizard = this.toggleAlertWizard.bind(this);
+    this.openModal = this.openModal.bind(this);
+    this.toggleModal = this.toggleModal.bind(this);
+  }
+
+  componentDidMount() {
     document.title = "Outfront Media · Emergency Takeover";
   }
 


### PR DESCRIPTION
**Asana task**: ad-hoc

The state was not being set early enough and was causing some child components to error when rendering. Moved the fetch to the constructor so it is ready before child components render.

[Sentry error](https://mbtace.sentry.io/issues/5111135163/?alert_rule_id=9754397&alert_type=issue&environment=prod&notification_uuid=0106feac-205e-4916-ae9a-71b5638ca730&project=6061951&referrer=issue_alert-slack)