### PR TITLE
relax permissions for root redirect

### DIFF
--- a/lib/screenplay_web/controllers/dashboard_controller.ex
+++ b/lib/screenplay_web/controllers/dashboard_controller.ex
@@ -4,4 +4,8 @@ defmodule ScreenplayWeb.DashboardController do
   def index(conn, _params) do
     render(conn, "index.html")
   end
+
+  def root_redirect(conn, _params) do
+    redirect(conn, to: ~p"/dashboard")
+  end
 end

--- a/lib/screenplay_web/controllers/outfront_takeover_tool/page_controller.ex
+++ b/lib/screenplay_web/controllers/outfront_takeover_tool/page_controller.ex
@@ -23,10 +23,6 @@ defmodule ScreenplayWeb.OutfrontTakeoverTool.PageController do
     render(conn, "index.html")
   end
 
-  def root_redirect(conn, _params) do
-    redirect(conn, to: ~p"/dashboard")
-  end
-
   def stations_and_screen_orientations(conn, _params) do
     json(conn, @stations_and_screen_orientations)
   end

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -63,13 +63,13 @@ defmodule ScreenplayWeb.Router do
       :ensure_screenplay_emergency_admin_group
     ])
 
-    get("/", PageController, :root_redirect)
     get("/emergency-takeover", PageController, :index)
   end
 
   scope "/", ScreenplayWeb do
     pipe_through([:redirect_prod_http, :browser, :auth, :ensure_auth, :metadata])
 
+    get("/", DashboardController, :root_redirect)
     get("/dashboard", DashboardController, :index)
     get("/alerts/*id", AlertsController, :index)
     get("/unauthorized", UnauthorizedController, :index)

--- a/test/screenplay_web/controllers/dashboard_controller_test.exs
+++ b/test/screenplay_web/controllers/dashboard_controller_test.exs
@@ -22,4 +22,12 @@ defmodule ScreenplayWeb.Controllers.DashboardControllerTest do
       assert %{assigns: %{username: "test_user"}}
     end
   end
+
+  describe "root_redirect/2" do
+    @tag :authenticated
+    test "redirects authenticated to /dashboard", %{conn: conn} do
+      conn = get(conn, "/")
+      assert redirected_to(conn) =~ "/dashboard"
+    end
+  end
 end

--- a/test/screenplay_web/controllers/outfront_takeover_tool/page_controller_test.exs
+++ b/test/screenplay_web/controllers/outfront_takeover_tool/page_controller_test.exs
@@ -19,18 +19,4 @@ defmodule ScreenplayWeb.OutfrontTakeoverTool.PageControllerTest do
       assert %{status: 302} = conn
     end
   end
-
-  describe "root_redirect/2" do
-    @tag :authenticated_emergency_admin
-    test "redirects admin to /dashboard", %{conn: conn} do
-      conn = get(conn, "/")
-      assert redirected_to(conn) =~ "/dashboard"
-    end
-
-    @tag :authenticated
-    test "does not redirect non-admin to /dashboard", %{conn: conn} do
-      conn = get(conn, "/")
-      assert redirected_to(conn) =~ "/unauthorized"
-    end
-  end
 end


### PR DESCRIPTION
**Asana task**: [Revise Screenplay entry URL](https://app.asana.com/0/1185117109217413/1206753590642890/f)

This fixes an issue where the root redirect is gated by the emergency takeover permission, so non-admins don't get redirected to the dashboard. This required moving the redirect to another controller to avoid creating a new scope, since all the `OutfrontTakeoverTool` scopes currently enforce this permission.