### PR TITLE
feat: Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: mix
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "10:00"
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-patch"]
+  - package-ecosystem: npm
+    directory: "/assets"
+    schedule:
+      interval: daily
+      time: "10:00"
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,7 @@ updates:
     open-pull-requests-limit: 5
     ignore:
       - dependency-name: "*"
-        update-types:
-          ["version-update:semver-minor", "version-update:semver-patch"]
+        update-types: ["version-update:semver-minor"]
   - package-ecosystem: npm
     directory: "/assets"
     schedule:
@@ -18,5 +17,4 @@ updates:
     open-pull-requests-limit: 5
     ignore:
       - dependency-name: "*"
-        update-types:
-          ["version-update:semver-minor", "version-update:semver-patch"]
+        update-types: ["version-update:semver-minor"]


### PR DESCRIPTION
**Asana task**: ad-hoc

I noticed a package warning while compiling locally and then realized dependabot is not even set up here. Adding it so we can be more aware of big updates. The PR limit I picked was arbitrary so open to changing it. I also chose to ignore minor updates. This should prevent us from getting overwhelmed by these PRs. 
