### PR TITLE
cleanup: Make test filename consistent

### DIFF
--- a/test/screenplay/config/permanent_config_test.exs
+++ b/test/screenplay/config/permanent_config_test.exs
@@ -1,4 +1,4 @@
-defmodule Screenplay.Config.ConfigTest do
+defmodule Screenplay.Config.PermanentConfigTest do
   use ExUnit.Case
 
   import Mox


### PR DESCRIPTION
**Asana task**: ad-hoc

I noticed that the test module was not named after the module being tested. Just a name change for consistency.
