### PR TITLE
tweak: Auth rework

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -49,12 +49,25 @@ config :phoenix, :json_library, Jason
 # Use Jason for JSON parsing in ExAws
 config :ex_aws, json_codec: Jason
 
-config :screenplay, ScreenplayWeb.AuthManager, issuer: "screenplay"
+# 12 hours in seconds
+max_session_time = 12 * 60 * 60
 
-# Placeholder for Keycloak authentication, defined for real in environment configs
+config :screenplay, ScreenplayWeb.AuthManager,
+  issuer: "screenplay",
+  max_session_time: max_session_time,
+  # 30 minutes
+  idle_time: 30 * 60
+
 config :ueberauth, Ueberauth,
   providers: [
-    keycloak: nil
+    keycloak:
+      {Ueberauth.Strategy.Oidcc,
+       issuer: :keycloak_issuer,
+       userinfo: true,
+       uid_field: "email",
+       scopes: ~w"openid email",
+       authorization_params: %{max_age: "#{max_session_time}"},
+       authorization_params_passthrough: ~w"prompt login_hint"}
   ]
 
 import_config "outfront_takeover_tool_screens.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -54,6 +54,7 @@ max_session_time = 12 * 60 * 60
 
 config :screenplay, ScreenplayWeb.AuthManager,
   issuer: "screenplay",
+  secret_key: nil,
   max_session_time: max_session_time,
   # 30 minutes
   idle_time: 30 * 60

--- a/lib/screenplay_web/auth_manager/auth_manager.ex
+++ b/lib/screenplay_web/auth_manager/auth_manager.ex
@@ -39,7 +39,7 @@ defmodule ScreenplayWeb.AuthManager do
   def resource_from_claims(_), do: {:error, :invalid_claims}
 
   @impl true
-  def verify_claims(%{"iat" => iat, "auth_time" => auth_time} = claims, _opts) do
+  def verify_claims(claims = %{"iat" => iat, "auth_time" => auth_time}, _opts) do
     now = System.system_time(:second)
     # auth_time is when the user entered their password at the SSO provider
     auth_time_expires = auth_time + max_session_time()

--- a/lib/screenplay_web/auth_manager/auth_manager.ex
+++ b/lib/screenplay_web/auth_manager/auth_manager.ex
@@ -12,6 +12,15 @@ defmodule ScreenplayWeb.AuthManager do
     "pa-message-admin" => :pa_message_admin
   }
 
+  def max_session_time do
+    Application.get_env(:screenplay, __MODULE__)[:max_session_time]
+  end
+
+  def idle_time do
+    Application.get_env(:screenplay, __MODULE__)[:idle_time]
+  end
+
+  @impl true
   @spec subject_for_token(
           resource :: Guardian.Token.resource(),
           claims :: Guardian.Token.claims()
@@ -20,6 +29,7 @@ defmodule ScreenplayWeb.AuthManager do
     {:ok, resource}
   end
 
+  @impl true
   @spec resource_from_claims(claims :: Guardian.Token.claims()) ::
           {:error, :invalid_claims} | {:ok, String.t()}
   def resource_from_claims(%{"sub" => username}) do
@@ -27,6 +37,21 @@ defmodule ScreenplayWeb.AuthManager do
   end
 
   def resource_from_claims(_), do: {:error, :invalid_claims}
+
+  @impl true
+  def verify_claims(%{"iat" => iat, "auth_time" => auth_time} = claims, _opts) do
+    now = System.system_time(:second)
+    # auth_time is when the user entered their password at the SSO provider
+    auth_time_expires = auth_time + max_session_time()
+    # iat is when the token was issued
+    iat_expires = iat + idle_time()
+    # did either timeout expire?
+    if min(auth_time_expires, iat_expires) < now do
+      {:error, {:auth_expired, claims["sub"]}}
+    else
+      {:ok, claims}
+    end
+  end
 
   @spec claims_access_level(Guardian.Token.claims()) :: list(access_level())
   def claims_access_level(%{"roles" => roles}) when not is_nil(roles) do

--- a/lib/screenplay_web/auth_manager/auth_manager.ex
+++ b/lib/screenplay_web/auth_manager/auth_manager.ex
@@ -12,13 +12,8 @@ defmodule ScreenplayWeb.AuthManager do
     "pa-message-admin" => :pa_message_admin
   }
 
-  def max_session_time do
-    Application.get_env(:screenplay, __MODULE__)[:max_session_time]
-  end
-
-  def idle_time do
-    Application.get_env(:screenplay, __MODULE__)[:idle_time]
-  end
+  @max_session_time Application.compile_env(:screenplay, __MODULE__)[:max_session_time]
+  @max_idle_time Application.compile_env(:screenplay, __MODULE__)[:idle_time]
 
   @impl true
   @spec subject_for_token(
@@ -42,9 +37,9 @@ defmodule ScreenplayWeb.AuthManager do
   def verify_claims(claims = %{"iat" => iat, "auth_time" => auth_time}, _opts) do
     now = System.system_time(:second)
     # auth_time is when the user entered their password at the SSO provider
-    auth_time_expires = auth_time + max_session_time()
+    auth_time_expires = auth_time + @max_session_time
     # iat is when the token was issued
-    iat_expires = iat + idle_time()
+    iat_expires = iat + @max_idle_time
     # did either timeout expire?
     if min(auth_time_expires, iat_expires) < now do
       {:error, {:auth_expired, claims["sub"]}}

--- a/lib/screenplay_web/auth_manager/auth_manager.ex
+++ b/lib/screenplay_web/auth_manager/auth_manager.ex
@@ -12,9 +12,6 @@ defmodule ScreenplayWeb.AuthManager do
     "pa-message-admin" => :pa_message_admin
   }
 
-  @max_session_time Application.compile_env(:screenplay, __MODULE__)[:max_session_time]
-  @max_idle_time Application.compile_env(:screenplay, __MODULE__)[:idle_time]
-
   @impl true
   @spec subject_for_token(
           resource :: Guardian.Token.resource(),
@@ -37,9 +34,11 @@ defmodule ScreenplayWeb.AuthManager do
   def verify_claims(claims = %{"iat" => iat, "auth_time" => auth_time}, _opts) do
     now = System.system_time(:second)
     # auth_time is when the user entered their password at the SSO provider
-    auth_time_expires = auth_time + @max_session_time
+    auth_time_expires =
+      auth_time + Application.get_env(:screenplay, __MODULE__)[:max_session_time]
+
     # iat is when the token was issued
-    iat_expires = iat + @max_idle_time
+    iat_expires = iat + Application.get_env(:screenplay, __MODULE__)[:idle_time]
     # did either timeout expire?
     if min(auth_time_expires, iat_expires) < now do
       {:error, {:auth_expired, claims["sub"]}}

--- a/lib/screenplay_web/auth_manager/auth_manager.ex
+++ b/lib/screenplay_web/auth_manager/auth_manager.ex
@@ -12,6 +12,9 @@ defmodule ScreenplayWeb.AuthManager do
     "pa-message-admin" => :pa_message_admin
   }
 
+  @max_session_time Application.compile_env(:screenplay, [__MODULE__, :max_session_time])
+  @max_idle_time Application.compile_env(:screenplay, [__MODULE__, :idle_time])
+
   @impl true
   @spec subject_for_token(
           resource :: Guardian.Token.resource(),
@@ -34,11 +37,9 @@ defmodule ScreenplayWeb.AuthManager do
   def verify_claims(claims = %{"iat" => iat, "auth_time" => auth_time}, _opts) do
     now = System.system_time(:second)
     # auth_time is when the user entered their password at the SSO provider
-    auth_time_expires =
-      auth_time + Application.get_env(:screenplay, __MODULE__)[:max_session_time]
-
+    auth_time_expires = auth_time + @max_session_time
     # iat is when the token was issued
-    iat_expires = iat + Application.get_env(:screenplay, __MODULE__)[:idle_time]
+    iat_expires = iat + @max_idle_time
     # did either timeout expire?
     if min(auth_time_expires, iat_expires) < now do
       {:error, {:auth_expired, claims["sub"]}}

--- a/lib/screenplay_web/auth_manager/error_handler.ex
+++ b/lib/screenplay_web/auth_manager/error_handler.ex
@@ -5,10 +5,35 @@ defmodule ScreenplayWeb.AuthManager.ErrorHandler do
 
   use ScreenplayWeb, :plug
 
+  alias ScreenplayWeb.Router.Helpers, as: Routes
+
   @behaviour Guardian.Plug.ErrorHandler
 
   @impl Guardian.Plug.ErrorHandler
-  def auth_error(conn, {_type, _reason}, _opts) do
-    Phoenix.Controller.redirect(conn, to: ~p"/auth/keycloak")
+  def auth_error(conn, error, _opts) do
+    auth_params = auth_params_for_error(error)
+
+    Phoenix.Controller.redirect(conn,
+      to: Routes.auth_path(conn, :request, "keycloak", auth_params)
+    )
+  end
+
+  def auth_params_for_error({:invalid_token, {:auth_expired, sub}}) do
+    # if we know the user who was logged in before, provide that upstream to simplify
+    # logging in
+    %{
+      prompt: "login",
+      login_hint: sub
+    }
+  end
+
+  def auth_params_for_error({:unauthenticated, _}) do
+    %{}
+  end
+
+  def auth_params_for_error(_) do
+    %{
+      prompt: "login"
+    }
   end
 end

--- a/lib/screenplay_web/auth_manager/pipeline.ex
+++ b/lib/screenplay_web/auth_manager/pipeline.ex
@@ -10,6 +10,7 @@ defmodule ScreenplayWeb.AuthManager.Pipeline do
   plug(Guardian.Plug.VerifySession, claims: %{"typ" => "access"})
   plug(Guardian.Plug.VerifyHeader, claims: %{"typ" => "access"})
   plug(Guardian.Plug.LoadResource, allow_blank: true)
+  plug :refresh_idle_token
 
   # A plug to save the current path before the auth process loses it through several
   # redirects. We use this path in auth_controller to send us back to the original url
@@ -18,6 +19,23 @@ defmodule ScreenplayWeb.AuthManager.Pipeline do
       conn
     else
       Plug.Conn.put_session(conn, :previous_path, conn.request_path)
+    end
+  end
+
+  @doc """
+  Refreshes the token with each request.
+
+  This allows us to use the `iat` time in the token as an idle timeout.
+  """
+  def refresh_idle_token(conn, _opts) do
+    old_token = Guardian.Plug.current_token(conn)
+
+    case ScreenplayWeb.AuthManager.refresh(old_token) do
+      {:ok, _old, {new_token, _new_claims}} ->
+        Guardian.Plug.put_session_token(conn, new_token)
+
+      _ ->
+        conn
     end
   end
 end

--- a/lib/screenplay_web/controllers/auth_controller.ex
+++ b/lib/screenplay_web/controllers/auth_controller.ex
@@ -6,7 +6,6 @@ defmodule ScreenplayWeb.AuthController do
   def callback(conn = %{assigns: %{ueberauth_auth: auth}}, _params) do
     username = auth.uid
     name = auth.info.name
-    session_ttl_hours = 24 * 30
 
     keycloak_client_id =
       get_in(Application.get_env(:ueberauth_oidcc, :providers), [:keycloak, :client_id])
@@ -15,14 +14,33 @@ defmodule ScreenplayWeb.AuthController do
       get_in(auth.extra.raw_info.userinfo, ["resource_access", keycloak_client_id, "roles"]) || []
 
     previous_path = Plug.Conn.get_session(conn, :previous_path)
-    Plug.Conn.delete_session(conn, :previous_path)
+    conn = delete_session(conn, :previous_path)
+
+    auth_time =
+      Map.get(
+        auth.extra.raw_info.claims,
+        "auth_time",
+        auth.extra.raw_info.claims["iat"]
+      )
+
+    logout_url =
+      case UeberauthOidcc.initiate_logout_url(auth, %{
+             post_logout_redirect_uri: "https://www.mbta.com/"
+           }) do
+        {:ok, url} ->
+          url
+
+        _ ->
+          nil
+      end
 
     conn
+    |> configure_session(drop: true)
+    |> put_session(:logout_url, logout_url)
     |> Guardian.Plug.sign_in(
       ScreenplayWeb.AuthManager,
       username,
-      %{roles: roles},
-      ttl: {session_ttl_hours, :hours}
+      %{auth_time: auth_time, roles: roles}
     )
     |> Plug.Conn.put_session(:username, name || username)
     # Redirect to whatever page they came from

--- a/lib/screenplay_web/controllers/auth_controller.ex
+++ b/lib/screenplay_web/controllers/auth_controller.ex
@@ -3,6 +3,10 @@ defmodule ScreenplayWeb.AuthController do
 
   plug Ueberauth
 
+  def request(conn, %{"provider" => provider}) when provider != "keycloak" do
+    send_resp(conn, 404, "Not Found")
+  end
+
   def callback(conn = %{assigns: %{ueberauth_auth: auth}}, _params) do
     username = auth.uid
     name = auth.info.name

--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,7 @@ defmodule Screenplay.MixProject do
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:guardian, "~> 2.3"},
       {:ueberauth, "~> 0.10.0"},
-      {:ueberauth_oidcc, "~> 0.3"},
+      {:ueberauth_oidcc, "~> 0.4"},
       {:sftp_client, "~> 2.0"},
       {:ex_aws, "~> 2.5"},
       {:ex_aws_s3, "~> 2.5"},

--- a/test/screenplay_web/auth_manager/error_handler_test.exs
+++ b/test/screenplay_web/auth_manager/error_handler_test.exs
@@ -10,7 +10,7 @@ defmodule ScreenplayWeb.AuthManager.ErrorHandlerTest do
         |> init_test_session(%{})
         |> ErrorHandler.auth_error({:some_type, :reason}, [])
 
-      assert html_response(conn, 302) =~ "\"/auth/keycloak\""
+      assert html_response(conn, 302) =~ "\"/auth/keycloak?prompt=login\""
     end
   end
 end


### PR DESCRIPTION
**Asana task**: ad-hoc

Paul S. recently created a [Notion doc](https://www.notion.so/mbta-downtown-crossing/Session-Management-ad53a774fd39462c82146f60700db5fc?pvs=4) that outlines best practices for application session management. In the past, we have seen issues with auth expiring way too early and the band-aid fix was to arbitrarily increase TTL to get around this. This doc gives recommendations to managing TTLs so that use recommended TTL values and lean on `ueberatuh_oidcc` to keep sessions alive for only as long as they should be. 