### PR TITLE
fix: User Session TTL

### DIFF
--- a/lib/screenplay_web.ex
+++ b/lib/screenplay_web.ex
@@ -62,6 +62,13 @@ defmodule ScreenplayWeb do
     end
   end
 
+  def plug do
+    quote do
+      import Plug.Conn
+      unquote(verified_routes())
+    end
+  end
+
   defp view_helpers do
     quote do
       # Use all HTML functionality (forms, tags, etc)

--- a/lib/screenplay_web/auth_manager/error_handler.ex
+++ b/lib/screenplay_web/auth_manager/error_handler.ex
@@ -3,12 +3,12 @@ defmodule ScreenplayWeb.AuthManager.ErrorHandler do
   Custom Guardian error handler.
   """
 
-  @behaviour Guardian.Plug.ErrorHandler
+  use ScreenplayWeb, :plug
 
-  alias ScreenplayWeb.Router.Helpers
+  @behaviour Guardian.Plug.ErrorHandler
 
   @impl Guardian.Plug.ErrorHandler
   def auth_error(conn, {_type, _reason}, _opts) do
-    Phoenix.Controller.redirect(conn, to: Helpers.auth_path(conn, :request, "keycloak"))
+    Phoenix.Controller.redirect(conn, to: ~p"/auth/keycloak")
   end
 end

--- a/lib/screenplay_web/auth_manager/pipeline.ex
+++ b/lib/screenplay_web/auth_manager/pipeline.ex
@@ -14,6 +14,10 @@ defmodule ScreenplayWeb.AuthManager.Pipeline do
   # A plug to save the current path before the auth process loses it through several
   # redirects. We use this path in auth_controller to send us back to the original url
   def save_previous_path(conn, _opts) do
-    Plug.Conn.put_session(conn, :previous_path, conn.request_path)
+    if String.contains?(conn.request_path, "/api/") do
+      conn
+    else
+      Plug.Conn.put_session(conn, :previous_path, conn.request_path)
+    end
   end
 end

--- a/lib/screenplay_web/controllers/auth_controller.ex
+++ b/lib/screenplay_web/controllers/auth_controller.ex
@@ -6,8 +6,7 @@ defmodule ScreenplayWeb.AuthController do
   def callback(conn = %{assigns: %{ueberauth_auth: auth}}, _params) do
     username = auth.uid
     name = auth.info.name
-    expiration = auth.credentials.expires_at
-    current_time = System.system_time(:second)
+    session_ttl_hours = 24 * 30
 
     keycloak_client_id =
       get_in(Application.get_env(:ueberauth_oidcc, :providers), [:keycloak, :client_id])
@@ -23,7 +22,7 @@ defmodule ScreenplayWeb.AuthController do
       ScreenplayWeb.AuthManager,
       username,
       %{roles: roles},
-      ttl: {expiration - current_time, :seconds}
+      ttl: {session_ttl_hours, :hours}
     )
     |> Plug.Conn.put_session(:username, name || username)
     # Redirect to whatever page they came from


### PR DESCRIPTION
**Asana task**: ad-hoc

Was finally able to discover the cause of some [Sentry errors](https://mbtace.sentry.io/issues/5102241771/events/a8c2509681314021885c47f6181fef43/) with terribly unhelpful stack traces. Basically, our session TTL was only 5 minutes. Because we have an auth enforced endpoint that is requested every 4 seconds, this throws a ton of errors if the tab is left open. Users should be able to leave the app open without worrying about this every 5 minutes. Bumped it up to 30 days (same as Glides) to help with this. 

In the future, we will consider storing refresh tokens in the DB and refreshing sessions before they expire. 