### PR TITLE
fix: positioning and color of webkit calendar icon.

### DIFF
--- a/assets/css/dashboard/new-pa-message/new-pa-message-page.scss
+++ b/assets/css/dashboard/new-pa-message/new-pa-message-page.scss
@@ -286,7 +286,16 @@
     }
   }
 
-  input::-webkit-calendar-picker-indicator {
-    display: none;
+  input[type="time"],
+  input[type="date"] {
+    position: relative;
+    &::-webkit-calendar-picker-indicator {
+      filter: invert(0.75);
+
+      position: absolute;
+      right: 0;
+      margin-right: 8px;
+      color: $text-secondary;
+    }
   }
 }


### PR DESCRIPTION
Forgot to unhide the calendar icon in webkit browsers. Once I fixed that, I noticed they were black making them hard to see. Once I fixed that, I noticed the positioning was also not right. Position and color should now be consistent across browsers.