### PR TITLE
fix takeover tool modal styles

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -123,47 +123,28 @@ footer {
   margin-top: 48px;
 }
 
-.modal-content {
-  border-radius: 8px;
-  border: none;
-  .modal-body {
-    padding: 24px;
-    .modal-header {
-      justify-content: unset;
-      border: none;
-      padding: 0 0 24px 0;
-    }
-    .header-text {
-      color: $gray-800;
-      font-weight: 700;
-      font-size: 30px;
-      line-height: 36px;
-    }
-    .modal-description {
-      margin-left: 64px;
-      color: $gray-600;
-    }
+.outfront-modal {
+  --bs-modal-border-radius: 8px;
+  --bs-modal-bg: #{$gray-200};
+  --bs-modal-padding: 16px;
+  --bs-modal-header-padding: 16px;
+}
+
+.cancel-button {
+  background-color: $gray-50;
+  border: 1px solid $gray-300;
+  color: $gray-700;
+  &:hover {
+    color: $gray-700;
+    background-color: white;
   }
-  .modal-footer {
-    background-color: $gray-200;
-    padding: 24px;
-    border-radius: 0 0 8px 8px;
-    .cancel-button {
-      background-color: $gray-50;
-      border: 1px solid $gray-300;
-      color: $gray-700;
-      &:hover {
-        background-color: white;
-      }
-    }
-    .confirm-button {
-      margin-left: 24px;
-      background-color: $cyan-700;
-      border: 1px solid $gray-300;
-      &:hover {
-        background-color: $cyan-900;
-      }
-    }
+}
+.confirm-button {
+  margin-left: 24px;
+  background-color: $cyan-700;
+  border: 1px solid $gray-300;
+  &:hover {
+    background-color: $cyan-900;
   }
 }
 

--- a/assets/js/components/OutfrontTakeoverTool/ConfirmationModal.tsx
+++ b/assets/js/components/OutfrontTakeoverTool/ConfirmationModal.tsx
@@ -27,14 +27,13 @@ const ConfirmationModal = (props: ModalProps): JSX.Element => {
       size="lg"
       aria-labelledby="contained-modal-title-vcenter"
       centered
+      className="outfront-modal"
     >
-      <Modal.Body>
-        <div className="modal-header">
-          <div className="icon-circle">{icon}</div>
-          <div className="header-text">{header}</div>
-        </div>
-        <div className="modal-description">{description}</div>
-      </Modal.Body>
+      <Modal.Header className="text-30">
+        <div className="icon-circle">{icon}</div>
+        <Modal.Title>{header}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>{description}</Modal.Body>
       <Modal.Footer>
         <button className="cancel-button" onClick={props.onHide}>
           {cancelText}


### PR DESCRIPTION
Fixes the styling of the confirmation modals in the outfront takeover tool. This mostly replicates the original style, but makes a few simplifications.