### PR TITLE
chore: support Busway v2 screens

### DIFF
--- a/assets/css/screen-detail.scss
+++ b/assets/css/screen-detail.scss
@@ -1,4 +1,4 @@
-.screen-detail__solari-layout {
+.screen-detail__inline-layout {
   display: flex;
   justify-content: space-between;
 }
@@ -8,7 +8,7 @@
   border-radius: 8px;
   padding: 16px;
 
-  &--solari {
+  &--inline {
     flex-grow: 1;
 
     &:not(:last-child) {

--- a/assets/css/screen-simulation.scss
+++ b/assets/css/screen-simulation.scss
@@ -44,6 +44,7 @@
     // so height adjusted to fit
     width: 100%;
 
+    &--busway_v2,
     &--bus_shelter_v2 {
       height: 379px;
     }

--- a/assets/js/components/Dashboard/PlaceRow.tsx
+++ b/assets/js/components/Dashboard/PlaceRow.tsx
@@ -102,6 +102,7 @@ const PlaceRow = ({
     bus_eink: "Bus E-Ink",
     bus_eink_v2: "Bus E-Ink",
     solari: "Solari",
+    busway_v2: "Solari",
     triptych_v2: "Triptych",
   };
 
@@ -109,6 +110,8 @@ const PlaceRow = ({
     const screenTypeOrder = [
       "dup",
       "dup_v2",
+      "busway_v2",
+      "solari",
       "bus_shelter_v2",
       "bus_eink",
       "bus_eink_v2",
@@ -117,7 +120,6 @@ const PlaceRow = ({
       "gl_eink_v2",
       "pre_fare_v2",
       "triptych_v2",
-      "solari",
       "pa_ess",
     ];
 

--- a/assets/js/components/Dashboard/PlaceRowAccordion.tsx
+++ b/assets/js/components/Dashboard/PlaceRowAccordion.tsx
@@ -51,17 +51,19 @@ const PlaceRowAccordion: ComponentType<PlaceRowAccordionProps> = ({
 
   const filterAndGroupScreens = (screens: Screen[]) => {
     const visibleScreens = screens.filter((screen) => !screen.hidden);
-    const solariScreens = visibleScreens.filter(
-      (screen) => screen.type === "solari",
+    const inlineScreens = visibleScreens.filter((screen) =>
+      ["busway_v2", "solari"].includes(screen.type),
     );
     const paEssScreens = visibleScreens.filter(
       (screen) => screen.type === "pa_ess",
     );
     const groupedScreens = visibleScreens
-      .filter((screen) => screen.type !== "solari" && screen.type !== "pa_ess")
+      .filter(
+        (screen) => !["busway_v2", "pa_ess", "solari"].includes(screen.type),
+      )
       .map((screen) => [screen]);
 
-    groupedScreens.push(solariScreens);
+    groupedScreens.push(inlineScreens);
 
     if (paEssScreens.length > 0) {
       groupPaEssScreensbyRoute(paEssScreens, groupedScreens);

--- a/assets/js/components/Dashboard/ScreenDetail.tsx
+++ b/assets/js/components/Dashboard/ScreenDetail.tsx
@@ -14,11 +14,13 @@ interface ScreenDetailProps {
 }
 
 const ScreenDetail = (props: ScreenDetailProps): JSX.Element => {
-  const isSolari = props.screens.every((screen) => screen.type === "solari");
+  const isInlineGroup = props.screens.every((screen) =>
+    ["busway_v2", "solari"].includes(screen.type),
+  );
   const isMultipleScreens = props.screens.length > 1;
 
-  return isSolari ? (
-    <div className="screen-detail__solari-layout">
+  return isInlineGroup ? (
+    <div className="screen-detail__inline-layout">
       {props.screens.map((screens, index) => (
         <ScreenCard
           {...props}
@@ -36,7 +38,9 @@ const ScreenDetail = (props: ScreenDetailProps): JSX.Element => {
 const ScreenCard = (props: ScreenDetailProps) => {
   const { screens, eventKey, isMultipleScreens } = props;
   const isPaess = screens.every((screen) => screen.type === "pa_ess");
-  const isSolari = screens.every((screen) => screen.type === "solari");
+  const isInline = screens.every((screen) =>
+    ["busway_v2", "solari"].includes(screen.type),
+  );
   const isTriptych = screens.every((screen) => screen.type === "triptych_v2");
   const paessRouteLetter = screens[0].station_code
     ? screens[0].station_code.charAt(0).toLowerCase()
@@ -94,7 +98,7 @@ const ScreenCard = (props: ScreenDetailProps) => {
       className={classNames("screen-detail__container", {
         [`screen-detail__container--paess screen-detail__container--paess-${paessRouteLetter}`]:
           isPaess,
-        [`screen-detail__container--solari`]: isSolari,
+        [`screen-detail__container--inline`]: isInline,
       })}
       onClick={(e: SyntheticEvent) => e.stopPropagation()}
     >

--- a/assets/js/components/Dashboard/ScreenDetail.tsx
+++ b/assets/js/components/Dashboard/ScreenDetail.tsx
@@ -10,22 +10,20 @@ import { AccordionContext } from "react-bootstrap";
 interface ScreenDetailProps {
   screens: Screen[];
   eventKey: string;
+  isInlineGroup?: boolean;
   isMultipleScreens?: boolean;
 }
 
 const ScreenDetail = (props: ScreenDetailProps): JSX.Element => {
-  const isInlineGroup = props.screens.every((screen) =>
-    ["busway_v2", "solari"].includes(screen.type),
-  );
   const isMultipleScreens = props.screens.length > 1;
 
-  return isInlineGroup ? (
+  return props.isInlineGroup ? (
     <div className="screen-detail__inline-layout">
-      {props.screens.map((screens, index) => (
+      {props.screens.map((screen, index) => (
         <ScreenCard
           {...props}
           key={index}
-          screens={[screens]}
+          screens={[screen]}
           isMultipleScreens={isMultipleScreens}
         />
       ))}
@@ -38,9 +36,6 @@ const ScreenDetail = (props: ScreenDetailProps): JSX.Element => {
 const ScreenCard = (props: ScreenDetailProps) => {
   const { screens, eventKey, isMultipleScreens } = props;
   const isPaess = screens.every((screen) => screen.type === "pa_ess");
-  const isInline = screens.every((screen) =>
-    ["busway_v2", "solari"].includes(screen.type),
-  );
   const isTriptych = screens.every((screen) => screen.type === "triptych_v2");
   const paessRouteLetter = screens[0].station_code
     ? screens[0].station_code.charAt(0).toLowerCase()
@@ -98,7 +93,7 @@ const ScreenCard = (props: ScreenDetailProps) => {
       className={classNames("screen-detail__container", {
         [`screen-detail__container--paess screen-detail__container--paess-${paessRouteLetter}`]:
           isPaess,
-        [`screen-detail__container--inline`]: isInline,
+        [`screen-detail__container--inline`]: props.isInlineGroup,
       })}
       onClick={(e: SyntheticEvent) => e.stopPropagation()}
     >

--- a/assets/js/constants/constants.ts
+++ b/assets/js/constants/constants.ts
@@ -53,8 +53,8 @@ export const SCREEN_TYPES: { label: string; ids: string[] }[] = [
   { label: "Elevator", ids: ["elevator"] },
   { label: "PA ESS", ids: ["pa_ess"] },
   { label: "Pre Fare Duo", ids: ["pre_fare_v2"] },
+  { label: "Solari", ids: ["busway_v2", "solari"] },
   { label: "Triptych", ids: ["triptych_v2"] },
-  { label: "Solari", ids: ["solari"] },
 ];
 
 export const STATUSES = [

--- a/assets/js/util.ts
+++ b/assets/js/util.ts
@@ -178,23 +178,23 @@ export const placesWithSelectedAlert = (
     : [];
 };
 
-export const sortScreens = (screenList: Screen[]) => {
-  const screenTypeOrder = [
-    "dup",
-    "dup_v2",
-    "busway_v2",
-    "solari",
-    "bus_shelter_v2",
-    "bus_eink",
-    "bus_eink_v2",
-    "gl_eink_single",
-    "gl_eink_double",
-    "gl_eink_v2",
-    "pre_fare_v2",
-    "triptych_v2",
-    "pa_ess",
-  ];
+const screenTypeOrder = [
+  "dup",
+  "dup_v2",
+  "busway_v2",
+  "solari",
+  "bus_shelter_v2",
+  "bus_eink",
+  "bus_eink_v2",
+  "gl_eink_single",
+  "gl_eink_double",
+  "gl_eink_v2",
+  "pre_fare_v2",
+  "triptych_v2",
+  "pa_ess",
+];
 
+export const sortScreens = (screenList: Screen[]) => {
   return screenList.sort((a, b) =>
     screenTypeOrder.indexOf(a.type) >= screenTypeOrder.indexOf(b.type) ? 1 : -1,
   );

--- a/assets/js/util.ts
+++ b/assets/js/util.ts
@@ -182,6 +182,8 @@ export const sortScreens = (screenList: Screen[]) => {
   const screenTypeOrder = [
     "dup",
     "dup_v2",
+    "busway_v2",
+    "solari",
     "bus_shelter_v2",
     "bus_eink",
     "bus_eink_v2",
@@ -190,7 +192,6 @@ export const sortScreens = (screenList: Screen[]) => {
     "gl_eink_v2",
     "pre_fare_v2",
     "triptych_v2",
-    "solari",
     "pa_ess",
   ];
 

--- a/scripts/build_places.exs
+++ b/scripts/build_places.exs
@@ -193,6 +193,23 @@ formatted_screens =
 
     {id,
      %{
+       "app_id" => "busway_v2",
+       "app_params" => %{
+         "departures" => %{"sections" => sections}
+       }
+     } = screen} ->
+      stops =
+        Enum.flat_map(sections, fn %{"query" => %{"params" => %{"stop_ids" => stop_ids}}} ->
+          stop_ids
+        end)
+        |> Enum.map(fn stop_id ->
+          {id, Map.put(screen, "stop", stop_id)}
+        end)
+
+      stops
+
+    {id,
+     %{
        "app_id" => "solari",
        "app_params" => %{
          "sections" => sections
@@ -258,6 +275,13 @@ live_screens =
       {_id,
        %{
          "app_id" => "solari",
+         "stop" => stop_id
+       }} ->
+        stop_id
+
+      {_id,
+       %{
+         "app_id" => "busway_v2",
          "stop" => stop_id
        }} ->
         stop_id

--- a/scripts/build_places.exs
+++ b/scripts/build_places.exs
@@ -1,14 +1,32 @@
-# Script to gather screenplay places and screens.
-#
-# Example usage: API_V3_KEY=<your_key_here> mix run scripts/fetch_places_and_screens.exs --environment prod
+# Script to populate `places_and_screens.json`.
 
 {opts, _, _} =
   System.argv()
-  |> OptionParser.parse(strict: [environment: :string])
+  |> OptionParser.parse(strict: [env: :string, path: :string])
 
-environment = Keyword.get(opts, :environment, "dev")
+environment = Keyword.get(opts, :env)
+local_path = Keyword.get(opts, :path)
 
-api_v3_key = System.get_env("API_V3_KEY")
+if is_nil(environment) and is_nil(local_path) do
+  IO.puts(:stderr, """
+  Usage: mix run scripts/build_places.exs [options]
+
+  Requires a valid `API_V3_KEY` in environment variables.
+
+  Options:
+
+    --env <ENV>
+    Load screen configuration from S3 using the specified Screens environment.
+    Requires ExAWS to have valid credentials, e.g. from `AWS_` environment variables.
+
+    --path <PATH>
+    Load screen configuration from a local file.
+  """)
+
+  exit({:shutdown, 1})
+end
+
+api_v3_key = System.fetch_env!("API_V3_KEY")
 headers = [{"x-api-key", api_v3_key}]
 
 string_is_number? = fn string ->
@@ -80,13 +98,20 @@ add_routes_to_stops = fn
 end
 
 # Get live config from S3
-{:ok, file} = get_config.("mbta-ctd-config", "screens/screens-#{environment}.json")
-parsed = Jason.decode!(file)
+config =
+  if environment do
+    {:ok, body} = get_config.("mbta-ctd-config", "screens/screens-#{environment}.json")
+    body
+  else
+    File.read!(local_path)
+  end
+
+parsed = Jason.decode!(config)
 
 formatted_screens =
   parsed["screens"]
-  # Certain screens (test screens, ones we've configured for non-MBTA locations) are intentionally not included in Screenplay,
-  # and marked as such with the `hidden_from_screenplay` boolean field.
+  # Certain screens (test screens, ones we've configured for non-MBTA locations) are intentionally
+  # not included in Screenplay, and marked as such with the `hidden_from_screenplay` boolean.
   |> Enum.reject(&match?({_id, %{"hidden_from_screenplay" => true}}, &1))
   # This flat_map allows us to split out a single config into multiple places.
   |> Enum.flat_map(fn


### PR DESCRIPTION
~~There is some existing duplicative logic here around screen types and how certain ones may be displayed differently on the frontend, which I haven't yet attempted to clean up, but I did rename some things to hopefully make the intent clearer.~~

When a config migrated using https://github.com/mbta/screens/pull/2030 is loaded into the updated places-and-screens script, and Screenplay is pointing to an instance of Screens that has the changes in https://github.com/mbta/screens/pull/2039, this branch creates the following result:

<img width="1719" alt="Screenshot 2024-04-30 at 5 46 01 PM" src="https://github.com/mbta/screenplay/assets/394835/0d67a37d-6828-493d-bc74-a4eb384d5233">

Reasons this still looks a bit weird:

* Both the old `solari` and new `busway_v2` screens are displayed at once. In production I don't think this will ever be the case, as one of the two will always be `hidden_from_screenplay`, and there will be a "cutover" at some point. But I'd like to check this assumption before merging.

* The section resizing code on the Screens frontend doesn't actually know how to handle multiple sections yet (nor headers, "Later Departures", etc.), so we only get the first section on the v2 screen.

* The "location name" from `screen_locations.json` for this screen (and others) was set to "Busway". When the name for this category of screen was "Solari", this made sense and resulted in the header being **Solari / Busway**. ~~But now that the category name itself is "Busway", there is some redundancy. We might want to update this file in deployed environments to account for the rename.~~ We'll continue to use "Solari" for now and rename it once the larger naming discussion has happened.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206730847640133