### PR TITLE
QA: Autofocus search bar.

### DIFF
--- a/assets/js/components/Dashboard/PermanentConfiguration/PlacesSearchBar.tsx
+++ b/assets/js/components/Dashboard/PermanentConfiguration/PlacesSearchBar.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-autofocus */
 import React, { ComponentType, useState } from "react";
 import { ReactSearchAutocomplete } from "react-search-autocomplete";
 
@@ -35,6 +36,7 @@ const PlacesSearchBar: ComponentType<PlacesSearchBarProps> = ({
 
   return (
     <ReactSearchAutocomplete
+      autoFocus
       key={reset}
       formatResult={formatResult}
       fuseOptions={{


### PR DESCRIPTION
[Notion](https://www.notion.so/mbta-downtown-crossing/Select-Stations-Search-bar-loses-focus-after-selection-via-search-bar-d9465c320e2d403390a8735f9b7a4b83?pvs=4)

Adds `autofocus` to the search bar.
