### PR TITLE
fix: Ignore local dependencies in dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,5 +16,7 @@ updates:
       time: "10:00"
     open-pull-requests-limit: 5
     ignore:
+      - dependency-name: "phoenix"
+      - dependency-name: "phoenix_html"
       - dependency-name: "*"
         update-types: ["version-update:semver-minor"]


### PR DESCRIPTION
**Asana task**: ad-hoc

Dependabot isn't successfully retrieving updates because it doesn't know where to look for Phoenix upgrades. These are local dependencies anyway so can just ignore them.
