### PR TITLE
fix: Table header conditional render

### DIFF
--- a/assets/js/components/Dashboard/PermanentConfiguration/Workflows/GlEink/ConfigureScreensPage.tsx
+++ b/assets/js/components/Dashboard/PermanentConfiguration/Workflows/GlEink/ConfigureScreensPage.tsx
@@ -214,7 +214,8 @@ const ConfigurePlaceCard: ComponentType<ConfigurePlaceCardProps> = ({
 
   const hasRows =
     Object.keys(existingLiveScreens).length > 0 ||
-    Object.keys(existingPendingScreens).length > 0 ||
+    Object.values(existingPendingScreens).filter((config) => !config.is_deleted)
+      .length > 0 ||
     newScreens.length > 0;
 
   const deleteExistingPendingRow = (


### PR DESCRIPTION
**Asana task**: ad-hoc

When a location has no more screens after a pending screen was deleted, it was still showing the table headers. Fix conditional so it does not consider deleted pending screens as a row to display.
