### PR TITLE
chore: update naming for Sectional screens

### DIFF
--- a/assets/js/components/Dashboard/PermanentConfiguration/SelectScreenType.tsx
+++ b/assets/js/components/Dashboard/PermanentConfiguration/SelectScreenType.tsx
@@ -61,8 +61,8 @@ const SelectScreenTypeComponent: ComponentType = () => {
         <Col>
           <ButtonImage
             fileName="solari.png"
-            label="Solari"
-            onClick={() => selectScreenType("solari")}
+            label="Sectional"
+            onClick={() => selectScreenType("sectional")}
           />
         </Col>
       </Row>

--- a/assets/js/components/Dashboard/PlaceRow.tsx
+++ b/assets/js/components/Dashboard/PlaceRow.tsx
@@ -29,8 +29,8 @@ const typeMap: Record<string, string> = {
   gl_eink_v2: "GL E-Ink",
   bus_eink: "Bus E-Ink",
   bus_eink_v2: "Bus E-Ink",
-  solari: "Solari",
-  busway_v2: "Solari",
+  solari: "Sectional",
+  busway_v2: "Sectional",
   triptych_v2: "Triptych",
 };
 

--- a/assets/js/constants/constants.ts
+++ b/assets/js/constants/constants.ts
@@ -53,7 +53,7 @@ export const SCREEN_TYPES: { label: string; ids: string[] }[] = [
   { label: "Elevator", ids: ["elevator"] },
   { label: "PA ESS", ids: ["pa_ess"] },
   { label: "Pre Fare Duo", ids: ["pre_fare_v2"] },
-  { label: "Solari", ids: ["busway_v2", "solari"] },
+  { label: "Sectional", ids: ["busway_v2", "solari"] },
   { label: "Triptych", ids: ["triptych_v2"] },
 ];
 


### PR DESCRIPTION
Previously we decided the final "user-facing" name for `solari`/`busway_v2` screens would be "Sectional". This updates Screenplay to use the correct name.