### PR TITLE
fix: ignore lab sign in places script

### DIFF
--- a/scripts/paess_labels.json
+++ b/scripts/paess_labels.json
@@ -1,4 +1,5 @@
 {
+  "201-m": null,
   "OOAK-s": "Platform",
   "OOAK-e": "Busway",
   "OMAL-n": "Platform",


### PR DESCRIPTION
Similar to how other screens can be marked `hidden_from_screenplay`, this enables flagging specific PA/ESS signs that we don't want shown in Screenplay. This fixes the issue that the output of `build_places.exs` was no longer directly uploadable since the addition of the lab sign, and had to be manually tweaked to remove it.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207943699921831