### PR TITLE
feat: PA Message endpoint

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -25,4 +25,4 @@ export SIGNS_UI_URL="https://signs.mbta.com"
 export DATABASE_HOSTNAME="localhost"
 
 # Access key for allowing PA Message API calls. Required for endpoints in the /api/pa_messages scope. Generate a unique random string for local use.
-# export SCREENPLAY_API_KEY=
+export SCREENPLAY_API_KEY="local_api_key"

--- a/.envrc.template
+++ b/.envrc.template
@@ -22,7 +22,7 @@ export SIGNS_UI_URL="https://signs.mbta.com"
 ## * Your local Postgres server should go here
 # export DATABASE_USER=
 # export DATABASE_PASSWORD=
-# export DATABASE_HOSTNAME=
+export DATABASE_HOSTNAME="localhost"
 
 # Access key for allowing PA Message API calls. Required for endpoints in the /api/pa_messages scope. Generate a unique random string for local use.
 # export SCREENPLAY_API_KEY=

--- a/.envrc.template
+++ b/.envrc.template
@@ -23,3 +23,6 @@ export SIGNS_UI_URL="https://signs.mbta.com"
 # export DATABASE_USER=
 # export DATABASE_PASSWORD=
 # export DATABASE_HOSTNAME=
+
+# Access key for allowing PA Message API calls. Required for endpoints in the /api/pa_messages scope. Generate a unique random string for local use.
+# export SCREENPLAY_API_KEY=

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Screenplay requires Postgres. If you don't already have Postgres installed, and 
 1. Install [`direnv`](https://direnv.net/)
 1. `cp .envrc.template .envrc`
 1. Fill in `API_V3_KEY` with a [V3 API key](https://api-v3.mbta.com/)
+1. Fill in `DATABASE_USER` and `DATABASE_PASSWORD` with the username and password of a DB user configured in your local psql server
 1. `direnv allow`
+1. `mix ecto.create` to stand up DB used by PA Messaging features
 
 Note the various `_URL` values in `.envrc`, which default to the production
 environments of the relevant apps — change these to e.g. point Screenplay to

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -50,7 +50,8 @@ config :screenplay,
   screens_url: System.get_env("SCREENS_URL"),
   signs_ui_url: System.get_env("SIGNS_UI_URL"),
   alerts_ui_url: System.get_env("ALERTS_UI_URL"),
-  fullstory_org_id: System.get_env("FULLSTORY_ORG_ID")
+  fullstory_org_id: System.get_env("FULLSTORY_ORG_ID"),
+  api_key: System.get_env("SCREENPLAY_API_KEY")
 
 if sentry_dsn not in [nil, ""] do
   config :sentry,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -35,6 +35,9 @@ end
 
 sentry_dsn = System.get_env("SENTRY_DSN")
 
+api_key = System.get_env("SCREENPLAY_API_KEY")
+if api_key in [nil, ""], do: raise("SCREENPLAY_API_KEY key not set")
+
 config :screenplay,
   alerts_s3_path: "screenplay/" <> System.get_env("ALERTS_S3_FILENAME", ""),
   sftp_client_module: sftp_client_module,
@@ -51,7 +54,7 @@ config :screenplay,
   signs_ui_url: System.get_env("SIGNS_UI_URL"),
   alerts_ui_url: System.get_env("ALERTS_UI_URL"),
   fullstory_org_id: System.get_env("FULLSTORY_ORG_ID"),
-  api_key: System.get_env("SCREENPLAY_API_KEY")
+  api_key: api_key
 
 if sentry_dsn not in [nil, ""] do
   config :sentry,

--- a/docs/tech_specs/pa_message_api.md
+++ b/docs/tech_specs/pa_message_api.md
@@ -2,7 +2,7 @@
 
 Lists all PA messages that are currently eligible to play.
 
-**URL** : `/api/active_pa_messages`
+**URL** : `/api/pa_messages/active_pa_messages`
 
 **Method** : `GET`
 

--- a/lib/screenplay_web/controllers/pa_messages_api_controller.ex
+++ b/lib/screenplay_web/controllers/pa_messages_api_controller.ex
@@ -1,0 +1,7 @@
+defmodule ScreenplayWeb.PaMessagesApiController do
+  use ScreenplayWeb, :controller
+
+  def active_pa_messages(conn, _params) do
+    json(conn, [])
+  end
+end

--- a/lib/screenplay_web/plugs/enforce_api_key.ex
+++ b/lib/screenplay_web/plugs/enforce_api_key.ex
@@ -5,13 +5,15 @@ defmodule ScreenplayWeb.Plugs.EnforceApiKey do
 
   import Plug.Conn
 
+  @api_key Application.compile_env!(:screenplay, :api_key)
+
   def init(default), do: default
 
   def call(conn, _default) do
     api_key =
       Enum.find_value(conn.req_headers, fn {key, value} -> if(key == "x-api-key", do: value) end)
 
-    if api_key != Application.get_env(:screenplay, :api_key) do
+    if api_key != @api_key do
       conn |> send_resp(403, "Invalid API key") |> halt()
     else
       conn

--- a/lib/screenplay_web/plugs/enforce_api_key.ex
+++ b/lib/screenplay_web/plugs/enforce_api_key.ex
@@ -1,0 +1,20 @@
+defmodule ScreenplayWeb.Plugs.EnforceApiKey do
+  @moduledoc """
+  Plug used to verify a request contains a valid API key in the x-api-key request header.
+  """
+
+  import Plug.Conn
+
+  def init(default), do: default
+
+  def call(conn, _default) do
+    api_key =
+      Enum.find_value(conn.req_headers, fn {key, value} -> if(key == "x-api-key", do: value) end)
+
+    if api_key != Application.get_env(:screenplay, :api_key) do
+      conn |> send_resp(403, "Invalid API key") |> halt()
+    else
+      conn
+    end
+  end
+end

--- a/lib/screenplay_web/plugs/enforce_api_key.ex
+++ b/lib/screenplay_web/plugs/enforce_api_key.ex
@@ -5,15 +5,13 @@ defmodule ScreenplayWeb.Plugs.EnforceApiKey do
 
   import Plug.Conn
 
-  @api_key Application.compile_env!(:screenplay, :api_key)
-
   def init(default), do: default
 
   def call(conn, _default) do
     api_key =
       Enum.find_value(conn.req_headers, fn {key, value} -> if(key == "x-api-key", do: value) end)
 
-    if api_key != @api_key do
+    if api_key != Application.get_env(:screenplay, :api_key) do
       conn |> send_resp(403, "Invalid API key") |> halt()
     else
       conn

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -39,6 +39,10 @@ defmodule ScreenplayWeb.Router do
     plug(ScreenplayWeb.EnsurePaMessageAdmin)
   end
 
+  pipeline :enforce_api_key do
+    plug(ScreenplayWeb.Plugs.EnforceApiKey)
+  end
+
   # Load balancer health check
   # Exempt from auth checks and SSL redirects
   scope "/", ScreenplayWeb do
@@ -111,6 +115,12 @@ defmodule ScreenplayWeb.Router do
     get("/past_alerts", AlertController, :past_alerts)
 
     get("/stations_and_screen_orientations", PageController, :stations_and_screen_orientations)
+  end
+
+  scope "/api/pa_messages", ScreenplayWeb do
+    pipe_through([:redirect_prod_http, :api, :enforce_api_key])
+
+    get("/active_pa_messages", PaMessagesApiController, :active_pa_messages)
   end
 
   # Enables LiveDashboard only for development


### PR DESCRIPTION
This PR adds the endpoint RTS will use to retrieve PA messages from Screenplay. Endpoint is protected by a plug that checks for the correct API key stored for the environment (PR for that is [here](https://github.com/mbta/devops/pull/1756)). I had a slight pivot from the API spec on the full URL, but I updated the doc to reflect the change. Also made a small edit to the README regarding psql connection stuff.
