### PR TITLE
fix: wrap migration function in `with_repo/2`

### DIFF
--- a/lib/screenplay/migrate.ex
+++ b/lib/screenplay/migrate.ex
@@ -22,11 +22,13 @@ defmodule Screenplay.Migrate do
   end
 
   defp default_migrate_fn(migration_directory) do
-    Ecto.Migrator.run(
-      Screenplay.Repo,
-      Ecto.Migrator.migrations_path(Screenplay.Repo, migration_directory),
-      :up,
-      all: true
-    )
+    Ecto.Migrator.with_repo(Screenplay.Repo, fn repo ->
+      Ecto.Migrator.run(
+        repo,
+        Ecto.Migrator.migrations_path(Screenplay.Repo, migration_directory),
+        :up,
+        all: true
+      )
+    end)
   end
 end


### PR DESCRIPTION
`Ecto.Migrator.with_repo/2/3` ensures that the repo is started for the sake of running migrations.

https://hexdocs.pm/ecto_sql/3.11.1/Ecto.Migrator.html#with_repo/2

**Asana task**: [Address Screenplay sometimes crashing on startup](https://app.asana.com/0/1185117109217422/1207647895639263/f)

---

**Edit:** Deploys are still failing

<details>
<summary>Logs</summary>

```
8a9f971a27a6 18:36:24.479 [info] Postgrex.Protocol (#PID<0.3106.0>) missed message: {:EXIT, #PID<0.3156.0>, :shutdown}
8a9f971a27a6 18:36:24.479 [info] Postgrex.Protocol (#PID<0.3105.0>) missed message: {:EXIT, #PID<0.3156.0>, :shutdown}
eba8180bcaf5 Last message: {:error, #PID<0.2894.0>, {Logger, ["Postgrex.Protocol", 32, 40, "#PID<0.3227.0>", ") failed to connect: " | "** (DBConnection.ConnectionError) ssl recv (idle): closed"], {{2024, 8, 8}, {18, 32, 19, 406}}, [erl_level: :error, function: "handle_event/4", line: 125, module: DBConnection.Connection, pid: #PID<0.3227.0>, time: 1723141939406192, file: "lib/db_connection/connection.ex", gl: #PID<0.2894.0>, domain: [:elixir], application: :db_connection, mfa: {DBConnection.Connection, :handle_event, 4}, crash_reason: {%DBConnection.ConnectionError{message: "ssl recv (idle): closed", severity: :error, reason: :error}, []}]}}
eba8180bcaf5 18:32:19.406 [error] Postgrex.Protocol (#PID<0.3226.0>) failed to connect: ** (DBConnection.ConnectionError) ssl recv (idle): closed
eba8180bcaf5 18:32:19.406 [error] Postgrex.Protocol (#PID<0.3229.0>) failed to connect: ** (DBConnection.ConnectionError) ssl recv (idle): closed
eba8180bcaf5 18:32:19.406 [error] Postgrex.Protocol (#PID<0.3230.0>) failed to connect: ** (DBConnection.ConnectionError) ssl recv (idle): closed
eba8180bcaf5 18:32:19.406 [error] Postgrex.Protocol (#PID<0.3233.0>) failed to connect: ** (DBConnection.ConnectionError) ssl recv (idle): closed
eba8180bcaf5 18:32:19.406 [error] Postgrex.Protocol (#PID<0.3232.0>) failed to connect: ** (DBConnection.ConnectionError) ssl recv (idle): closed
eba8180bcaf5 18:32:19.406 [error] Postgrex.Protocol (#PID<0.3228.0>) failed to connect: ** (DBConnection.ConnectionError) ssl recv (idle): closed
eba8180bcaf5 18:32:19.406 [error] Postgrex.Protocol (#PID<0.3227.0>) failed to connect: ** (DBConnection.ConnectionError) ssl recv (idle): closed
eba8180bcaf5 18:32:19.406 [error] Postgrex.Protocol (#PID<0.3231.0>) failed to connect: ** (DBConnection.ConnectionError) ssl recv (idle): closed
eba8180bcaf5 18:32:19.404 [error] Postgrex.Protocol (#PID<0.3228.0>) timed out because it was handshaking for longer than 15000ms
eba8180bcaf5 18:32:19.404 [error] Postgrex.Protocol (#PID<0.3232.0>) timed out because it was handshaking for longer than 15000ms
eba8180bcaf5 18:32:19.404 [error] Postgrex.Protocol (#PID<0.3233.0>) timed out because it was handshaking for longer than 15000ms
eba8180bcaf5 18:32:19.404 [error] Postgrex.Protocol (#PID<0.3226.0>) timed out because it was handshaking for longer than 15000ms
eba8180bcaf5 18:32:19.404 [error] Postgrex.Protocol (#PID<0.3229.0>) timed out because it was handshaking for longer than 15000ms
eba8180bcaf5 18:32:19.404 [error] Postgrex.Protocol (#PID<0.3230.0>) timed out because it was handshaking for longer than 15000ms
eba8180bcaf5 18:32:19.405 [error] Postgrex.Protocol (#PID<0.3227.0>) timed out because it was handshaking for longer than 15000ms
eba8180bcaf5 18:32:19.404 [error] Postgrex.Protocol (#PID<0.3231.0>) timed out because it was handshaking for longer than 15000ms
```

[Splunk](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22screenplay-dev-green-application%22%20Postgrex&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1723140420&latest=1723142224&display.events.type=raw&sid=1723142376.6645089)

</details>

Is it possible there aren't enough available connections so when ECS tries to do a rolling deploy the new instances fail to make connections to the database?