### PR TITLE
feat: Preview Audio

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -26,3 +26,8 @@ export DATABASE_HOSTNAME="localhost"
 
 # Access key for allowing PA Message API calls. Required for endpoints in the /api/pa-messages scope. Generate a unique random string for local use.
 export SCREENPLAY_API_KEY="local_api_key"
+
+# Host and access key needed to communicate with Watts. Required when previewing PA message audio.
+# For local use, set to the same value as your local instance of Watts.
+#export WATTS_URL=""
+#export WATTS_API_KEY=""

--- a/.envrc.template
+++ b/.envrc.template
@@ -29,5 +29,6 @@ export SCREENPLAY_API_KEY="local_api_key"
 
 # Host and access key needed to communicate with Watts. Required when previewing PA message audio.
 # For local use, set to the same value as your local instance of Watts.
-#export WATTS_URL=""
+#export WATTS_URL="https://watts-staging.mbtace.com"
+# API Key is in the Screens 1Password vault under `Watts Staging API Key`
 #export WATTS_API_KEY=""

--- a/.envrc.template
+++ b/.envrc.template
@@ -29,6 +29,7 @@ export SCREENPLAY_API_KEY="local_api_key"
 
 # Host and access key needed to communicate with Watts. Required when previewing PA message audio.
 # For local use, set to the same value as your local instance of Watts.
+# VPN is required for requests to watts-staging.
 #export WATTS_URL="https://watts-staging.mbtace.com"
 # API Key is in the Screens 1Password vault under `Watts Staging API Key`
 #export WATTS_API_KEY=""

--- a/assets/css/dashboard/new-pa-message-page/new-pa-message-page.scss
+++ b/assets/css/dashboard/new-pa-message-page/new-pa-message-page.scss
@@ -147,13 +147,17 @@
   }
 
   .message-card {
-    .copy-text-button {
-      background-color: $bg-border-disabled;
-      width: 38px;
-      height: 38px;
+    .copy-button-col {
+      margin-top: 141px;
 
-      .bi-arrow-right-short {
-        fill: $text-disabled;
+      .copy-text-button {
+        background-color: $bg-border-disabled;
+        width: 38px;
+        height: 38px;
+
+        .bi-arrow-right-short {
+          fill: $text-disabled;
+        }
       }
     }
 
@@ -162,14 +166,22 @@
       resize: none;
     }
 
-    .copy-button-col {
-      margin-top: 141px;
+    .audio-reviewed-text {
+      color: $text-primary;
+      margin-top: auto;
+      margin-bottom: auto;
+      align-self: center;
+
+      span {
+        vertical-align: middle;
+      }
     }
 
     .review-audio-button {
       color: $button-primary;
       margin-top: auto;
       margin-bottom: auto;
+      margin-left: 16px;
       padding: 0;
 
       &--audio-playing {

--- a/assets/css/dashboard/new-pa-message-page/new-pa-message-page.scss
+++ b/assets/css/dashboard/new-pa-message-page/new-pa-message-page.scss
@@ -184,6 +184,10 @@
       margin-left: 16px;
       padding: 0;
 
+      .bi {
+        margin-right: 8px;
+      }
+
       &--audio-playing {
         color: $text-primary;
         text-decoration: none;
@@ -198,6 +202,42 @@
     .review-audio-card {
       height: 250px;
       background-color: $cool-gray-15;
+    }
+  }
+
+  .error-alert-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: fixed;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: 40px;
+    z-index: 1001;
+  }
+
+  .error-alert {
+    width: 400px;
+    background-color: #ffdd00;
+    font-size: 16px;
+    display: flex;
+    align-items: center;
+
+    .btn-close {
+      &:hover {
+        background-color: transparent;
+      }
+    }
+
+    &__icon {
+      height: 24px;
+      width: 24px;
+      opacity: 60%;
+      flex-shrink: 0;
+    }
+
+    &__text {
+      padding-left: 8px;
     }
   }
 }

--- a/assets/css/dashboard/new-pa-message-page/new-pa-message-page.scss
+++ b/assets/css/dashboard/new-pa-message-page/new-pa-message-page.scss
@@ -172,6 +172,11 @@
       margin-bottom: auto;
       padding: 0;
 
+      &--audio-playing {
+        color: $text-primary;
+        text-decoration: none;
+      }
+
       &:disabled {
         color: $text-secondary;
         text-decoration: none;

--- a/assets/css/dashboard/new-pa-message-page/new-pa-message-page.scss
+++ b/assets/css/dashboard/new-pa-message-page/new-pa-message-page.scss
@@ -162,15 +162,25 @@
       resize: none;
     }
 
+    .copy-button-col {
+      margin-top: 141px;
+    }
+
+    .review-audio-button {
+      color: $button-primary;
+      margin-top: auto;
+      margin-bottom: auto;
+      padding: 0;
+
+      &:disabled {
+        color: $text-secondary;
+        text-decoration: none;
+      }
+    }
+
     .review-audio-card {
       height: 250px;
       background-color: $cool-gray-15;
-
-      .review-audio-button {
-        color: $button-primary;
-        margin-top: auto;
-        margin-bottom: auto;
-      }
     }
   }
 }

--- a/assets/js/components/Dashboard/PaMessaging/NewPaMessagePage/MessageTextBox.tsx
+++ b/assets/js/components/Dashboard/PaMessaging/NewPaMessagePage/MessageTextBox.tsx
@@ -7,15 +7,24 @@ interface Props {
   disabled?: boolean;
   label: string;
   id: string;
+  maxLength: number;
 }
 
-const MessageTextBox = ({ text, onChangeText, disabled, label, id }: Props) => {
+const MessageTextBox = ({
+  text,
+  onChangeText,
+  disabled,
+  label,
+  id,
+  maxLength,
+}: Props) => {
   return (
     <Form.Group>
       <Form.Label htmlFor={id}>{label}</Form.Label>
       <Form.Control
         id={id}
         className="text-input"
+        maxLength={maxLength}
         as="textarea"
         value={text}
         onChange={(textbox) => onChangeText(textbox.target.value)}

--- a/assets/js/components/Dashboard/PaMessaging/NewPaMessagePage/NewPaMessagePage.tsx
+++ b/assets/js/components/Dashboard/PaMessaging/NewPaMessagePage/NewPaMessagePage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Alert,
   Button,
@@ -44,6 +44,10 @@ const NewPaMessagePage = () => {
   const [errorMessage, setErrorMessage] = useState("");
 
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!audioPlaying) setAudioReviewed(false);
+  }, [visualText, phoneticText]);
 
   const previewAudio = () => {
     if (audioPlaying) return;

--- a/assets/js/components/Dashboard/PaMessaging/NewPaMessagePage/NewPaMessagePage.tsx
+++ b/assets/js/components/Dashboard/PaMessaging/NewPaMessagePage/NewPaMessagePage.tsx
@@ -57,6 +57,7 @@ const NewPaMessagePage = () => {
     setAudioPlaying(true);
   };
 
+  // Called after the audio preview plays in full
   const onAudioEnded = () => {
     setAudioPlaying(false);
     setAudioReviewed(true);
@@ -164,7 +165,10 @@ const NewPaMessagePage = () => {
                 <MessageTextBox
                   id="visual-text-box"
                   text={visualText}
-                  onChangeText={setVisualText}
+                  onChangeText={(text) => {
+                    setVisualText(text);
+                    setAudioPlaying(false);
+                  }}
                   label="Text"
                 />
               </Col>
@@ -172,7 +176,10 @@ const NewPaMessagePage = () => {
                 <Button
                   disabled={visualText.length === 0}
                   className="copy-text-button"
-                  onClick={() => setPhoneticText(visualText)}
+                  onClick={() => {
+                    setPhoneticText(visualText);
+                    setAudioPlaying(false);
+                  }}
                   aria-label="copy-visual-to-phonetic"
                 >
                   <ArrowRightShort />
@@ -184,7 +191,10 @@ const NewPaMessagePage = () => {
                     <MessageTextBox
                       id="phonetic-audio-text-box"
                       text={phoneticText}
-                      onChangeText={setPhoneticText}
+                      onChangeText={(text) => {
+                        setPhoneticText(text);
+                        setAudioPlaying(false);
+                      }}
                       disabled={phoneticText.length === 0}
                       label="Phonetic Audio"
                     />
@@ -193,9 +203,6 @@ const NewPaMessagePage = () => {
                       audioReviewed={audioReviewed}
                       showErrorIcon={errorMessage.length > 0}
                       onClick={previewAudio}
-                      audioText={phoneticText}
-                      onAudioEnded={onAudioEnded}
-                      onAudioError={onAudioError}
                     />
                   </>
                 ) : (
@@ -207,12 +214,17 @@ const NewPaMessagePage = () => {
                         audioReviewed={audioReviewed}
                         disabled={visualText.length === 0}
                         onClick={previewAudio}
-                        audioText={phoneticText}
-                        onAudioEnded={onAudioEnded}
-                        onAudioError={onAudioError}
                       />
                     </Card>
                   </>
+                )}
+                {audioPlaying && (
+                  <audio
+                    src={`/api/pa-messages/preview_audio?text=${phoneticText}`}
+                    autoPlay
+                    onEnded={onAudioEnded}
+                    onError={onAudioError}
+                  />
                 )}
               </Col>
             </Row>
@@ -257,9 +269,6 @@ interface ReviewAudioButtonProps {
   disabled?: boolean;
   showErrorIcon?: boolean;
   onClick: () => void;
-  audioText: string;
-  onAudioEnded: () => void;
-  onAudioError: () => void;
 }
 
 const ReviewAudioButton = ({
@@ -268,57 +277,32 @@ const ReviewAudioButton = ({
   disabled,
   showErrorIcon,
   onClick,
-  audioText,
-  onAudioEnded,
-  onAudioError,
 }: ReviewAudioButtonProps) => {
-  let layout;
-  if (audioReviewed) {
-    layout = (
-      <div className="audio-reviewed-text">
-        <span>
-          <CheckCircleFill /> Audio reviewed
-        </span>
-        <Button
-          className="review-audio-button"
-          onClick={onClick}
-          variant="link"
-        >
-          Replay
-        </Button>
-      </div>
-    );
-  } else {
-    layout = (
-      <Button
-        disabled={!audioPlaying && disabled}
-        className={cx("review-audio-button", {
-          "review-audio-button--audio-playing": audioPlaying,
-        })}
-        variant="link"
-        onClick={onClick}
-      >
-        {showErrorIcon ? (
-          <ExclamationTriangleFill fill="#FFC107" height={16} />
-        ) : (
-          <VolumeUpFill height={16} />
-        )}
-        {audioPlaying ? "Reviewing audio" : "Review audio"}
+  return audioReviewed ? (
+    <div className="audio-reviewed-text">
+      <span>
+        <CheckCircleFill /> Audio reviewed
+      </span>
+      <Button className="review-audio-button" onClick={onClick} variant="link">
+        Replay
       </Button>
-    );
-  }
-  return (
-    <>
-      {layout}
-      {audioPlaying && (
-        <audio
-          src={`/api/pa-messages/preview_audio?text=${audioText}`}
-          autoPlay
-          onEnded={onAudioEnded}
-          onError={onAudioError}
-        />
+    </div>
+  ) : (
+    <Button
+      disabled={!audioPlaying && disabled}
+      className={cx("review-audio-button", {
+        "review-audio-button--audio-playing": audioPlaying,
+      })}
+      variant="link"
+      onClick={onClick}
+    >
+      {showErrorIcon ? (
+        <ExclamationTriangleFill fill="#FFC107" height={16} />
+      ) : (
+        <VolumeUpFill height={16} />
       )}
-    </>
+      {audioPlaying ? "Reviewing audio" : "Review audio"}
+    </Button>
   );
 };
 

--- a/assets/js/components/Dashboard/PaMessaging/NewPaMessagePage/NewPaMessagePage.tsx
+++ b/assets/js/components/Dashboard/PaMessaging/NewPaMessagePage/NewPaMessagePage.tsx
@@ -134,7 +134,7 @@ const NewPaMessagePage = () => {
           </Card>
           <Card className="message-card">
             <div className="title">Message</div>
-            <Row className="align-items-center">
+            <Row>
               <Col>
                 <MessageTextBox
                   id="visual-text-box"
@@ -143,7 +143,7 @@ const NewPaMessagePage = () => {
                   label="Text"
                 />
               </Col>
-              <Col md="auto">
+              <Col md="auto" className="copy-button-col">
                 <Button
                   disabled={visualText.length === 0}
                   className="copy-text-button"
@@ -155,13 +155,23 @@ const NewPaMessagePage = () => {
               </Col>
               <Col>
                 {phoneticText.length > 0 ? (
-                  <MessageTextBox
-                    id="phonetic-audio-text-box"
-                    text={phoneticText}
-                    onChangeText={setPhoneticText}
-                    disabled={phoneticText.length === 0}
-                    label="Phonetic Audio"
-                  />
+                  <>
+                    <MessageTextBox
+                      id="phonetic-audio-text-box"
+                      text={phoneticText}
+                      onChangeText={setPhoneticText}
+                      disabled={phoneticText.length === 0}
+                      label="Phonetic Audio"
+                    />
+                    <Button
+                      className="review-audio-button"
+                      variant="link"
+                      onClick={previewAudio}
+                    >
+                      <VolumeUpFill height={12} />
+                      {audioPlaying ? "Reviewing audio" : "Review audio"}
+                    </Button>
+                  </>
                 ) : (
                   <>
                     <div className="form-label">Phonetic Audio</div>

--- a/assets/js/components/Dashboard/PaMessaging/NewPaMessagePage/NewPaMessagePage.tsx
+++ b/assets/js/components/Dashboard/PaMessaging/NewPaMessagePage/NewPaMessagePage.tsx
@@ -268,58 +268,32 @@ const ReviewAudioButton = ({
   showErrorIcon,
   onClick,
 }: ReviewAudioButtonProps) => {
-  let layout = <></>;
-  if (audioPlaying) {
-    layout = (
-      <Button
-        className="review-audio-button review-audio-button--audio-playing"
-        variant="link"
-        onClick={onClick}
-      >
-        {showErrorIcon ? (
-          <ExclamationTriangleFill fill="#FFC107" height={16} />
-        ) : (
-          <VolumeUpFill height={16} />
-        )}
-        Reviewing audio
+  return audioReviewed ? (
+    <div className="audio-reviewed-text">
+      <span>
+        <CheckCircleFill /> Audio reviewed
+      </span>
+      <Button className="review-audio-button" onClick={onClick} variant="link">
+        Replay
       </Button>
-    );
-  } else if (audioReviewed) {
-    layout = (
-      <div className="audio-reviewed-text">
-        <span>
-          <CheckCircleFill /> Audio reviewed
-        </span>
-        <Button
-          className="review-audio-button"
-          onClick={onClick}
-          variant="link"
-        >
-          Replay
-        </Button>
-      </div>
-    );
-  } else {
-    layout = (
-      <Button
-        disabled={disabled}
-        className={cx("review-audio-button", {
-          "review-audio-button--audio-playing": audioPlaying,
-        })}
-        variant="link"
-        onClick={onClick}
-      >
-        {showErrorIcon ? (
-          <ExclamationTriangleFill fill="#FFC107" height={16} />
-        ) : (
-          <VolumeUpFill height={16} />
-        )}
-        Review audio
-      </Button>
-    );
-  }
-
-  return layout;
+    </div>
+  ) : (
+    <Button
+      disabled={!audioPlaying && disabled}
+      className={cx("review-audio-button", {
+        "review-audio-button--audio-playing": audioPlaying,
+      })}
+      variant="link"
+      onClick={onClick}
+    >
+      {showErrorIcon ? (
+        <ExclamationTriangleFill fill="#FFC107" height={16} />
+      ) : (
+        <VolumeUpFill height={16} />
+      )}
+      {audioPlaying ? "Reviewing audio" : "Review audio"}
+    </Button>
+  );
 };
 
 export default NewPaMessagePage;

--- a/assets/js/components/Dashboard/PaMessaging/NewPaMessagePage/NewPaMessagePage.tsx
+++ b/assets/js/components/Dashboard/PaMessaging/NewPaMessagePage/NewPaMessagePage.tsx
@@ -26,6 +26,8 @@ import {
 } from "react-bootstrap-icons";
 import cx from "classnames";
 
+const MAX_TEXT_LENGTH = 2000;
+
 enum AudioState {
   HasNotBeenPlayed,
   IsPlaying,
@@ -176,6 +178,7 @@ const NewPaMessagePage = () => {
                     }
                   }}
                   label="Text"
+                  maxLength={MAX_TEXT_LENGTH}
                 />
               </Col>
               <Col md="auto" className="copy-button-col">
@@ -207,6 +210,7 @@ const NewPaMessagePage = () => {
                       }}
                       disabled={phoneticText.length === 0}
                       label="Phonetic Audio"
+                      maxLength={MAX_TEXT_LENGTH}
                     />
                     <ReviewAudioButton
                       audioState={audioState}

--- a/assets/js/components/Dashboard/PaMessaging/NewPaMessagePage/NewPaMessagePage.tsx
+++ b/assets/js/components/Dashboard/PaMessaging/NewPaMessagePage/NewPaMessagePage.tsx
@@ -1,5 +1,13 @@
 import React, { useState } from "react";
-import { Button, Card, Col, Container, Form, Row } from "react-bootstrap";
+import {
+  Alert,
+  Button,
+  Card,
+  Col,
+  Container,
+  Form,
+  Row,
+} from "react-bootstrap";
 import DaysPicker from "./DaysPicker";
 import PriorityPicker from "./PriorityPicker";
 import IntervalPicker from "./IntervalPicker";
@@ -11,6 +19,7 @@ import TimePicker from "../../TimePicker";
 import {
   ArrowRightShort,
   CheckCircleFill,
+  ExclamationTriangleFill,
   PlusLg,
   VolumeUpFill,
 } from "react-bootstrap-icons";
@@ -31,6 +40,8 @@ const NewPaMessagePage = () => {
   const [phoneticText, setPhoneticText] = useState("");
   const [audioPlaying, setAudioPlaying] = useState(false);
   const [audioReviewed, setAudioReviewed] = useState(false);
+  const [showErrorAlert, setShowErrorAlert] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
 
   const navigate = useNavigate();
 
@@ -43,6 +54,15 @@ const NewPaMessagePage = () => {
     setAudioPlaying(true);
     fetchAudioPreview(phoneticText.length ? phoneticText : visualText).then(
       async (audioData) => {
+        if (audioData.status !== 200) {
+          setAudioPlaying(false);
+          setShowErrorAlert(true);
+          setErrorMessage(
+            "Error occurred while fetching audio preview. Please try again.",
+          );
+          return;
+        }
+
         const blob = await audioData.blob();
         const url = URL.createObjectURL(blob);
         const audio = new Audio(url);
@@ -179,6 +199,7 @@ const NewPaMessagePage = () => {
                     <ReviewAudioButton
                       audioPlaying={audioPlaying}
                       audioReviewed={audioReviewed}
+                      showErrorIcon={errorMessage.length > 0}
                       onClick={previewAudio}
                     />
                   </>
@@ -215,6 +236,18 @@ const NewPaMessagePage = () => {
             </Button>
           </Row>
         </Container>
+        <div className="error-alert-container">
+          <Alert
+            show={showErrorAlert}
+            variant="primary"
+            onClose={() => setShowErrorAlert(false)}
+            dismissible
+            className="error-alert"
+          >
+            <ExclamationTriangleFill className="error-alert__icon" />
+            <div className="error-alert__text">{errorMessage}</div>
+          </Alert>
+        </div>
       </Form>
     </div>
   );
@@ -224,6 +257,7 @@ interface ReviewAudioButtonProps {
   audioPlaying: boolean;
   audioReviewed: boolean;
   disabled?: boolean;
+  showErrorIcon?: boolean;
   onClick: () => void;
 }
 
@@ -231,6 +265,7 @@ const ReviewAudioButton = ({
   audioPlaying,
   audioReviewed,
   disabled,
+  showErrorIcon,
   onClick,
 }: ReviewAudioButtonProps) => {
   let layout = <></>;
@@ -241,7 +276,11 @@ const ReviewAudioButton = ({
         variant="link"
         onClick={onClick}
       >
-        <VolumeUpFill height={12} />
+        {showErrorIcon ? (
+          <ExclamationTriangleFill fill="#FFC107" height={16} />
+        ) : (
+          <VolumeUpFill height={16} />
+        )}
         Reviewing audio
       </Button>
     );
@@ -270,7 +309,12 @@ const ReviewAudioButton = ({
         variant="link"
         onClick={onClick}
       >
-        <VolumeUpFill height={16} /> Review audio
+        {showErrorIcon ? (
+          <ExclamationTriangleFill fill="#FFC107" height={16} />
+        ) : (
+          <VolumeUpFill height={16} />
+        )}
+        Review audio
       </Button>
     );
   }

--- a/assets/js/components/Dashboard/PaMessaging/NewPaMessagePage/NewPaMessagePage.tsx
+++ b/assets/js/components/Dashboard/PaMessaging/NewPaMessagePage/NewPaMessagePage.tsx
@@ -28,11 +28,11 @@ import cx from "classnames";
 
 const MAX_TEXT_LENGTH = 2000;
 
-enum AudioState {
-  HasNotBeenPlayed,
-  IsPlaying,
-  HasBeenReviewed,
-  NeedsReview,
+enum AudioPreview {
+  Unreviewed,
+  Playing,
+  Reviewed,
+  Outdated,
 }
 
 const NewPaMessagePage = () => {
@@ -47,30 +47,30 @@ const NewPaMessagePage = () => {
   const [interval, setInterval] = useState("4");
   const [visualText, setVisualText] = useState("");
   const [phoneticText, setPhoneticText] = useState("");
-  const [audioState, setAudioState] = useState<AudioState>(
-    AudioState.HasNotBeenPlayed,
+  const [audioState, setAudioState] = useState<AudioPreview>(
+    AudioPreview.Unreviewed,
   );
   const [errorMessage, setErrorMessage] = useState("");
 
   const navigate = useNavigate();
 
   const previewAudio = () => {
-    if (audioState === AudioState.IsPlaying) return;
+    if (audioState === AudioPreview.Playing) return;
 
     if (phoneticText.length === 0) {
       setPhoneticText(visualText);
     }
 
-    setAudioState(AudioState.IsPlaying);
+    setAudioState(AudioPreview.Playing);
   };
 
   // Called after the audio preview plays in full
   const onAudioEnded = () => {
-    setAudioState(AudioState.HasBeenReviewed);
+    setAudioState(AudioPreview.Reviewed);
   };
 
   const onAudioError = () => {
-    setAudioState(AudioState.NeedsReview);
+    setAudioState(AudioPreview.Outdated);
     setErrorMessage(
       "Error occurred while fetching audio preview. Please try again.",
     );
@@ -173,8 +173,8 @@ const NewPaMessagePage = () => {
                   text={visualText}
                   onChangeText={(text) => {
                     setVisualText(text);
-                    if (audioState !== AudioState.HasNotBeenPlayed) {
-                      setAudioState(AudioState.NeedsReview);
+                    if (audioState !== AudioPreview.Unreviewed) {
+                      setAudioState(AudioPreview.Outdated);
                     }
                   }}
                   label="Text"
@@ -187,8 +187,8 @@ const NewPaMessagePage = () => {
                   className="copy-text-button"
                   onClick={() => {
                     setPhoneticText(visualText);
-                    if (audioState !== AudioState.HasNotBeenPlayed) {
-                      setAudioState(AudioState.NeedsReview);
+                    if (audioState !== AudioPreview.Unreviewed) {
+                      setAudioState(AudioPreview.Outdated);
                     }
                   }}
                   aria-label="copy-visual-to-phonetic"
@@ -204,8 +204,8 @@ const NewPaMessagePage = () => {
                       text={phoneticText}
                       onChangeText={(text) => {
                         setPhoneticText(text);
-                        if (audioState !== AudioState.HasNotBeenPlayed) {
-                          setAudioState(AudioState.NeedsReview);
+                        if (audioState !== AudioPreview.Unreviewed) {
+                          setAudioState(AudioPreview.Outdated);
                         }
                       }}
                       disabled={phoneticText.length === 0}
@@ -229,7 +229,7 @@ const NewPaMessagePage = () => {
                     </Card>
                   </>
                 )}
-                {audioState === AudioState.IsPlaying && (
+                {audioState === AudioPreview.Playing && (
                   <audio
                     src={`/api/pa-messages/preview_audio?text=${phoneticText}`}
                     autoPlay
@@ -275,7 +275,7 @@ const NewPaMessagePage = () => {
 };
 
 interface ReviewAudioButtonProps {
-  audioState: AudioState;
+  audioState: AudioPreview;
   disabled?: boolean;
   onClick: () => void;
 }
@@ -285,8 +285,8 @@ const ReviewAudioButton = ({
   disabled,
   onClick,
 }: ReviewAudioButtonProps) => {
-  const audioPlaying = audioState === AudioState.IsPlaying;
-  return audioState === AudioState.HasBeenReviewed ? (
+  const audioPlaying = audioState === AudioPreview.Playing;
+  return audioState === AudioPreview.Reviewed ? (
     <div className="audio-reviewed-text">
       <span>
         <CheckCircleFill /> Audio reviewed
@@ -304,7 +304,7 @@ const ReviewAudioButton = ({
       variant="link"
       onClick={onClick}
     >
-      {audioState === AudioState.NeedsReview ? (
+      {audioState === AudioPreview.Outdated ? (
         <ExclamationTriangleFill fill="#FFC107" height={16} />
       ) : (
         <VolumeUpFill height={16} />

--- a/assets/js/components/Dashboard/PaMessaging/NewPaMessagePage/NewPaMessagePage.tsx
+++ b/assets/js/components/Dashboard/PaMessaging/NewPaMessagePage/NewPaMessagePage.tsx
@@ -8,7 +8,12 @@ import { useNavigate } from "react-router-dom";
 import moment from "moment";
 import DatePicker from "../../DatePicker";
 import TimePicker from "../../TimePicker";
-import { ArrowRightShort, PlusLg, VolumeUpFill } from "react-bootstrap-icons";
+import {
+  ArrowRightShort,
+  CheckCircleFill,
+  PlusLg,
+  VolumeUpFill,
+} from "react-bootstrap-icons";
 import { fetchAudioPreview } from "../../../../utils/api";
 import cx from "classnames";
 
@@ -25,12 +30,16 @@ const NewPaMessagePage = () => {
   const [visualText, setVisualText] = useState("");
   const [phoneticText, setPhoneticText] = useState("");
   const [audioPlaying, setAudioPlaying] = useState(false);
+  const [audioReviewed, setAudioReviewed] = useState(false);
 
   const navigate = useNavigate();
 
   const previewAudio = () => {
     if (audioPlaying) return;
 
+    if (phoneticText.length === 0) {
+      setPhoneticText(visualText);
+    }
     setAudioPlaying(true);
     fetchAudioPreview(phoneticText.length ? phoneticText : visualText).then(
       async (audioData) => {
@@ -39,6 +48,7 @@ const NewPaMessagePage = () => {
         const audio = new Audio(url);
         audio.onended = (_e) => {
           setAudioPlaying(false);
+          setAudioReviewed(true);
           URL.revokeObjectURL(url);
         };
 
@@ -168,6 +178,7 @@ const NewPaMessagePage = () => {
                     />
                     <ReviewAudioButton
                       audioPlaying={audioPlaying}
+                      audioReviewed={audioReviewed}
                       onClick={previewAudio}
                     />
                   </>
@@ -177,6 +188,7 @@ const NewPaMessagePage = () => {
                     <Card className="review-audio-card">
                       <ReviewAudioButton
                         audioPlaying={audioPlaying}
+                        audioReviewed={audioReviewed}
                         disabled={visualText.length === 0}
                         onClick={previewAudio}
                       />
@@ -210,28 +222,60 @@ const NewPaMessagePage = () => {
 
 interface ReviewAudioButtonProps {
   audioPlaying: boolean;
+  audioReviewed: boolean;
   disabled?: boolean;
   onClick: () => void;
 }
 
 const ReviewAudioButton = ({
   audioPlaying,
+  audioReviewed,
   disabled,
   onClick,
 }: ReviewAudioButtonProps) => {
-  return (
-    <Button
-      disabled={disabled}
-      className={cx("review-audio-button", {
-        "review-audio-button--audio-playing": audioPlaying,
-      })}
-      variant="link"
-      onClick={onClick}
-    >
-      <VolumeUpFill height={12} />
-      {audioPlaying ? "Reviewing audio" : "Review audio"}
-    </Button>
-  );
+  let layout = <></>;
+  if (audioPlaying) {
+    layout = (
+      <Button
+        className="review-audio-button review-audio-button--audio-playing"
+        variant="link"
+        onClick={onClick}
+      >
+        <VolumeUpFill height={12} />
+        Reviewing audio
+      </Button>
+    );
+  } else if (audioReviewed) {
+    layout = (
+      <div className="audio-reviewed-text">
+        <span>
+          <CheckCircleFill /> Audio reviewed
+        </span>
+        <Button
+          className="review-audio-button"
+          onClick={onClick}
+          variant="link"
+        >
+          Replay
+        </Button>
+      </div>
+    );
+  } else {
+    layout = (
+      <Button
+        disabled={disabled}
+        className={cx("review-audio-button", {
+          "review-audio-button--audio-playing": audioPlaying,
+        })}
+        variant="link"
+        onClick={onClick}
+      >
+        <VolumeUpFill height={16} /> Review audio
+      </Button>
+    );
+  }
+
+  return layout;
 };
 
 export default NewPaMessagePage;

--- a/assets/js/components/Dashboard/PaMessaging/NewPaMessagePage/NewPaMessagePage.tsx
+++ b/assets/js/components/Dashboard/PaMessaging/NewPaMessagePage/NewPaMessagePage.tsx
@@ -9,6 +9,7 @@ import moment from "moment";
 import DatePicker from "../../DatePicker";
 import TimePicker from "../../TimePicker";
 import { ArrowRightShort, PlusLg, VolumeUpFill } from "react-bootstrap-icons";
+import { fetchAudioPreview } from "../../../../utils/api";
 
 const NewPaMessagePage = () => {
   const now = moment();
@@ -22,8 +23,26 @@ const NewPaMessagePage = () => {
   const [interval, setInterval] = useState("4");
   const [visualText, setVisualText] = useState("");
   const [phoneticText, setPhoneticText] = useState("");
+  const [audioPlaying, setAudioPlaying] = useState(false);
 
   const navigate = useNavigate();
+
+  const previewAudio = () => {
+    setAudioPlaying(true);
+    fetchAudioPreview(phoneticText.length ? phoneticText : visualText).then(
+      async (audioData) => {
+        const blob = await audioData.blob();
+        const url = URL.createObjectURL(blob);
+        const audio = new Audio(url);
+        audio.onended = (_e) => {
+          setAudioPlaying(false);
+          URL.revokeObjectURL(url);
+        };
+
+        audio.play();
+      }
+    );
+  };
 
   return (
     <div className="new-pa-message-page">
@@ -144,12 +163,20 @@ const NewPaMessagePage = () => {
                     label="Phonetic Audio"
                   />
                 ) : (
-                  <Card className="review-audio-card">
-                    <Button className="review-audio-button" variant="link">
-                      <VolumeUpFill height={12} />
-                      Review audio
-                    </Button>
-                  </Card>
+                  <>
+                    <div className="form-label">Phonetic Audio</div>
+                    <Card className="review-audio-card">
+                      <Button
+                        disabled={visualText.length === 0}
+                        className="review-audio-button"
+                        variant="link"
+                        onClick={previewAudio}
+                      >
+                        <VolumeUpFill height={12} />
+                        {audioPlaying ? "Reviewing audio" : "Review audio"}
+                      </Button>
+                    </Card>
+                  </>
                 )}
               </Col>
             </Row>

--- a/assets/js/components/Dashboard/PaMessaging/NewPaMessagePage/NewPaMessagePage.tsx
+++ b/assets/js/components/Dashboard/PaMessaging/NewPaMessagePage/NewPaMessagePage.tsx
@@ -10,6 +10,7 @@ import DatePicker from "../../DatePicker";
 import TimePicker from "../../TimePicker";
 import { ArrowRightShort, PlusLg, VolumeUpFill } from "react-bootstrap-icons";
 import { fetchAudioPreview } from "../../../../utils/api";
+import cx from "classnames";
 
 const NewPaMessagePage = () => {
   const now = moment();
@@ -28,6 +29,8 @@ const NewPaMessagePage = () => {
   const navigate = useNavigate();
 
   const previewAudio = () => {
+    if (audioPlaying) return;
+
     setAudioPlaying(true);
     fetchAudioPreview(phoneticText.length ? phoneticText : visualText).then(
       async (audioData) => {
@@ -40,7 +43,7 @@ const NewPaMessagePage = () => {
         };
 
         audio.play();
-      }
+      },
     );
   };
 
@@ -163,28 +166,20 @@ const NewPaMessagePage = () => {
                       disabled={phoneticText.length === 0}
                       label="Phonetic Audio"
                     />
-                    <Button
-                      className="review-audio-button"
-                      variant="link"
+                    <ReviewAudioButton
+                      audioPlaying={audioPlaying}
                       onClick={previewAudio}
-                    >
-                      <VolumeUpFill height={12} />
-                      {audioPlaying ? "Reviewing audio" : "Review audio"}
-                    </Button>
+                    />
                   </>
                 ) : (
                   <>
                     <div className="form-label">Phonetic Audio</div>
                     <Card className="review-audio-card">
-                      <Button
+                      <ReviewAudioButton
+                        audioPlaying={audioPlaying}
                         disabled={visualText.length === 0}
-                        className="review-audio-button"
-                        variant="link"
                         onClick={previewAudio}
-                      >
-                        <VolumeUpFill height={12} />
-                        {audioPlaying ? "Reviewing audio" : "Review audio"}
-                      </Button>
+                      />
                     </Card>
                   </>
                 )}
@@ -210,6 +205,32 @@ const NewPaMessagePage = () => {
         </Container>
       </Form>
     </div>
+  );
+};
+
+interface ReviewAudioButtonProps {
+  audioPlaying: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+}
+
+const ReviewAudioButton = ({
+  audioPlaying,
+  disabled,
+  onClick,
+}: ReviewAudioButtonProps) => {
+  return (
+    <Button
+      disabled={disabled}
+      className={cx("review-audio-button", {
+        "review-audio-button--audio-playing": audioPlaying,
+      })}
+      variant="link"
+      onClick={onClick}
+    >
+      <VolumeUpFill height={12} />
+      {audioPlaying ? "Reviewing audio" : "Review audio"}
+    </Button>
   );
 };
 

--- a/assets/js/utils/api.ts
+++ b/assets/js/utils/api.ts
@@ -129,3 +129,17 @@ export const publishScreensForPlace = async (
 
   return { status: response.status, message };
 };
+
+export const fetchAudioPreview = async (text: string) => {
+  return await fetch("/api/pa-messages/preview_audio", {
+    method: "POST",
+    body: JSON.stringify({ text: text }),
+    headers: {
+      "content-type": "application/json",
+      "x-csrf-token":
+        document?.head?.querySelector<HTMLMetaElement>(
+          "[name~=csrf-token][content]",
+        )?.content ?? "",
+    },
+  });
+};

--- a/assets/js/utils/api.ts
+++ b/assets/js/utils/api.ts
@@ -84,17 +84,12 @@ export const putPendingScreens = async (
   version_id: string,
 ) => {
   return await fetch("/config/put", {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-csrf-token": getCsrfToken(),
-    },
-    credentials: "include",
-    body: JSON.stringify({
+    ...postBodyAndHeaders({
       places_and_screens: placesAndScreens,
       screen_type: screenType,
       version_id: version_id,
     }),
+    credentials: "include",
   });
 };
 
@@ -104,19 +99,11 @@ export const publishScreensForPlace = async (
   hiddenFromScreenplayIds: string[],
   etag: string,
 ) => {
+  const bodyData = {
+    hidden_from_screenplay_ids: hiddenFromScreenplayIds,
+  };
   const response = await fetch(`/config/publish/${placeId}/${appId}`, {
-    method: "POST",
-    body: JSON.stringify({
-      hidden_from_screenplay_ids: hiddenFromScreenplayIds,
-    }),
-    headers: {
-      "content-type": "application/json",
-      "if-match": etag,
-      "x-csrf-token":
-        document?.head?.querySelector<HTMLMetaElement>(
-          "[name~=csrf-token][content]",
-        )?.content ?? "",
-    },
+    ...postBodyAndHeaders(bodyData, { "if-match": etag }),
     credentials: "include",
   });
 
@@ -131,15 +118,23 @@ export const publishScreensForPlace = async (
 };
 
 export const fetchAudioPreview = async (text: string) => {
-  return await fetch("/api/pa-messages/preview_audio", {
+  return await fetch(
+    "/api/pa-messages/preview_audio",
+    postBodyAndHeaders({ text: text }),
+  );
+};
+
+const postBodyAndHeaders = (
+  bodyData: { [key: string]: any },
+  extraHeaders: { [key: string]: string } = {},
+) => {
+  return {
     method: "POST",
-    body: JSON.stringify({ text: text }),
+    body: JSON.stringify(bodyData),
     headers: {
+      ...extraHeaders,
       "content-type": "application/json",
-      "x-csrf-token":
-        document?.head?.querySelector<HTMLMetaElement>(
-          "[name~=csrf-token][content]",
-        )?.content ?? "",
+      "x-csrf-token": getCsrfToken(),
     },
-  });
+  };
 };

--- a/assets/js/utils/api.ts
+++ b/assets/js/utils/api.ts
@@ -84,7 +84,7 @@ export const putPendingScreens = async (
   version_id: string,
 ) => {
   return await fetch("/config/put", {
-    ...postBodyAndHeaders({
+    ...getPostBodyAndHeaders({
       places_and_screens: placesAndScreens,
       screen_type: screenType,
       version_id: version_id,
@@ -103,7 +103,7 @@ export const publishScreensForPlace = async (
     hidden_from_screenplay_ids: hiddenFromScreenplayIds,
   };
   const response = await fetch(`/config/publish/${placeId}/${appId}`, {
-    ...postBodyAndHeaders(bodyData, { "if-match": etag }),
+    ...getPostBodyAndHeaders(bodyData, { "if-match": etag }),
     credentials: "include",
   });
 
@@ -117,14 +117,7 @@ export const publishScreensForPlace = async (
   return { status: response.status, message };
 };
 
-export const fetchAudioPreview = async (text: string) => {
-  return await fetch(
-    "/api/pa-messages/preview_audio",
-    postBodyAndHeaders({ text: text }),
-  );
-};
-
-const postBodyAndHeaders = (
+const getPostBodyAndHeaders = (
   bodyData: { [key: string]: any },
   extraHeaders: { [key: string]: string } = {},
 ) => {

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -51,7 +51,9 @@ config :screenplay,
   signs_ui_url: System.get_env("SIGNS_UI_URL"),
   alerts_ui_url: System.get_env("ALERTS_UI_URL"),
   fullstory_org_id: System.get_env("FULLSTORY_ORG_ID"),
-  api_key: System.fetch_env!("SCREENPLAY_API_KEY")
+  api_key: System.fetch_env!("SCREENPLAY_API_KEY"),
+  watts_url: System.get_env("WATTS_URL"),
+  watts_api_key: System.get_env("WATTS_API_KEY")
 
 if sentry_dsn not in [nil, ""] do
   config :sentry,

--- a/lib/screenplay/watts.ex
+++ b/lib/screenplay/watts.ex
@@ -8,7 +8,7 @@ defmodule Screenplay.Watts do
   def fetch_tts(text) do
     watts_url = Application.get_env(:screenplay, :watts_url)
     watts_api_key = Application.get_env(:screenplay, :watts_api_key)
-    request_data = Jason.encode!(%{text: text, voice_id: "Matthew"})
+    request_data = Jason.encode!(%{text: "<speak>#{text}</speak>", voice_id: "Matthew"})
 
     case HTTPoison.post(
            "#{watts_url}/tts",

--- a/lib/screenplay/watts.ex
+++ b/lib/screenplay/watts.ex
@@ -1,0 +1,39 @@
+defmodule Screenplay.Watts do
+  @moduledoc """
+  Module used to fetch TTS audio files from the Watts app.
+  """
+
+  require Logger
+
+  def fetch_tts(text) do
+    watts_url = Application.get_env(:screenplay, :watts_url)
+    watts_api_key = Application.get_env(:screenplay, :watts_api_key)
+    request_data = Jason.encode!(%{text: text, voice_id: "Matthew"})
+
+    case HTTPoison.post(
+           "#{watts_url}/tts",
+           request_data,
+           [
+             {"Content-type", "application/json"},
+             {"x-api-key", watts_api_key}
+           ]
+         ) do
+      {:ok, %{status_code: 200, body: body}} ->
+        {:ok, body}
+
+      {:ok, response} ->
+        log_error({:bad_response_code, response})
+
+      {:error, httpoison_error} ->
+        log_error({:http_post_error, httpoison_error})
+    end
+  end
+
+  defp log_error({error_type, error_data}) do
+    Logger.error(
+      "[watts_request_error] error_type=#{error_type} error_data=#{inspect(error_data)}"
+    )
+
+    :error
+  end
+end

--- a/lib/screenplay/watts.ex
+++ b/lib/screenplay/watts.ex
@@ -5,6 +5,10 @@ defmodule Screenplay.Watts do
 
   require Logger
 
+  @doc """
+  Fetches an audio file from Watts given a string.
+  """
+  @spec fetch_tts(String.t()) :: :error | {:ok, binary()}
   def fetch_tts(text) do
     watts_url = Application.fetch_env!(:screenplay, :watts_url)
     watts_api_key = Application.fetch_env!(:screenplay, :watts_api_key)

--- a/lib/screenplay/watts.ex
+++ b/lib/screenplay/watts.ex
@@ -6,8 +6,8 @@ defmodule Screenplay.Watts do
   require Logger
 
   def fetch_tts(text) do
-    watts_url = Application.get_env(:screenplay, :watts_url)
-    watts_api_key = Application.get_env(:screenplay, :watts_api_key)
+    watts_url = Application.fetch_env!(:screenplay, :watts_url)
+    watts_api_key = Application.fetch_env!(:screenplay, :watts_api_key)
     request_data = Jason.encode!(%{text: "<speak>#{text}</speak>", voice_id: "Matthew"})
 
     case HTTPoison.post(

--- a/lib/screenplay_web/controllers/pa_messages_api_controller.ex
+++ b/lib/screenplay_web/controllers/pa_messages_api_controller.ex
@@ -17,7 +17,7 @@ defmodule ScreenplayWeb.PaMessagesApiController do
         send_download(conn, {:binary, audio_data}, filename: "preview.mp3")
 
       :error ->
-        send_resp(conn, 404, "Not found")
+        send_resp(conn, 500, "Could not fetch audio preview")
     end
   end
 end

--- a/lib/screenplay_web/controllers/pa_messages_api_controller.ex
+++ b/lib/screenplay_web/controllers/pa_messages_api_controller.ex
@@ -10,4 +10,14 @@ defmodule ScreenplayWeb.PaMessagesApiController do
   def active(conn, _params) do
     json(conn, PaMessage.get_active_messages())
   end
+
+  def preview_audio(conn, %{"text" => text}) do
+    case Screenplay.Watts.fetch_tts(text) do
+      {:ok, audio_data} ->
+        send_download(conn, {:binary, audio_data})
+
+      :error ->
+        send_resp(conn, 404, "Not found")
+    end
+  end
 end

--- a/lib/screenplay_web/controllers/pa_messages_api_controller.ex
+++ b/lib/screenplay_web/controllers/pa_messages_api_controller.ex
@@ -14,7 +14,7 @@ defmodule ScreenplayWeb.PaMessagesApiController do
   def preview_audio(conn, %{"text" => text}) do
     case Screenplay.Watts.fetch_tts(text) do
       {:ok, audio_data} ->
-        send_download(conn, {:binary, audio_data})
+        send_download(conn, {:binary, audio_data}, filename: "preview.mp3")
 
       :error ->
         send_resp(conn, 404, "Not found")

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -88,7 +88,7 @@ defmodule ScreenplayWeb.Router do
     get("/pa-messages", PaMessagesController, :index)
     get("/pa-messages/new", PaMessagesController, :index)
     get("/api/pa-messages", PaMessagesApiController, :index)
-    post("/api/pa-messages/preview_audio", PaMessagesApiController, :preview_audio)
+    get("/api/pa-messages/preview_audio", PaMessagesApiController, :preview_audio)
   end
 
   scope "/", ScreenplayWeb do

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -88,6 +88,7 @@ defmodule ScreenplayWeb.Router do
     get("/pa-messages", PaMessagesController, :index)
     get("/pa-messages/new", PaMessagesController, :index)
     get("/api/pa-messages", PaMessagesApiController, :index)
+    post("/api/pa-messages/preview_audio", PaMessagesApiController, :preview_audio)
   end
 
   scope "/", ScreenplayWeb do


### PR DESCRIPTION
This PR adds the ability to preview audio for a PA message. Text that is entered is sent to Watts, which returns an audio file that is played in the browser. An error toast is displayed if the Watts call fails. While this sets up the foundation for what is need in form validation, this doesn't tackle the actual validation on form submit. I felt it was appropriate to save that for the Form Submission task. 


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207371755597657