### PR TITLE
fix: use URI module to build V3 API URIs

### DIFF
--- a/lib/screenplay/alerts/alert.ex
+++ b/lib/screenplay/alerts/alert.ex
@@ -61,7 +61,7 @@ defmodule Screenplay.Alerts.Alert do
         }
 
   def fetch(get_json_fn \\ &V3Api.get_json/2) do
-    case get_json_fn.("alerts", %{
+    case get_json_fn.("/alerts", %{
            "include" => "routes"
          }) do
       {:ok, result} ->

--- a/lib/screenplay/route_patterns/route_pattern.ex
+++ b/lib/screenplay/route_patterns/route_pattern.ex
@@ -7,7 +7,7 @@ defmodule Screenplay.RoutePatterns.RoutePattern do
 
   @impl true
   def fetch_platform_ids_for_route_at_stop(stop_id, route_id) do
-    case V3Api.get_json("route_patterns", %{
+    case V3Api.get_json("/route_patterns", %{
            "include" => "representative_trip.stops",
            "filter[route]" => route_id,
            "filter[canonical]" => true

--- a/lib/screenplay/v3_api.ex
+++ b/lib/screenplay/v3_api.ex
@@ -61,12 +61,21 @@ defmodule Screenplay.V3Api do
     error
   end
 
-  defp build_url(route, params) when map_size(params) == 0 do
-    base_url() <> route
-  end
+  @doc false
+  def build_url(route, params) do
+    query = URI.encode_query(params)
 
-  defp build_url(route, params) do
-    "#{base_url()}/#{route}?#{URI.encode_query(params)}"
+    base_url()
+    |> URI.parse()
+    |> URI.append_path(route)
+    |> then(fn url ->
+      if query == "" do
+        url
+      else
+        URI.append_query(url, query)
+      end
+    end)
+    |> URI.to_string()
   end
 
   defp base_url do

--- a/test/screenplay/alerts/cache_test.exs
+++ b/test/screenplay/alerts/cache_test.exs
@@ -24,7 +24,7 @@ defmodule Screenplay.Alerts.CacheTest do
   end
 
   test "It polls an API and updates the store" do
-    get_json_fn = fn "alerts", %{"include" => "routes"} ->
+    get_json_fn = fn "/alerts", %{"include" => "routes"} ->
       {:ok, %{"data" => [alert_json("1")], "included" => []}}
     end
 
@@ -39,7 +39,7 @@ defmodule Screenplay.Alerts.CacheTest do
   end
 
   test "It handles a failed API response and does not update the store" do
-    get_json_fn = fn "alerts", %{"include" => "routes"} ->
+    get_json_fn = fn "/alerts", %{"include" => "routes"} ->
       :error
     end
 

--- a/test/screenplay/pa_messages/pa_message_test.exs
+++ b/test/screenplay/pa_messages/pa_message_test.exs
@@ -62,7 +62,7 @@ defmodule Screenplay.PaMessages.PaMessageTest do
     test "returns messages linked to an existing alert" do
       now = ~U[2024-05-01T05:00:00Z]
 
-      get_json_fn = fn "alerts", %{"include" => "routes"} ->
+      get_json_fn = fn "/alerts", %{"include" => "routes"} ->
         {:ok,
          %{
            "data" => [

--- a/test/screenplay/v3_api_test.exs
+++ b/test/screenplay/v3_api_test.exs
@@ -1,0 +1,24 @@
+defmodule Screenplay.V3ApiTest do
+  use ExUnit.Case, async: true
+  alias Screenplay.V3Api
+
+  describe "build_url/2" do
+    setup do
+      original_api_v3_url = Application.get_env(:screenplay, :api_v3_url)
+      Application.put_env(:screenplay, :api_v3_url, "https://v3-api.test-v3-api.com/")
+
+      on_exit(fn ->
+        Application.put_env(:screenplay, :api_v3_url, original_api_v3_url)
+      end)
+    end
+
+    test "returns the base URL and the route when an empty map is passed" do
+      assert "https://v3-api.test-v3-api.com/alerts" == V3Api.build_url("/alerts", %{})
+    end
+
+    test "adds params to query string" do
+      assert "https://v3-api.test-v3-api.com/alerts?filter%5Broute%5D=Green-B&filter%5Bstop%5D=123" ==
+               V3Api.build_url("/alerts", %{"filter[route]" => "Green-B", "filter[stop]" => "123"})
+    end
+  end
+end


### PR DESCRIPTION
**Asana task**: [[bug] Screenplay forms V3 API urls inconsistently](https://app.asana.com/0/1185117109217422/1203906403602585/f)

#### Description

- Uses `URI` module to build V3 API URLs
- Adds tests for `build_url` function to verify there are no longer any leading `/`s being inserted into the URLs
