### PR TITLE
feat: support filtering by message state (past, active, future)

### DIFF
--- a/lib/screenplay/pa_messages/pa_message/queries.ex
+++ b/lib/screenplay/pa_messages/pa_message/queries.ex
@@ -10,6 +10,19 @@ defmodule Screenplay.PaMessages.PaMessage.Queries do
   alias Screenplay.PaMessages.PaMessage
   alias Screenplay.Util
 
+  def state(q \\ PaMessage, state, alert_ids, now)
+  def state(q, :past, alert_ids, now), do: past(q, alert_ids, now)
+  def state(q, :active, alert_ids, now), do: active(q, alert_ids, now)
+  def state(q, :future, _alert_ids, now), do: future(q, now)
+  def state(q, :all, _, _), do: q
+
+  @doc """
+  Limit the query to only PaMessages that are currently active.
+
+  A PaMessage is considered "active" if its start time is in the past and
+  either its end time is in the future or it has no end time and its associated
+  alert is in passed list of alert IDs.
+  """
   @spec active(queryable :: Ecto.Queryable.t(), alert_ids :: [String.t()], now :: DateTime.t()) ::
           Ecto.Query.t()
   def active(q \\ PaMessage, alert_ids, now) do
@@ -20,5 +33,15 @@ defmodule Screenplay.PaMessages.PaMessage.Queries do
         ^current_service_day_of_week in m.days_of_week and
           m.start_time <= ^now and
           ((is_nil(m.end_time) and m.alert_id in ^alert_ids) or m.end_time >= ^now)
+  end
+
+  @doc "Limit the query to only PaMessages that are in the past"
+  def past(q \\ PaMessage, alert_ids, now) do
+    from m in q, where: m.end_time < ^now or (is_nil(m.end_time) and m.alert_id not in ^alert_ids)
+  end
+
+  @doc "Limit the query to only PaMessages that are scheduled for the future"
+  def future(q \\ PaMessage, now) do
+    from m in q, where: ^now < m.start_time
   end
 end

--- a/lib/screenplay_web/controllers/pa_messages_api_controller.ex
+++ b/lib/screenplay_web/controllers/pa_messages_api_controller.ex
@@ -4,9 +4,13 @@ defmodule ScreenplayWeb.PaMessagesApiController do
   action_fallback ScreenplayWeb.FallbackController
 
   alias Screenplay.PaMessages
+  alias Screenplay.PaMessages.ListParams
 
-  def index(conn, _params) do
-    json(conn, PaMessages.get_all_messages())
+  def index(conn, params) do
+    with {:ok, opts} <- ListParams.parse(params) do
+      pa_messages = PaMessages.list_pa_messages(opts)
+      json(conn, pa_messages)
+    end
   end
 
   def active(conn, _params) do

--- a/test/screenplay_web/controllers/pa_messages_api_controller_test.exs
+++ b/test/screenplay_web/controllers/pa_messages_api_controller_test.exs
@@ -47,7 +47,7 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
         id: 1,
         start_time: ~U[2024-05-01T01:00:00Z],
         end_time: ~U[2024-05-01T13:00:00Z],
-        days_of_week: [3],
+        days_of_week: [1, 2, 3, 4, 5, 6, 7],
         inserted_at: ~U[2024-05-01T01:00:00Z]
       })
 
@@ -55,13 +55,106 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
         id: 2,
         start_time: ~U[2024-05-02T12:00:00Z],
         end_time: ~U[2024-05-02T12:00:00Z],
-        days_of_week: [3],
+        days_of_week: [1, 2, 3, 4, 5, 6, 7],
         inserted_at: ~U[2024-05-02T12:00:00Z]
       })
 
       assert [%{"id" => 2}, %{"id" => 1}] =
                conn
                |> get("/api/pa-messages")
+               |> json_response(200)
+    end
+
+    @tag :authenticated_pa_message_admin
+    test "responds with only the active messages when filtered by state=active", %{conn: conn} do
+      now = "2024-08-06T15:10:00Z"
+
+      insert(:pa_message, %{
+        id: 1,
+        days_of_week: [1, 2, 3, 4, 5, 6, 7],
+        start_time: ~U[2024-08-04 00:00:00Z],
+        end_time: ~U[2024-08-05 23:59:59Z]
+      })
+
+      insert(:pa_message, %{
+        id: 2,
+        days_of_week: [1, 2, 3, 4, 5, 6, 7],
+        start_time: ~U[2024-08-05 00:00:00Z],
+        end_time: ~U[2024-08-06 23:59:59Z]
+      })
+
+      insert(:pa_message, %{
+        id: 3,
+        days_of_week: [1, 2, 3, 4, 5, 6, 7],
+        start_time: ~U[2024-08-07 00:00:00Z],
+        end_time: ~U[2024-08-08 23:59:59Z]
+      })
+
+      assert [%{"id" => 2}] =
+               conn
+               |> get("/api/pa-messages?state=active&now=#{now}")
+               |> json_response(200)
+    end
+
+    @tag :authenticated_pa_message_admin
+    test "responds with only the past messages when filtered by state=past", %{conn: conn} do
+      now = "2024-08-06T15:10:00Z"
+
+      insert(:pa_message, %{
+        id: 1,
+        days_of_week: [1, 2, 3, 4, 5, 6, 7],
+        start_time: ~U[2024-08-04 00:00:00Z],
+        end_time: ~U[2024-08-05 23:59:59Z]
+      })
+
+      insert(:pa_message, %{
+        id: 2,
+        days_of_week: [1, 2, 3, 4, 5, 6, 7],
+        start_time: ~U[2024-08-05 00:00:00Z],
+        end_time: ~U[2024-08-06 23:59:59Z]
+      })
+
+      insert(:pa_message, %{
+        id: 3,
+        days_of_week: [1, 2, 3, 4, 5, 6, 7],
+        start_time: ~U[2024-08-07 00:00:00Z],
+        end_time: ~U[2024-08-08 23:59:59Z]
+      })
+
+      assert [%{"id" => 1}] =
+               conn
+               |> get("/api/pa-messages?state=past&now=#{now}")
+               |> json_response(200)
+    end
+
+    @tag :authenticated_pa_message_admin
+    test "responds with only the future messages when filtered by state=future", %{conn: conn} do
+      now = "2024-08-06T15:10:00Z"
+
+      insert(:pa_message, %{
+        id: 1,
+        days_of_week: [1, 2, 3, 4, 5, 6, 7],
+        start_time: ~U[2024-08-04 00:00:00Z],
+        end_time: ~U[2024-08-05 23:59:59Z]
+      })
+
+      insert(:pa_message, %{
+        id: 2,
+        days_of_week: [1, 2, 3, 4, 5, 6, 7],
+        start_time: ~U[2024-08-05 00:00:00Z],
+        end_time: ~U[2024-08-06 23:59:59Z]
+      })
+
+      insert(:pa_message, %{
+        id: 3,
+        days_of_week: [1, 2, 3, 4, 5, 6, 7],
+        start_time: ~U[2024-08-07 00:00:00Z],
+        end_time: ~U[2024-08-08 23:59:59Z]
+      })
+
+      assert [%{"id" => 3}] =
+               conn
+               |> get("/api/pa-messages?state=future&now=#{now}")
                |> json_response(200)
     end
   end


### PR DESCRIPTION
Updates the `GET /api/pa-messages` endpoint to filter the returned PA Messages based on provided query parameters.

So far the only supported parameters are `state` and `now`. `state` can be used to limit the returned PA Messages to only those which are "past", "active", or "future". `now` is mostly a testing convience but allows passing in a timestamp to be treated as the current time when determining which state a PA Message is currently in.