### PR TITLE
fix: Session fetching

### DIFF
--- a/lib/screenplay_web/auth_manager/pipeline.ex
+++ b/lib/screenplay_web/auth_manager/pipeline.ex
@@ -6,6 +6,7 @@ defmodule ScreenplayWeb.AuthManager.Pipeline do
     error_handler: ScreenplayWeb.AuthManager.ErrorHandler,
     module: ScreenplayWeb.AuthManager
 
+  plug :fetch_session
   plug :save_previous_path
   plug(Guardian.Plug.VerifySession, claims: %{"typ" => "access"})
   plug(Guardian.Plug.VerifyHeader, claims: %{"typ" => "access"})
@@ -14,10 +15,6 @@ defmodule ScreenplayWeb.AuthManager.Pipeline do
   # A plug to save the current path before the auth process loses it through several
   # redirects. We use this path in auth_controller to send us back to the original url
   def save_previous_path(conn, _opts) do
-    if String.contains?(conn.request_path, "/api/") do
-      conn
-    else
-      Plug.Conn.put_session(conn, :previous_path, conn.request_path)
-    end
+    Plug.Conn.put_session(conn, :previous_path, conn.request_path)
   end
 end


### PR DESCRIPTION
When we call `get_session` to grab the `previous_path`, the session is not always ready to be read. This was causing some API calls to fail and get a 302. Adding `fetch_session` to the pipeline will ensure the session is always ready.