### PR TITLE
fix: Handle empty alerts response

### DIFF
--- a/lib/screenplay/alerts/parser.ex
+++ b/lib/screenplay/alerts/parser.ex
@@ -1,9 +1,9 @@
 defmodule Screenplay.Alerts.Parser do
   @moduledoc false
 
-  def parse_result(%{"data" => data, "included" => included}) when is_list(data) do
+  def parse_result(%{"data" => data} = result) when is_list(data) do
     data
-    |> Enum.map(&parse_alert(&1, included))
+    |> Enum.map(&parse_alert(&1, result["included"]))
     |> Enum.reject(&is_nil/1)
   end
 

--- a/test/screenplay/alerts/alert_test.exs
+++ b/test/screenplay/alerts/alert_test.exs
@@ -75,6 +75,7 @@ defmodule Screenplay.Alerts.AlertTest do
 
       assert {:ok, [%Alert{id: "1"}, %Alert{id: "2"}]} = Alert.fetch(get_json_fn)
     end
+
     test "returns :error if fetch function returns :error", context do
       %{
         x_get_json_fn: x_get_json_fn

--- a/test/screenplay/alerts/alert_test.exs
+++ b/test/screenplay/alerts/alert_test.exs
@@ -63,6 +63,12 @@ defmodule Screenplay.Alerts.AlertTest do
               ]} = Alert.fetch(get_json_fn)
     end
 
+    test "returns {:ok, []} if fetch function returns an empty alerts list" do
+      get_json_fn = fn _, _ -> {:ok, %{"data" => []}} end
+
+      assert {:ok, []} = Alert.fetch(get_json_fn)
+    end
+
     test "returns :error if fetch function returns :error", context do
       %{
         x_get_json_fn: x_get_json_fn

--- a/test/screenplay/alerts/alert_test.exs
+++ b/test/screenplay/alerts/alert_test.exs
@@ -69,6 +69,12 @@ defmodule Screenplay.Alerts.AlertTest do
       assert {:ok, []} = Alert.fetch(get_json_fn)
     end
 
+    test "returns {:ok, alerts} if fetch function does not return an `include` key" do
+      alerts = [alert_json("1"), alert_json("2")]
+      get_json_fn = fn _, _ -> {:ok, %{"data" => alerts}} end
+
+      assert {:ok, [%Alert{id: "1"}, %Alert{id: "2"}]} = Alert.fetch(get_json_fn)
+    end
     test "returns :error if fetch function returns :error", context do
       %{
         x_get_json_fn: x_get_json_fn


### PR DESCRIPTION
**Asana task**: ad-hoc

[Sentry link](https://mbtace.sentry.io/issues/5578657101/events/19a162f2a5394441834f3caa08dade88/)

The Parser logic assumed we would always receive alerts from the API. Over the weekend, there seems to have been a blip and no alerts were returned. This small tweak should allow the server to respond appropriately in that case.
