### PR TITLE
Fix dimensions for paess iframes

### DIFF
--- a/assets/js/components/Dashboard/PaessScreenDetail.tsx
+++ b/assets/js/components/Dashboard/PaessScreenDetail.tsx
@@ -43,7 +43,7 @@ const PaessScreenDetail = (props: PaessScreenDetailProps): JSX.Element => {
         />
       </div>
       <iframe
-        className="screen-detail__iframe screen-detail__iframe--pa_ess"
+        className="screen-simulation__iframe screen-simulation__iframe--pa_ess"
         title={props.stationCode}
         src={generateSource()}
       />


### PR DESCRIPTION
Adhoc

The CSS classes that defined the dimensions was refactored a while ago in #261 but the classname for PAESS iframes was never reassigned which is why we've been seeing weird dimensions.
