### PR TITLE
fix: send 404 for /auth/* not handled by ueberauth

### DIFF
--- a/lib/screenplay_web/controllers/auth_controller.ex
+++ b/lib/screenplay_web/controllers/auth_controller.ex
@@ -35,4 +35,14 @@ defmodule ScreenplayWeb.AuthController do
       ) do
     send_resp(conn, 401, "unauthenticated")
   end
+
+  ## Fallback handlers for unknown/unconfigured "providers"
+
+  def callback(conn, _) do
+    send_resp(conn, 404, "Not Found")
+  end
+
+  def request(conn, _) do
+    send_resp(conn, 404, "Not Found")
+  end
 end


### PR DESCRIPTION
**Asana task**: [SCREENPLAY-2N](https://app.asana.com/0/1185117109217413/1207485011307264/f)

#### Description

Fixes Sentry issue [SCREENPLAY-2N](https://mbtace.sentry.io/issues/5187288913/?environment=prod&project=6061951).

- Adds fallback function definitions for `request/2` and `callback/2`
    - These are called if `/auth/:provider` or `/auth/:provider/callback` are visited by a provider that hasn't been configured
