### PR TITLE
ignore asana workflows on dependabot branches

### DIFF
--- a/.github/workflows/asana-merged.yml
+++ b/.github/workflows/asana-merged.yml
@@ -2,6 +2,7 @@ name: Move Asana ticket after merge
 on: 
   pull_request:
     types: [closed]
+    branches-ignore: ['dependabot/*']
 
 jobs:
   move-asana-ticket-job:

--- a/.github/workflows/asana-pr-opened.yml
+++ b/.github/workflows/asana-pr-opened.yml
@@ -2,6 +2,7 @@ name: Move Asana ticket after PR opened
 on: 
   pull_request:
     types: [opened, reopened]
+    branches-ignore: ["dependabot/*"]
 
 jobs:
   move-asana-ticket-job:


### PR DESCRIPTION
This turns off the asana integration for dependabot PRs, since they don't run with the necessary permissions.