### PR TITLE
actually skip workflow on dependabot PRs

### DIFF
--- a/.github/workflows/asana-pr-opened.yml
+++ b/.github/workflows/asana-pr-opened.yml
@@ -2,11 +2,11 @@ name: Modify Asana ticket
 on: 
   pull_request:
     types: [opened, reopened]
-    branches-ignore: ["dependabot/**"]
 
 jobs:
   create-asana-attachment-job:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     name: Create pull request attachments on Asana tasks
     steps:
       - name: Create pull request attachments


### PR DESCRIPTION
This should hopefully prevent dependabot from trying to run the workflow it doesn't have secrets available for. Note that the previous attempt didn't work because the branch filter is for the target branch, not the source. The `if` clause is used in the official docs, so should work.