### PR TITLE
fix: Fake ueberauth strategy

### DIFF
--- a/lib/screenplay/ueberauth/strategy/fake.ex
+++ b/lib/screenplay/ueberauth/strategy/fake.ex
@@ -45,6 +45,7 @@ defmodule Screenplay.Ueberauth.Strategy.Fake do
   def extra(conn) do
     %Ueberauth.Auth.Extra{
       raw_info: %UeberauthOidcc.RawInfo{
+        claims: %{"iat" => System.system_time(:second)},
         userinfo: %{
           "resource_access" => %{
             "dev-client" => %{"roles" => Helpers.options(conn)[:roles]}


### PR DESCRIPTION
**Asana task**: ad-hoc

Forgot a small update to the fake strategy in #348. Without this, the auth redirect never completes because the claims doesn't have the require `iat` key.