### PR TITLE
feat: support filtering PaMessages by sign ids

### DIFF
--- a/lib/screenplay/pa_messages/pa_message/queries.ex
+++ b/lib/screenplay/pa_messages/pa_message/queries.ex
@@ -44,4 +44,17 @@ defmodule Screenplay.PaMessages.PaMessage.Queries do
   def future(q \\ PaMessage, now) do
     from m in q, where: ^now < m.start_time
   end
+
+  @doc """
+  Limits the query to PaMessages that have sign ids overlapping the list of
+  sign ids passed. Passes through the queryable if an empty lists or a non-list
+  is passed.
+  """
+  def signs(q \\ PaMessage, signs)
+
+  def signs(q, sign_ids = [_ | _]) do
+    from m in q, where: fragment("? && ?", m.sign_ids, ^sign_ids)
+  end
+
+  def signs(q, _), do: q
 end

--- a/priv/repo/migrations/20240808191935_add_gin_index_to_pa_message_sign_ids.exs
+++ b/priv/repo/migrations/20240808191935_add_gin_index_to_pa_message_sign_ids.exs
@@ -1,0 +1,7 @@
+defmodule Screenplay.Repo.Migrations.AddGinIndexToPaMessageSignIds do
+  use Ecto.Migration
+
+  def change do
+    create index(:pa_message, :sign_ids, using: "GIN", name: :pa_message_sign_ids_index)
+  end
+end

--- a/test/fixtures/places_and_screens.json
+++ b/test/fixtures/places_and_screens.json
@@ -1,1 +1,1 @@
-[{"id":"place-test","name":"Test Place","screens":[],"routes":["Green-B"]}]
+[{"id":"place-test","name":"Test Place","routes":["Green-B"],"screens":[]}]


### PR DESCRIPTION
- Adds `sign_ids/2` query which uses the `&&` operator to look for array overlap between a PaMessage's sign_ids field and a list of sign ids passed as an argument into the query function

- Adds parameter parser for `sign_ids` array param

- Adds GIN index on `pa_message.sign_ids` so filters on `sign_ids` do not require a sequential scan of the entire table an index 

https://postgresql.org/docs/16/interactive/functions-array.html
https://postgresql.org/docs/16/interactive/gin-intro.html
