### PR TITLE
fix slack reminder errors when running locally

### DIFF
--- a/lib/screenplay/outfront_takeover_tool/alerts/reminders.ex
+++ b/lib/screenplay/outfront_takeover_tool/alerts/reminders.ex
@@ -17,14 +17,11 @@ defmodule Screenplay.OutfrontTakeoverTool.Alerts.Reminders do
   end
 
   def handle_info(:work, state) do
-    url = Application.get_env(:screenplay, :slack_webhook_url, "")
-
     schedule_work()
 
-    if url == "" do
-      Logger.info("No Slack Webhook URL found")
-    else
-      send_slack_messages_for_outdated_alerts(url)
+    case Application.get_env(:screenplay, :slack_webhook_url) do
+      v when v in [nil, ""] -> Logger.info("No Slack Webhook URL found")
+      url -> send_slack_messages_for_outdated_alerts(url)
     end
 
     {:noreply, state}


### PR DESCRIPTION
This fixes the slack reminder logic to correctly suppress reminders when running locally with no `SLACK_WEBHOOK_URL` environment variable set. Note that the default value in `Application.get_env` was not doing anything, since there's always a value present from `config/runtime.exs`, even if it's `nil`.