### PR TITLE
fix: Publish error fixes

### DIFF
--- a/lib/screenplay/config/fetch.ex
+++ b/lib/screenplay/config/fetch.ex
@@ -1,10 +1,14 @@
 defmodule Screenplay.Config.Fetch do
   @moduledoc false
 
-  @callback get_places_and_screens() :: {:ok, term()} | :error
-  @callback get_locations() :: {:ok, term()} | :error
-  @callback get_place_descriptions() :: {:ok, term()} | :error
-  @callback put_config(String.t()) :: :ok | :error
+  alias Screenplay.Config.PlaceAndScreens
+
+  @type version_id :: String.t()
+
+  @callback get_places_and_screens() :: {:ok, list(map()), String.t()} | :error
+  @callback get_locations() :: {:ok, list(map()), version_id()} | :error
+  @callback get_place_descriptions() :: {:ok, list(map()), version_id()} | :error
+  @callback put_config(list(PlaceAndScreens.t())) :: :ok | :error
   @callback commit() :: :ok
-  @callback revert(String.t()) :: :ok
+  @callback revert(version_id()) :: any()
 end

--- a/lib/screenplay/config/fetch.ex
+++ b/lib/screenplay/config/fetch.ex
@@ -5,7 +5,8 @@ defmodule Screenplay.Config.Fetch do
 
   @type version_id :: String.t()
 
-  @callback get_places_and_screens() :: {:ok, list(map()), String.t()} | :error
+  # All logic assumes that the configs will always be a list of maps.
+  @callback get_places_and_screens() :: {:ok, list(map()), version_id()} | :error
   @callback get_locations() :: {:ok, list(map()), version_id()} | :error
   @callback get_place_descriptions() :: {:ok, list(map()), version_id()} | :error
   @callback put_config(list(PlaceAndScreens.t())) :: :ok | :error

--- a/lib/screenplay/config/local_fetch.ex
+++ b/lib/screenplay/config/local_fetch.ex
@@ -50,7 +50,10 @@ defmodule Screenplay.Config.LocalFetch do
   @impl true
   # sobelow_skip ["Traversal.FileModule"]
   def commit do
-    File.rm!(local_path(:local_config_file_spec) <> ".temp")
+    case File.rm(local_path(:local_config_file_spec) <> ".temp") do
+      {:error, reason} when reason != :enoent -> :error
+      _ -> :ok
+    end
   end
 
   @impl true

--- a/lib/screenplay/config/local_fetch.ex
+++ b/lib/screenplay/config/local_fetch.ex
@@ -8,6 +8,8 @@ defmodule Screenplay.Config.LocalFetch do
     with {:ok, config_contents, version_id} <- do_get(:local_config_file_spec),
          {:ok, config_json} <- do_decode(config_contents, :local_config_file_spec) do
       {:ok, config_json, version_id}
+    else
+      _ -> :error
     end
   end
 
@@ -16,6 +18,8 @@ defmodule Screenplay.Config.LocalFetch do
     with {:ok, config_contents, version_id} <- do_get(:local_locations_file_spec),
          {:ok, config_json} <- do_decode(config_contents, :local_locations_file_spec) do
       {:ok, config_json, version_id}
+    else
+      _ -> :error
     end
   end
 
@@ -24,6 +28,8 @@ defmodule Screenplay.Config.LocalFetch do
     with {:ok, config_contents, version_id} <- do_get(:local_place_descriptions_file_spec),
          {:ok, config_json} <- do_decode(config_contents, :local_place_descriptions_file_spec) do
       {:ok, config_json, version_id}
+    else
+      _ -> :error
     end
   end
 

--- a/lib/screenplay/config/permanent_config.ex
+++ b/lib/screenplay/config/permanent_config.ex
@@ -4,7 +4,7 @@ defmodule Screenplay.Config.PermanentConfig do
   # Suppress dialyzer warning until more app_ids are implemented.
   @dialyzer [{:nowarn_function, get_route_id: 3}, {:nowarn_function, json_to_struct: 4}]
 
-  alias Screenplay.Config.PlaceAndScreens
+  alias Screenplay.Config.{Fetch, PlaceAndScreens}
   alias Screenplay.PendingScreensConfig.Fetch, as: PendingScreensFetch
   alias Screenplay.RoutePatterns.RoutePattern
   alias Screenplay.ScreensConfig.Cache, as: ScreensConfigCache
@@ -86,7 +86,7 @@ defmodule Screenplay.Config.PermanentConfig do
     }
   end
 
-  @spec put_pending_screens(map(), screen_type(), binary()) ::
+  @spec put_pending_screens(map(), screen_type(), Fetch.version_id()) ::
           {:error,
            :version_mismatch
            | :config_not_fetched

--- a/lib/screenplay/config/permanent_config.ex
+++ b/lib/screenplay/config/permanent_config.ex
@@ -149,9 +149,7 @@ defmodule Screenplay.Config.PermanentConfig do
     new_published_screens_config = get_new_published_screens(published_config, screens_to_publish)
 
     screenplay_screens_to_add =
-      screens_to_publish
-      |> Enum.into(%{})
-      |> Enum.reject(fn {_, screen} -> screen.hidden_from_screenplay end)
+      Enum.reject(screens_to_publish, fn {_, screen} -> screen.hidden_from_screenplay end)
 
     new_places_and_screens_config =
       get_new_places_and_screens_config(places_and_screens_config, screenplay_screens_to_add)

--- a/lib/screenplay/config/permanent_config.ex
+++ b/lib/screenplay/config/permanent_config.ex
@@ -148,12 +148,17 @@ defmodule Screenplay.Config.PermanentConfig do
 
     new_published_screens_config = get_new_published_screens(published_config, screens_to_publish)
 
+    screenplay_screens_to_add =
+      screens_to_publish
+      |> Enum.into(%{})
+      |> Enum.reject(fn {_, screen} -> screen.hidden_from_screenplay end)
+
     new_places_and_screens_config =
-      get_new_places_and_screens_config(places_and_screens_config, screens_to_publish)
+      get_new_places_and_screens_config(places_and_screens_config, screenplay_screens_to_add)
 
     with :ok <- PendingScreensFetch.put_config(new_pending_screens_config),
          :ok <- PublishedScreensFetch.put_config(new_published_screens_config),
-         :ok <- @config_fetcher.put_config(new_places_and_screens_config) do
+         :ok <- put_places_and_screens(new_places_and_screens_config, screenplay_screens_to_add) do
       PendingScreensFetch.commit()
       PublishedScreensFetch.commit()
       @config_fetcher.commit()
@@ -166,6 +171,9 @@ defmodule Screenplay.Config.PermanentConfig do
         :error
     end
   end
+
+  defp put_places_and_screens(_, []), do: :ok
+  defp put_places_and_screens(new_config, _), do: @config_fetcher.put_config(new_config)
 
   defp check_for_duplicate_screen_ids(
          deserialized,
@@ -420,15 +428,13 @@ defmodule Screenplay.Config.PermanentConfig do
     end
   end
 
-  defp get_new_places_and_screens_config(places_and_screens_config, new_published_screens) do
+  defp get_new_places_and_screens_config(places_and_screens_config, screens_to_add) do
     places_and_screens_config =
       Enum.map(places_and_screens_config, &PlaceAndScreens.from_map/1)
 
     grouped_places_and_screens =
-      new_published_screens
-      |> Enum.into(%{})
-      |> Enum.reject(fn {_, screen} -> screen.hidden_from_screenplay end)
-      |> Enum.group_by(
+      Enum.group_by(
+        screens_to_add,
         fn
           {_, %Screen{app_id: :gl_eink_v2} = config} ->
             config.app_params.footer.stop_id

--- a/lib/screenplay/config/s3_fetch.ex
+++ b/lib/screenplay/config/s3_fetch.ex
@@ -37,9 +37,15 @@ defmodule Screenplay.Config.S3Fetch do
 
   @impl true
   def put_config(file_contents) do
+    encoded_contents =
+      case Jason.encode(file_contents, pretty: true) do
+        {:ok, contents} -> contents
+        {:error, _} -> :error
+      end
+
     bucket = Application.get_env(:screenplay, :config_s3_bucket)
     path = config_path_for_environment(:config)
-    put_operation = ExAws.S3.put_object(bucket, path, file_contents)
+    put_operation = ExAws.S3.put_object(bucket, path, encoded_contents)
 
     case ExAws.request(put_operation) do
       {:ok, %{status_code: 200}} -> :ok


### PR DESCRIPTION
**Asana task**: [[extra] Screenplay prod crash in PermConfig when trying to publish changes](https://app.asana.com/0/1185117109217413/1207697513391315/f)

Some context from Slack: https://mbta.slack.com/archives/G012H4G4U06/p1719868261122079?thread_ts=1719859672.363579&cid=G012H4G4U06.

Tl;dr, Ana had trouble publishing screens due to an error when trying to upload a new `places_and_screens` file to S3. Two big problems here:
1. The data we send to S3 wasn't being encoded. That's the reason for the Sentry error.
2. We shouldn't bother with talking to S3 if we know the config isn't changing.

We know the config isn't changing here because Ana checked `Hide on Places page` for each of the pending screens. This results in no changes to `places_and_screens`.
