### PR TITLE
fix: Allow screen IDs to have any format

### DIFF
--- a/assets/js/components/Dashboard/PermanentConfiguration/Workflows/GlEink/GlEinkWorkflow.tsx
+++ b/assets/js/components/Dashboard/PermanentConfiguration/Workflows/GlEink/GlEinkWorkflow.tsx
@@ -137,16 +137,9 @@ const GlEinkWorkflow: ComponentType = () => {
     const fieldsWithErrors = new Set<string>();
     for (const [place_id, screens] of Object.entries(placesAndScreens)) {
       const fieldsByScreen = screens["new_pending_screens"]?.map((screen) => {
-        const presentFields = [];
-
-        // Validate that screen id is in correct format
-        if (screen.new_id?.match(/^EIG-\d+$/)) {
-          presentFields.push("screen_id");
-        }
-
         // Get what fields are present in the config for this screen
         return [
-          ...presentFields,
+          "screen_id",
           ...Object.keys(screen["app_params"]),
           ...Object.keys(screen["app_params"].header),
         ];


### PR DESCRIPTION
**Asana task**: Permanent Config GL E-Ink QA (Too-strict screen ID validations)

The validation code enforced a particular format on the GL e-ink screen IDs, but we don't need that.

---

Notes for posterity:
- The other validation issue found during eng QA, where duplicate screen IDs were not always caught, was actually just one more symptom of the auth issue that Christian fixed in #277.
- I originally went down a rabbit hole trying to fix a large number of issues with state value mutation on the client, but ended up dropping that work in favor of a more surgical fix. In case we do end up finding problems caused by the mutations in the future, I've pushed my WIP, semi-broken code to the [jz/fix-pending-screen-validation](https://github.com/mbta/screenplay/compare/permanent-configuration...jz/fix-pending-screen-validation) as a possible reference or starting point for a more complete fix.