### PR TITLE
Auth needs for PA Message Creation

### DIFF
--- a/assets/js/components/Dashboard/ScreenDetailActionBar.tsx
+++ b/assets/js/components/Dashboard/ScreenDetailActionBar.tsx
@@ -81,9 +81,11 @@ const ScreenDetailActionBar = (
     );
   };
 
-  const isAdmin = document.querySelector("meta[name=is-admin]");
+  const isEmergencyAdmin = document.querySelector(
+    "meta[name=is-emergency-admin]"
+  );
 
-  const adminLink = isAdmin
+  const reportAProblemURL = isEmergencyAdmin
     ? "https://mbta.slack.com/channels/screens-team-pios"
     : "https://mbta.slack.com/channels/screens";
 
@@ -120,7 +122,7 @@ const ScreenDetailActionBar = (
           </Dropdown.Item>
           <Dropdown.Item
             className="three-dots-vertical-dropdown__item"
-            href={adminLink}
+            href={reportAProblemURL}
             onClick={(e: SyntheticEvent) => e.stopPropagation()}
             target="_blank"
           >
@@ -138,7 +140,7 @@ const ScreenDetailActionBar = (
           url={props.screenUrl}
           queueToastExpiration={queueToastExpiration}
         />
-        <ReportAProblemButton url={adminLink} />
+        <ReportAProblemButton url={reportAProblemURL} />
       </div>
     );
   }

--- a/assets/tests/components/reportAProblemButton.test.tsx
+++ b/assets/tests/components/reportAProblemButton.test.tsx
@@ -18,7 +18,7 @@ describe("ReportAProblemButton", () => {
 
   test("uses correct URL for admins", async () => {
     const meta = document.createElement("meta");
-    meta.setAttribute("name", "is-admin");
+    meta.setAttribute("name", "is-emergency-admin");
     document.head.appendChild(meta);
 
     const { getByTestId } = render(

--- a/assets/tests/components/reportAProblemButton.test.tsx
+++ b/assets/tests/components/reportAProblemButton.test.tsx
@@ -3,7 +3,7 @@ import { render, waitFor } from "@testing-library/react";
 import ReportAProblemButton from "../../js/components/Dashboard/ReportAProblemButton";
 
 describe("ReportAProblemButton", () => {
-  test("uses correct URL for non-admin users", async () => {
+  test("uses correct URL for users that are not emergency admins", async () => {
     const { getByTestId } = render(
       <ReportAProblemButton url={"https://mbta.slack.com/channels/screens"} />
     );
@@ -16,7 +16,7 @@ describe("ReportAProblemButton", () => {
     );
   });
 
-  test("uses correct URL for admins", async () => {
+  test("uses correct URL for emergency admins", async () => {
     const meta = document.createElement("meta");
     meta.setAttribute("name", "is-emergency-admin");
     document.head.appendChild(meta);

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -84,7 +84,9 @@ config :screenplay,
 
 config :ueberauth, Ueberauth,
   providers: [
-    keycloak: {Screenplay.Ueberauth.Strategy.Fake, [roles: ["screenplay-emergency-admin"]]}
+    keycloak:
+      {Screenplay.Ueberauth.Strategy.Fake,
+       [roles: ["screenplay-emergency-admin", "pa-message-admin"]]}
   ]
 
 config :ueberauth_oidcc,

--- a/lib/screenplay_web/auth_manager/auth_manager.ex
+++ b/lib/screenplay_web/auth_manager/auth_manager.ex
@@ -3,10 +3,12 @@ defmodule ScreenplayWeb.AuthManager do
 
   use Guardian, otp_app: :screenplay
 
-  @type access_level :: :none | :read_only | :emergency_admin | :screens_config_admin
+  @type access_level ::
+          :none | :read_only | :emergency_admin | :screens_config_admin | :pa_message_admin
 
   @screenplay_emergency_admin_role "screenplay-emergency-admin"
   @screens_admin "screens-admin"
+  @pa_message_admin "pa-message-admin"
 
   @spec subject_for_token(
           resource :: Guardian.Token.resource(),
@@ -30,6 +32,7 @@ defmodule ScreenplayWeb.AuthManager do
       []
       |> append_if(@screenplay_emergency_admin_role in roles, :emergency_admin)
       |> append_if(@screens_admin in roles, :screens_admin)
+      |> append_if(@pa_message_admin in roles, :pa_message_admin)
 
     if access_levels == [] do
       [:read_only]

--- a/lib/screenplay_web/auth_manager/auth_manager.ex
+++ b/lib/screenplay_web/auth_manager/auth_manager.ex
@@ -3,8 +3,7 @@ defmodule ScreenplayWeb.AuthManager do
 
   use Guardian, otp_app: :screenplay
 
-  @type access_level ::
-          :none | :read_only | :emergency_admin | :screens_config_admin | :pa_message_admin
+  @type access_level :: :emergency_admin | :screens_config_admin | :pa_message_admin
 
   @roles %{
     "screenplay-emergency-admin" => :emergency_admin,
@@ -30,16 +29,10 @@ defmodule ScreenplayWeb.AuthManager do
 
   @spec claims_access_level(Guardian.Token.claims()) :: list(access_level())
   def claims_access_level(%{"roles" => roles}) when not is_nil(roles) do
-    access_levels = Enum.map(roles, &Map.get(@roles, &1)) |> Enum.reject(&is_nil/1)
-
-    if access_levels == [] do
-      [:read_only]
-    else
-      access_levels
-    end
+    Enum.map(roles, &Map.get(@roles, &1)) |> Enum.reject(&is_nil/1)
   end
 
   def claims_access_level(_claims) do
-    [:read_only]
+    []
   end
 end

--- a/lib/screenplay_web/auth_manager/auth_manager.ex
+++ b/lib/screenplay_web/auth_manager/auth_manager.ex
@@ -3,7 +3,7 @@ defmodule ScreenplayWeb.AuthManager do
 
   use Guardian, otp_app: :screenplay
 
-  @type access_level :: :none | :read_only | :emergency_admin | :screens_config_admmin
+  @type access_level :: :none | :read_only | :emergency_admin | :screens_config_admin
 
   @screenplay_admin_role "screenplay-emergency-admin"
   @screens_admin "screens-admin"
@@ -24,21 +24,25 @@ defmodule ScreenplayWeb.AuthManager do
 
   def resource_from_claims(_), do: {:error, :invalid_claims}
 
-  @spec claims_access_level(Guardian.Token.claims()) :: access_level()
+  @spec claims_access_level(Guardian.Token.claims()) :: list(access_level())
   def claims_access_level(%{"roles" => roles}) when not is_nil(roles) do
-    cond do
-      @screenplay_admin_role in roles ->
-        :emergency_admin
+    access_levels =
+      []
+      |> append_if(@screenplay_admin_role in roles, :emergency_admin)
+      |> append_if(@screens_admin in roles, :screens_admin)
 
-      @screens_admin in roles ->
-        :screens_config_admmin
-
-      true ->
-        :read_only
+    if access_levels == [] do
+      [:read_only]
+    else
+      access_levels
     end
   end
 
   def claims_access_level(_claims) do
-    :read_only
+    [:read_only]
+  end
+
+  defp append_if(list, condition, item) do
+    if condition, do: list ++ [item], else: list
   end
 end

--- a/lib/screenplay_web/auth_manager/auth_manager.ex
+++ b/lib/screenplay_web/auth_manager/auth_manager.ex
@@ -5,7 +5,7 @@ defmodule ScreenplayWeb.AuthManager do
 
   @type access_level :: :none | :read_only | :emergency_admin | :screens_config_admin
 
-  @screenplay_admin_role "screenplay-emergency-admin"
+  @screenplay_emergency_admin_role "screenplay-emergency-admin"
   @screens_admin "screens-admin"
 
   @spec subject_for_token(
@@ -28,7 +28,7 @@ defmodule ScreenplayWeb.AuthManager do
   def claims_access_level(%{"roles" => roles}) when not is_nil(roles) do
     access_levels =
       []
-      |> append_if(@screenplay_admin_role in roles, :emergency_admin)
+      |> append_if(@screenplay_emergency_admin_role in roles, :emergency_admin)
       |> append_if(@screens_admin in roles, :screens_admin)
 
     if access_levels == [] do

--- a/lib/screenplay_web/auth_manager/ensure_pa_message_admin.ex
+++ b/lib/screenplay_web/auth_manager/ensure_pa_message_admin.ex
@@ -1,0 +1,22 @@
+defmodule ScreenplayWeb.EnsurePaMessageAdmin do
+  @moduledoc """
+  Verify that the user has permission to access the PA Message Creation feature.
+  """
+
+  import Plug.Conn, only: [halt: 1]
+  import Phoenix.Controller, only: [redirect: 2]
+
+  def init(options), do: options
+
+  def call(conn, _opts) do
+    with claims <- Guardian.Plug.current_claims(conn),
+         true <- :pa_message_admin in ScreenplayWeb.AuthManager.claims_access_level(claims) do
+      conn
+    else
+      _ ->
+        conn
+        |> redirect(to: "/dashboard")
+        |> halt()
+    end
+  end
+end

--- a/lib/screenplay_web/auth_manager/ensure_pa_message_admin.ex
+++ b/lib/screenplay_web/auth_manager/ensure_pa_message_admin.ex
@@ -8,15 +8,13 @@ defmodule ScreenplayWeb.EnsurePaMessageAdmin do
 
   def init(options), do: options
 
-  def call(conn, _opts) do
-    with claims <- Guardian.Plug.current_claims(conn),
-         true <- :pa_message_admin in ScreenplayWeb.AuthManager.claims_access_level(claims) do
+  def call(conn = %{assigns: %{roles: roles}}, _opts) do
+    if :pa_message_admin in roles do
       conn
     else
-      _ ->
-        conn
-        |> redirect(to: "/dashboard")
-        |> halt()
+      conn
+      |> redirect(to: "/dashboard")
+      |> halt()
     end
   end
 end

--- a/lib/screenplay_web/auth_manager/ensure_screenplay_admin_group.ex
+++ b/lib/screenplay_web/auth_manager/ensure_screenplay_admin_group.ex
@@ -11,7 +11,7 @@ defmodule ScreenplayWeb.EnsureScreenplayAdminGroup do
 
   def call(conn, _opts) do
     with claims <- Guardian.Plug.current_claims(conn),
-         true <- ScreenplayWeb.AuthManager.claims_access_level(claims) == :emergency_admin do
+         true <- :emergency_admin in ScreenplayWeb.AuthManager.claims_access_level(claims) do
       conn
     else
       _ ->

--- a/lib/screenplay_web/auth_manager/ensure_screenplay_emergency_admin_group.ex
+++ b/lib/screenplay_web/auth_manager/ensure_screenplay_emergency_admin_group.ex
@@ -1,4 +1,4 @@
-defmodule ScreenplayWeb.EnsureScreenplayAdminGroup do
+defmodule ScreenplayWeb.EnsureScreenplayEmergencyAdminGroup do
   @moduledoc """
   Verify that the user has permission to access the Outfront Takeover Tool.
   """

--- a/lib/screenplay_web/auth_manager/ensure_screenplay_emergency_admin_group.ex
+++ b/lib/screenplay_web/auth_manager/ensure_screenplay_emergency_admin_group.ex
@@ -9,15 +9,13 @@ defmodule ScreenplayWeb.EnsureScreenplayEmergencyAdminGroup do
 
   def init(options), do: options
 
-  def call(conn, _opts) do
-    with claims <- Guardian.Plug.current_claims(conn),
-         true <- :emergency_admin in ScreenplayWeb.AuthManager.claims_access_level(claims) do
+  def call(conn = %{assigns: %{roles: roles}}, _opts) do
+    if :emergency_admin in roles do
       conn
     else
-      _ ->
-        conn
-        |> Phoenix.Controller.redirect(to: Helpers.unauthorized_path(conn, :index))
-        |> halt()
+      conn
+      |> Phoenix.Controller.redirect(to: Helpers.unauthorized_path(conn, :index))
+      |> halt()
     end
   end
 end

--- a/lib/screenplay_web/plugs/metadata.ex
+++ b/lib/screenplay_web/plugs/metadata.ex
@@ -32,14 +32,13 @@ defmodule ScreenplayWeb.Plugs.Metadata do
     |> assign(:alerts_ui_url, Application.get_env(:screenplay, :alerts_ui_url))
     |> assign(:screens_url, Application.get_env(:screenplay, :screens_url))
     |> assign(:signs_ui_url, Application.get_env(:screenplay, :signs_ui_url))
-    |> assign(:is_admin, admin?(conn))
+    |> assign(:is_emergency_admin, emergency_admin?(conn))
     |> assign(:fullstory_org_id, Application.get_env(:screenplay, :fullstory_org_id))
   end
 
-  defp admin?(conn) do
+  defp emergency_admin?(conn) do
     claims = Guardian.Plug.current_claims(conn)
 
-    not is_nil(claims) and
-      ScreenplayWeb.AuthManager.claims_access_level(claims) == :emergency_admin
+    :emergency_admin in ScreenplayWeb.AuthManager.claims_access_level(claims)
   end
 end

--- a/lib/screenplay_web/plugs/metadata.ex
+++ b/lib/screenplay_web/plugs/metadata.ex
@@ -25,6 +25,8 @@ defmodule ScreenplayWeb.Plugs.Metadata do
         ""
       end
 
+    claims = Guardian.Plug.current_claims(conn)
+
     conn
     |> assign(:username, username)
     |> assign(:environment_name, Application.get_env(:screenplay, :environment_name, "dev"))
@@ -32,20 +34,7 @@ defmodule ScreenplayWeb.Plugs.Metadata do
     |> assign(:alerts_ui_url, Application.get_env(:screenplay, :alerts_ui_url))
     |> assign(:screens_url, Application.get_env(:screenplay, :screens_url))
     |> assign(:signs_ui_url, Application.get_env(:screenplay, :signs_ui_url))
-    |> assign(:is_emergency_admin, emergency_admin?(conn))
-    |> assign(:is_pa_message_admin, pa_message_admin?(conn))
+    |> assign(:roles, ScreenplayWeb.AuthManager.claims_access_level(claims))
     |> assign(:fullstory_org_id, Application.get_env(:screenplay, :fullstory_org_id))
-  end
-
-  defp emergency_admin?(conn) do
-    claims = Guardian.Plug.current_claims(conn)
-
-    :emergency_admin in ScreenplayWeb.AuthManager.claims_access_level(claims)
-  end
-
-  defp pa_message_admin?(conn) do
-    claims = Guardian.Plug.current_claims(conn)
-
-    :pa_message_admin in ScreenplayWeb.AuthManager.claims_access_level(claims)
   end
 end

--- a/lib/screenplay_web/plugs/metadata.ex
+++ b/lib/screenplay_web/plugs/metadata.ex
@@ -33,6 +33,7 @@ defmodule ScreenplayWeb.Plugs.Metadata do
     |> assign(:screens_url, Application.get_env(:screenplay, :screens_url))
     |> assign(:signs_ui_url, Application.get_env(:screenplay, :signs_ui_url))
     |> assign(:is_emergency_admin, emergency_admin?(conn))
+    |> assign(:is_pa_message_admin, pa_message_admin?(conn))
     |> assign(:fullstory_org_id, Application.get_env(:screenplay, :fullstory_org_id))
   end
 
@@ -40,5 +41,11 @@ defmodule ScreenplayWeb.Plugs.Metadata do
     claims = Guardian.Plug.current_claims(conn)
 
     :emergency_admin in ScreenplayWeb.AuthManager.claims_access_level(claims)
+  end
+
+  defp pa_message_admin?(conn) do
+    claims = Guardian.Plug.current_claims(conn)
+
+    :pa_message_admin in ScreenplayWeb.AuthManager.claims_access_level(claims)
   end
 end

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -35,6 +35,10 @@ defmodule ScreenplayWeb.Router do
     plug(ScreenplayWeb.EnsureScreenplayAdminGroup)
   end
 
+  pipeline :ensure_pa_message_admin do
+    plug(ScreenplayWeb.EnsurePaMessageAdmin)
+  end
+
   # Load balancer health check
   # Exempt from auth checks and SSL redirects
   scope "/", ScreenplayWeb do
@@ -61,6 +65,17 @@ defmodule ScreenplayWeb.Router do
     get("/dashboard", DashboardController, :index)
     get("/alerts/*id", AlertsController, :index)
     get("/unauthorized", UnauthorizedController, :index)
+  end
+
+  scope "/", ScreenplayWeb do
+    pipe_through([
+      :redirect_prod_http,
+      :browser,
+      :auth,
+      :ensure_auth,
+      :ensure_pa_message_admin,
+      :metadata
+    ])
   end
 
   scope "/api", ScreenplayWeb do

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -31,8 +31,8 @@ defmodule ScreenplayWeb.Router do
     plug(Guardian.Plug.EnsureAuthenticated)
   end
 
-  pipeline :ensure_screenplay_admin_group do
-    plug(ScreenplayWeb.EnsureScreenplayAdminGroup)
+  pipeline :ensure_screenplay_emergency_admin_group do
+    plug(ScreenplayWeb.EnsureScreenplayEmergencyAdminGroup)
   end
 
   pipeline :ensure_pa_message_admin do
@@ -51,7 +51,7 @@ defmodule ScreenplayWeb.Router do
       :browser,
       :auth,
       :ensure_auth,
-      :ensure_screenplay_admin_group,
+      :ensure_screenplay_emergency_admin_group,
       :metadata
     ])
 
@@ -99,7 +99,7 @@ defmodule ScreenplayWeb.Router do
       :browser,
       :auth,
       :ensure_auth,
-      :ensure_screenplay_admin_group
+      :ensure_screenplay_emergency_admin_group
     ])
 
     post("/create", AlertController, :create)

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -51,8 +51,8 @@ defmodule ScreenplayWeb.Router do
       :browser,
       :auth,
       :ensure_auth,
-      :ensure_screenplay_emergency_admin_group,
-      :metadata
+      :metadata,
+      :ensure_screenplay_emergency_admin_group
     ])
 
     get("/", PageController, :takeover_redirect)
@@ -73,8 +73,8 @@ defmodule ScreenplayWeb.Router do
       :browser,
       :auth,
       :ensure_auth,
-      :ensure_pa_message_admin,
-      :metadata
+      :metadata,
+      :ensure_pa_message_admin
     ])
   end
 
@@ -99,6 +99,7 @@ defmodule ScreenplayWeb.Router do
       :browser,
       :auth,
       :ensure_auth,
+      :metadata,
       :ensure_screenplay_emergency_admin_group
     ])
 

--- a/lib/screenplay_web/templates/layout/app.html.heex
+++ b/lib/screenplay_web/templates/layout/app.html.heex
@@ -23,6 +23,9 @@
     <%= if @is_emergency_admin do %>
         <meta name="is-emergency-admin" content={@is_emergency_admin}>
     <% end %>
+    <%= if @is_pa_message_admin do %>
+        <meta name="is-pa-message-admin" content={@is_pa_message_admin}>
+    <% end %>
     <%= if @fullstory_org_id do %>
         <meta name="fullstory-org-id" content={@fullstory_org_id}>
     <% end %>

--- a/lib/screenplay_web/templates/layout/app.html.heex
+++ b/lib/screenplay_web/templates/layout/app.html.heex
@@ -20,8 +20,8 @@
     <%= if @alerts_ui_url do %>
         <meta name="alerts-ui-url" content={@alerts_ui_url}>
     <% end %>
-    <%= if @is_admin do %>
-        <meta name="is-admin" content={@is_admin}>
+    <%= if @is_emergency_admin do %>
+        <meta name="is-emergency-admin" content={@is_emergency_admin}>
     <% end %>
     <%= if @fullstory_org_id do %>
         <meta name="fullstory-org-id" content={@fullstory_org_id}>

--- a/lib/screenplay_web/templates/layout/app.html.heex
+++ b/lib/screenplay_web/templates/layout/app.html.heex
@@ -20,11 +20,11 @@
     <%= if @alerts_ui_url do %>
         <meta name="alerts-ui-url" content={@alerts_ui_url}>
     <% end %>
-    <%= if @is_emergency_admin do %>
-        <meta name="is-emergency-admin" content={@is_emergency_admin}>
+    <%= if :emergency_admin in @roles do %>
+        <meta name="is-emergency-admin" content={true}>
     <% end %>
-    <%= if @is_pa_message_admin do %>
-        <meta name="is-pa-message-admin" content={@is_pa_message_admin}>
+    <%= if :pa_message_admin in @roles do %>
+        <meta name="is-pa-message-admin" content={true}>
     <% end %>
     <%= if @fullstory_org_id do %>
         <meta name="fullstory-org-id" content={@fullstory_org_id}>

--- a/test/screenplay_web/controllers/alerts_controller_test.exs
+++ b/test/screenplay_web/controllers/alerts_controller_test.exs
@@ -2,7 +2,7 @@ defmodule ScreenplayWeb.Controllers.AlertsControllerTest do
   use ScreenplayWeb.ConnCase
 
   describe "index/2" do
-    @tag :authenticated_admin
+    @tag :authenticated_emergency_admin
     test "responds 200 to authenticated admin requests", %{conn: conn} do
       conn = get(conn, "/alerts")
       assert %{status: 200} = conn

--- a/test/screenplay_web/controllers/dashboard_api_controller_test.exs
+++ b/test/screenplay_web/controllers/dashboard_api_controller_test.exs
@@ -2,7 +2,7 @@ defmodule ScreenplayWeb.Controllers.DashboardApiControllerTest do
   use ScreenplayWeb.ConnCase
 
   describe "index/2" do
-    @tag :authenticated_admin
+    @tag :authenticated_emergency_admin
     test "responds 200 to authenticated admin requests", %{conn: conn} do
       conn = get(conn, "/dashboard")
       assert %{status: 200} = conn

--- a/test/screenplay_web/controllers/dashboard_controller_test.exs
+++ b/test/screenplay_web/controllers/dashboard_controller_test.exs
@@ -2,7 +2,7 @@ defmodule ScreenplayWeb.Controllers.DashboardControllerTest do
   use ScreenplayWeb.ConnCase
 
   describe "index/2" do
-    @tag :authenticated_admin
+    @tag :authenticated_emergency_admin
     test "responds 200 to authenticated admin requests", %{conn: conn} do
       conn = get(conn, "/dashboard")
       assert %{status: 200} = conn

--- a/test/screenplay_web/controllers/outfront_takeover_tool/page_controller_test.exs
+++ b/test/screenplay_web/controllers/outfront_takeover_tool/page_controller_test.exs
@@ -2,7 +2,7 @@ defmodule ScreenplayWeb.OutfrontTakeoverTool.PageControllerTest do
   use ScreenplayWeb.ConnCase
 
   describe "index/2" do
-    @tag :authenticated_admin
+    @tag :authenticated_emergency_admin
     test "responds 200 to authenticated admin requests", %{conn: conn} do
       conn = get(conn, "/emergency-takeover")
       assert %{status: 200} = conn
@@ -21,7 +21,7 @@ defmodule ScreenplayWeb.OutfrontTakeoverTool.PageControllerTest do
   end
 
   describe "takeover_redirect/2" do
-    @tag :authenticated_admin
+    @tag :authenticated_emergency_admin
     test "redirects admin to /emergency-takeover", %{conn: conn} do
       conn = get(conn, "/")
       assert redirected_to(conn) =~ "/emergency-takeover"

--- a/test/screenplay_web/ensure_pa_message_admin_test.exs
+++ b/test/screenplay_web/ensure_pa_message_admin_test.exs
@@ -1,0 +1,23 @@
+defmodule ScreenplayWeb.EnsurePaMessageAdminTest do
+  use ScreenplayWeb.ConnCase
+
+  describe "init/1" do
+    test "passes options through unchanged" do
+      assert ScreenplayWeb.EnsurePaMessageAdmin.init([]) == []
+    end
+  end
+
+  describe "call/2" do
+    @tag :authenticated_pa_message_admin
+    test "does nothing when user is a PA message admin", %{conn: conn} do
+      assert conn == ScreenplayWeb.EnsurePaMessageAdmin.call(conn, [])
+    end
+
+    @tag :authenticated
+    test "redirects to Dashboard when user is not a PA message admin", %{conn: conn} do
+      conn = ScreenplayWeb.EnsurePaMessageAdmin.call(conn, [])
+
+      assert redirected_to(conn) =~ "/dashboard"
+    end
+  end
+end

--- a/test/screenplay_web/ensure_screenplay_emergency_admin_group_test.exs
+++ b/test/screenplay_web/ensure_screenplay_emergency_admin_group_test.exs
@@ -1,21 +1,21 @@
-defmodule ScreenplayWeb.EnsureScreenplayAdminGroupTest do
+defmodule ScreenplayWeb.EnsureScreenplayEmergencyAdminGroupTest do
   use ScreenplayWeb.ConnCase
 
   describe "init/1" do
     test "passes options through unchanged" do
-      assert ScreenplayWeb.EnsureScreenplayAdminGroup.init([]) == []
+      assert ScreenplayWeb.EnsureScreenplayEmergencyAdminGroup.init([]) == []
     end
   end
 
   describe "call/2" do
-    @tag :authenticated_admin
+    @tag :authenticated_emergency_admin
     test "does nothing when user is in the outfront admin group", %{conn: conn} do
-      assert conn == ScreenplayWeb.EnsureScreenplayAdminGroup.call(conn, [])
+      assert conn == ScreenplayWeb.EnsureScreenplayEmergencyAdminGroup.call(conn, [])
     end
 
     @tag :authenticated
     test "redirects when user is not in the outfront admin group", %{conn: conn} do
-      conn = ScreenplayWeb.EnsureScreenplayAdminGroup.call(conn, [])
+      conn = ScreenplayWeb.EnsureScreenplayEmergencyAdminGroup.call(conn, [])
 
       response = html_response(conn, 302)
       assert response =~ "/unauthorized"

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -61,6 +61,20 @@ defmodule ScreenplayWeb.ConnCase do
 
           {conn, user}
 
+        tags[:authenticated_pa_message_admin] ->
+          user = "test_user"
+
+          conn =
+            Phoenix.ConnTest.build_conn()
+            |> Plug.Test.init_test_session(%{})
+            |> Guardian.Plug.sign_in(ScreenplayWeb.AuthManager, user, %{
+              "roles" => ["pa-message-admin"]
+            })
+            |> Plug.Conn.put_session(:username, user)
+            |> assign(:roles, [:pa_message_admin])
+
+          {conn, user}
+
         true ->
           {Phoenix.ConnTest.build_conn(), nil}
       end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -34,7 +34,7 @@ defmodule ScreenplayWeb.ConnCase do
   setup tags do
     {conn, user} =
       cond do
-        tags[:authenticated_admin] ->
+        tags[:authenticated_emergency_admin] ->
           user = "test_user"
 
           conn =

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -13,7 +13,6 @@ defmodule ScreenplayWeb.ConnCase do
   this option is not recommended for other databases.
   """
 
-  import Plug.Conn
   use ExUnit.CaseTemplate
 
   using do
@@ -45,7 +44,7 @@ defmodule ScreenplayWeb.ConnCase do
               "roles" => ["screenplay-emergency-admin"]
             })
             |> Plug.Conn.put_session(:username, user)
-            |> assign(:roles, [:emergency_admin])
+            |> Plug.run([{ScreenplayWeb.Plugs.Metadata, []}])
 
           {conn, user}
 
@@ -57,7 +56,7 @@ defmodule ScreenplayWeb.ConnCase do
             |> Plug.Test.init_test_session(%{})
             |> Guardian.Plug.sign_in(ScreenplayWeb.AuthManager, user, %{roles: []})
             |> Plug.Conn.put_session(:username, user)
-            |> assign(:roles, [])
+            |> Plug.run([{ScreenplayWeb.Plugs.Metadata, []}])
 
           {conn, user}
 
@@ -71,7 +70,7 @@ defmodule ScreenplayWeb.ConnCase do
               "roles" => ["pa-message-admin"]
             })
             |> Plug.Conn.put_session(:username, user)
-            |> assign(:roles, [:pa_message_admin])
+            |> Plug.run([{ScreenplayWeb.Plugs.Metadata, []}])
 
           {conn, user}
 

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -13,6 +13,7 @@ defmodule ScreenplayWeb.ConnCase do
   this option is not recommended for other databases.
   """
 
+  import Plug.Conn
   use ExUnit.CaseTemplate
 
   using do
@@ -44,6 +45,7 @@ defmodule ScreenplayWeb.ConnCase do
               "roles" => ["screenplay-emergency-admin"]
             })
             |> Plug.Conn.put_session(:username, user)
+            |> assign(:roles, [:emergency_admin])
 
           {conn, user}
 
@@ -55,6 +57,7 @@ defmodule ScreenplayWeb.ConnCase do
             |> Plug.Test.init_test_session(%{})
             |> Guardian.Plug.sign_in(ScreenplayWeb.AuthManager, user, %{roles: []})
             |> Plug.Conn.put_session(:username, user)
+            |> assign(:roles, [])
 
           {conn, user}
 


### PR DESCRIPTION
**Asana task**: [Permission needs for Screenplay](https://app.asana.com/0/1185117109217413/1206790423002398/f)

In the new PA Messaging integration, only users with the `pa-message-admin` can access the tool. This PR adds all of the necessary auth needed to check permissions when implementation for the feature starts. 