### PR TITLE
feat: New Messages backend

### DIFF
--- a/lib/screenplay/pa_messages.ex
+++ b/lib/screenplay/pa_messages.ex
@@ -31,4 +31,13 @@ defmodule Screenplay.PaMessages do
     |> PaMessage.Queries.active(now)
     |> Repo.all()
   end
+
+  @doc """
+  Creates a new PA Message.
+  """
+  @spec create_message(message :: map()) ::
+          {:ok, PaMessage.t()} | {:error, Ecto.Changeset.t()}
+  def create_message(message) do
+    %PaMessage{} |> PaMessage.changeset(message) |> Repo.insert()
+  end
 end

--- a/lib/screenplay/pa_messages/pa_message.ex
+++ b/lib/screenplay/pa_messages/pa_message.ex
@@ -75,7 +75,7 @@ defmodule Screenplay.PaMessages.PaMessage do
     alert_id = get_field(changeset, :alert_id)
 
     if is_nil(end_time) and is_nil(alert_id) do
-      add_error(changeset, :end_time, "can't be nil if alert_id is nil")
+      add_error(changeset, :end_time, "cannot have an end time if associated with an alert")
     else
       changeset
     end

--- a/lib/screenplay/pa_messages/pa_message.ex
+++ b/lib/screenplay/pa_messages/pa_message.ex
@@ -3,6 +3,7 @@ defmodule Screenplay.PaMessages.PaMessage do
   Represents a PA Message that will be retrieved by RTS to play audio in stations.
   """
   use Ecto.Schema
+  import Ecto.Changeset
 
   @derive {Jason.Encoder, except: [:__meta__]}
 
@@ -38,5 +39,33 @@ defmodule Screenplay.PaMessages.PaMessage do
     field(:message_type, :string)
 
     timestamps(type: :utc_datetime)
+  end
+
+  def changeset(message, attrs \\ %{}) do
+    message
+    |> cast(attrs, [
+      :alert_id,
+      :start_time,
+      :end_time,
+      :days_of_week,
+      :sign_ids,
+      :priority,
+      :interval_in_minutes,
+      :visual_text,
+      :audio_text,
+      :paused,
+      :saved
+    ])
+    |> validate_required([
+      :start_time,
+      :days_of_week,
+      :sign_ids,
+      :priority,
+      :interval_in_minutes,
+      :visual_text,
+      :audio_text
+    ])
+    |> validate_length(:sign_ids, min: 1)
+    |> validate_subset(:days_of_week, 1..7)
   end
 end

--- a/lib/screenplay/pa_messages/pa_message.ex
+++ b/lib/screenplay/pa_messages/pa_message.ex
@@ -67,5 +67,17 @@ defmodule Screenplay.PaMessages.PaMessage do
     ])
     |> validate_length(:sign_ids, min: 1)
     |> validate_subset(:days_of_week, 1..7)
+    |> validate_end_date()
+  end
+
+  defp validate_end_date(changeset) do
+    end_time = get_field(changeset, :end_time)
+    alert_id = get_field(changeset, :alert_id)
+
+    if is_nil(end_time) and is_nil(alert_id) do
+      add_error(changeset, :end_time, "can't be nil if alert_id is nil")
+    else
+      changeset
+    end
   end
 end

--- a/lib/screenplay/util.ex
+++ b/lib/screenplay/util.ex
@@ -20,4 +20,11 @@ defmodule Screenplay.Util do
     |> DateTime.add(-180, :minute)
     |> Date.day_of_week()
   end
+
+  @spec format_changeset_errors(changeset :: Ecto.Changeset.t()) :: String.t()
+  def format_changeset_errors(changeset) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(fn {msg, _} -> msg end)
+    |> Enum.map_join(", ", fn {field, msg} -> "#{field}: #{msg}" end)
+  end
 end

--- a/lib/screenplay_web/controllers/changeset_json.ex
+++ b/lib/screenplay_web/controllers/changeset_json.ex
@@ -8,6 +8,5 @@ defmodule ScreenplayWeb.ChangesetJSON do
     # When encoded, the changeset returns its errors
     # as a JSON object. So we just pass it forward.
     %{errors: Ecto.Changeset.traverse_errors(changeset, &translate_error/1)}
-    |> Jason.encode!()
   end
 end

--- a/lib/screenplay_web/controllers/changeset_json.ex
+++ b/lib/screenplay_web/controllers/changeset_json.ex
@@ -1,0 +1,13 @@
+defmodule ScreenplayWeb.ChangesetJSON do
+  import ScreenplayWeb.ErrorHelpers, only: [translate_error: 1]
+
+  @doc """
+  Renders changeset errors.
+  """
+  def error(%{changeset: changeset}) do
+    # When encoded, the changeset returns its errors
+    # as a JSON object. So we just pass it forward.
+    %{errors: Ecto.Changeset.traverse_errors(changeset, &translate_error/1)}
+    |> Jason.encode!()
+  end
+end

--- a/lib/screenplay_web/controllers/fallback_controller.ex
+++ b/lib/screenplay_web/controllers/fallback_controller.ex
@@ -1,0 +1,10 @@
+defmodule ScreenplayWeb.FallbackController do
+  use ScreenplayWeb, :controller
+
+  def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(ScreenplayWeb.ChangesetJSON)
+    |> render(:error, changeset: changeset)
+  end
+end

--- a/lib/screenplay_web/controllers/fallback_controller.ex
+++ b/lib/screenplay_web/controllers/fallback_controller.ex
@@ -4,7 +4,7 @@ defmodule ScreenplayWeb.FallbackController do
   def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
     conn
     |> put_status(:unprocessable_entity)
-    |> put_view(ScreenplayWeb.ChangesetJSON)
+    |> put_view(json: ScreenplayWeb.ChangesetJSON)
     |> render(:error, changeset: changeset)
   end
 end

--- a/lib/screenplay_web/controllers/pa_messages_api_controller.ex
+++ b/lib/screenplay_web/controllers/pa_messages_api_controller.ex
@@ -3,7 +3,9 @@ defmodule ScreenplayWeb.PaMessagesApiController do
 
   require Logger
 
-  alias Screenplay.{PaMessages, Util}
+  action_fallback ScreenplayWeb.FallbackController
+
+  alias Screenplay.PaMessages
 
   def index(conn, _params) do
     json(conn, PaMessages.get_all_messages())
@@ -24,13 +26,8 @@ defmodule ScreenplayWeb.PaMessagesApiController do
   end
 
   def create(conn, params) do
-    case PaMessages.create_message(params) do
-      {:ok, _} ->
-        json(conn, %{success: true})
-
-      {:error, changeset} ->
-        Logger.error("[pa_message create] #{Util.format_changeset_errors(changeset)}")
-        send_resp(conn, 500, "Could not create message")
+    with {:ok, _} <- PaMessages.create_message(params) do
+      json(conn, %{success: true})
     end
   end
 end

--- a/lib/screenplay_web/controllers/pa_messages_api_controller.ex
+++ b/lib/screenplay_web/controllers/pa_messages_api_controller.ex
@@ -3,7 +3,7 @@ defmodule ScreenplayWeb.PaMessagesApiController do
 
   require Logger
 
-  alias Screenplay.PaMessages
+  alias Screenplay.{PaMessages, Util}
 
   def index(conn, _params) do
     json(conn, PaMessages.get_all_messages())
@@ -28,8 +28,8 @@ defmodule ScreenplayWeb.PaMessagesApiController do
       {:ok, _} ->
         json(conn, %{success: true})
 
-      {:error, error} ->
-        Logger.error(inspect(error))
+      {:error, changeset} ->
+        Logger.error("[pa_message create] #{Util.format_changeset_errors(changeset)}")
         send_resp(conn, 500, "Could not create message")
     end
   end

--- a/lib/screenplay_web/controllers/pa_messages_api_controller.ex
+++ b/lib/screenplay_web/controllers/pa_messages_api_controller.ex
@@ -1,8 +1,6 @@
 defmodule ScreenplayWeb.PaMessagesApiController do
   use ScreenplayWeb, :controller
 
-  require Logger
-
   action_fallback ScreenplayWeb.FallbackController
 
   alias Screenplay.PaMessages

--- a/lib/screenplay_web/controllers/pa_messages_api_controller.ex
+++ b/lib/screenplay_web/controllers/pa_messages_api_controller.ex
@@ -1,6 +1,8 @@
 defmodule ScreenplayWeb.PaMessagesApiController do
   use ScreenplayWeb, :controller
 
+  require Logger
+
   alias Screenplay.PaMessages
 
   def index(conn, _params) do
@@ -21,7 +23,14 @@ defmodule ScreenplayWeb.PaMessagesApiController do
     end
   end
 
-  def create(conn, _) do
-    json(conn, %{success: true})
+  def create(conn, params) do
+    case PaMessages.create_message(params) do
+      {:ok, _} ->
+        json(conn, %{success: true})
+
+      {:error, error} ->
+        Logger.error(inspect(error))
+        send_resp(conn, 500, "Could not create message")
+    end
   end
 end

--- a/lib/screenplay_web/controllers/pa_messages_api_controller.ex
+++ b/lib/screenplay_web/controllers/pa_messages_api_controller.ex
@@ -20,4 +20,8 @@ defmodule ScreenplayWeb.PaMessagesApiController do
         send_resp(conn, 500, "Could not fetch audio preview")
     end
   end
+
+  def create(conn, _) do
+    json(conn, %{success: true})
+  end
 end

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -87,9 +87,21 @@ defmodule ScreenplayWeb.Router do
 
     get("/pa-messages", PaMessagesController, :index)
     get("/pa-messages/new", PaMessagesController, :index)
-    get("/api/pa-messages", PaMessagesApiController, :index)
     get("/api/pa-messages/preview_audio", PaMessagesApiController, :preview_audio)
-    post("/api/pa-messages", PaMessagesApiController, :create)
+  end
+
+  scope "/", ScreenplayWeb do
+    pipe_through [
+      :redirect_prod_http,
+      :api,
+      :auth,
+      :ensure_auth,
+      :metadata,
+      :ensure_pa_message_admin
+    ]
+
+    get "/api/pa-messages", PaMessagesApiController, :index
+    post "/api/pa-messages", PaMessagesApiController, :create
   end
 
   scope "/", ScreenplayWeb do

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -89,7 +89,7 @@ defmodule ScreenplayWeb.Router do
     get("/pa-messages/new", PaMessagesController, :index)
     get("/api/pa-messages", PaMessagesApiController, :index)
     get("/api/pa-messages/preview_audio", PaMessagesApiController, :preview_audio)
-    post("/create", PaMessagesApiController, :create)
+    post("/api/pa-messages/create", PaMessagesApiController, :create)
   end
 
   scope "/", ScreenplayWeb do

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -89,7 +89,7 @@ defmodule ScreenplayWeb.Router do
     get("/pa-messages/new", PaMessagesController, :index)
     get("/api/pa-messages", PaMessagesApiController, :index)
     get("/api/pa-messages/preview_audio", PaMessagesApiController, :preview_audio)
-    post("/api/pa-messages/create", PaMessagesApiController, :create)
+    post("/api/pa-messages", PaMessagesApiController, :create)
   end
 
   scope "/", ScreenplayWeb do

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -89,6 +89,7 @@ defmodule ScreenplayWeb.Router do
     get("/pa-messages/new", PaMessagesController, :index)
     get("/api/pa-messages", PaMessagesApiController, :index)
     get("/api/pa-messages/preview_audio", PaMessagesApiController, :preview_audio)
+    post("/create", PaMessagesApiController, :create)
   end
 
   scope "/", ScreenplayWeb do

--- a/test/screenplay/pa_messages_test.exs
+++ b/test/screenplay/pa_messages_test.exs
@@ -129,6 +129,53 @@ defmodule Screenplay.PaMessagesTest do
     assert [%PaMessage{id: 1}] = PaMessages.get_active_messages(now)
   end
 
+  describe "create/1" do
+    test "creates new message" do
+      now = ~U[2024-08-07T12:12:12Z]
+
+      new_message = %{
+        start_time: now,
+        end_time: DateTime.add(now, 60),
+        days_of_week: [1, 2, 3],
+        sign_ids: ["test_sign"],
+        priority: 1,
+        interval_in_minutes: 4,
+        visual_text: "Visual Text",
+        audio_text: "Audio Text"
+      }
+
+      assert {:ok, actual} = PaMessages.create_message(new_message)
+      assert actual.start_time == new_message.start_time
+      assert actual.end_time == new_message.end_time
+      assert actual.days_of_week == new_message.days_of_week
+      assert actual.sign_ids == new_message.sign_ids
+      assert actual.priority == new_message.priority
+      assert actual.interval_in_minutes == new_message.interval_in_minutes
+      assert actual.visual_text == new_message.visual_text
+      assert actual.audio_text == new_message.audio_text
+    end
+
+    test "does not create invalid message" do
+      now = DateTime.utc_now()
+
+      new_message = %{
+        start_time: now,
+        end_time: DateTime.add(now, 60),
+        days_of_week: [22],
+        sign_ids: [],
+        priority: 1,
+        visual_text: "",
+        audio_text: "Audio Text"
+      }
+
+      assert {:error, %Ecto.Changeset{} = changeset} = PaMessages.create_message(new_message)
+      assert {_, _} = changeset.errors[:days_of_week]
+      assert {_, _} = changeset.errors[:sign_ids]
+      assert {_, _} = changeset.errors[:interval_in_minutes]
+      assert {_, _} = changeset.errors[:visual_text]
+    end
+  end
+
   defp alert_json(id, start_dt, end_dt) do
     %{
       "id" => id,

--- a/test/screenplay/pa_messages_test.exs
+++ b/test/screenplay/pa_messages_test.exs
@@ -97,7 +97,7 @@ defmodule Screenplay.PaMessagesTest do
   test "returns messages linked to an existing alert using custom schedule" do
     now = ~U[2024-05-01T12:00:00Z]
 
-    get_json_fn = fn "alerts", %{"include" => "routes"} ->
+    get_json_fn = fn "/alerts", %{"include" => "routes"} ->
       {:ok,
        %{
          "data" => [

--- a/test/screenplay_web/controllers/pa_messages_api_controller_test.exs
+++ b/test/screenplay_web/controllers/pa_messages_api_controller_test.exs
@@ -65,4 +65,44 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
                |> json_response(200)
     end
   end
+
+  describe "POST /api/pa-messages" do
+    @tag :authenticated_pa_message_admin
+    test "creates a new PaMessage", %{conn: conn} do
+      now = ~U[2024-08-07T12:12:12Z]
+
+      assert %{"success" => true} =
+               conn
+               |> post("/api/pa-messages", %{
+                 start_time: now,
+                 end_time: DateTime.add(now, 60),
+                 days_of_week: [1, 2, 3],
+                 sign_ids: ["test_sign"],
+                 priority: 1,
+                 interval_in_minutes: 4,
+                 visual_text: "Visual Text",
+                 audio_text: "Audio Text"
+               })
+               |> json_response(200)
+    end
+
+    @tag :authenticated_pa_message_admin
+    test "returns an error object when passed invalid params", %{conn: conn} do
+      now = ~U[2024-08-07T12:12:12Z]
+
+      assert %{"errors" => _} =
+               conn
+               |> post("/api/pa-messages", %{
+                 start_time: now,
+                 end_time: DateTime.add(now, 60),
+                 days_of_week: [1, 2, 3, 90],
+                 sign_ids: ["test_sign"],
+                 priority: 1,
+                 interval_in_minutes: 4,
+                 visual_text: "Visual Text",
+                 audio_text: "Audio Text"
+               })
+               |> json_response(422)
+    end
+  end
 end


### PR DESCRIPTION
This PR adds an endpoint that can be used to create new PA messages. Although the client should catch any validation errors before the DB insert, I thought it was appropriate to add some changeset validation.