### PR TITLE
chore: remove "Search" and "Advanced Search" buttons

### DIFF
--- a/assets/js/components/Dashboard/PaMessagesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessagesPage.tsx
@@ -33,12 +33,13 @@ const PaMessagesPage: ComponentType = () => {
                   Add New
                 </Link>
               </Col>
-              <Col className="pa-message-table-action-bar__search">
+              {/* Can remove for now because this will not be implemented until after MVP launch */}
+              {/* <Col className="pa-message-table-action-bar__search">
                 <div>Search</div>
-              </Col>
-              <Col className="pa-message-table-action-bar__advance-search">
+              </Col> */}
+              {/* <Col className="pa-message-table-action-bar__advance-search">
                 <a href="/pa-messages">Advance Search</a>
-              </Col>
+              </Col> */}
             </Row>
             <Row>
               <PaMessageTable paMessages={paMessages} />


### PR DESCRIPTION
Comments out these buttons because they don't do anything yet. They can be shown again when the features they are intended link to are built.