### PR TITLE
feat: support filtering PaMessages by route

### DIFF
--- a/lib/screenplay/config/places_and_screens.ex
+++ b/lib/screenplay/config/places_and_screens.ex
@@ -16,10 +16,11 @@ defmodule Screenplay.Config.PlaceAndScreens do
             label: String.t() | nil,
             station_code: String.t(),
             type: String.t(),
-            zone: String.t()
+            zone: String.t(),
+            route_ids: [String.t()]
           }
 
-    @enforce_keys [:id, :label, :station_code, :type, :zone]
+    @enforce_keys [:id, :label, :station_code, :type, :zone, :route_ids]
     defstruct @enforce_keys
 
     def new(map) do

--- a/lib/screenplay/config/routes_to_signs.ex
+++ b/lib/screenplay/config/routes_to_signs.ex
@@ -1,0 +1,45 @@
+defmodule Screenplay.Config.RoutesToSigns do
+  @moduledoc """
+  Helper to derive a mapping of route to sign id from "places and screens"
+  configuration.
+  """
+
+  alias Screenplay.Config.PlaceAndScreens
+  alias Screenplay.Config.PlaceAndScreens.PaEssScreen
+
+  @config_fetcher Application.compile_env(:screenplay, :config_fetcher)
+
+  @spec routes_to_signs() :: %{
+          (route_id :: String.t()) => [sign_id :: String.t()]
+        }
+  def routes_to_signs do
+    {:ok, places_and_screens, _} = @config_fetcher.get_places_and_screens()
+
+    places_and_screens = Enum.map(places_and_screens, &PlaceAndScreens.from_map/1)
+
+    pa_ess_screens =
+      Enum.flat_map(places_and_screens, fn place ->
+        Enum.filter(place.screens, &match?(%PaEssScreen{}, &1))
+      end)
+
+    routes_to_signs =
+      pa_ess_screens
+      |> Enum.flat_map(fn screen ->
+        Enum.map(screen.route_ids, &{&1, screen.id})
+      end)
+      |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+
+    routes_to_signs
+  end
+
+  @spec signs_for_routes([route_id :: String.t()]) :: [sign_id :: String.t()]
+  def signs_for_routes(routes = [_ | _]) do
+    routes_to_signs()
+    |> Map.take(routes)
+    |> Map.values()
+    |> List.flatten()
+    |> Enum.uniq()
+  end
+
+  def signs_for_routes(_), do: []
+end

--- a/test/fixtures/places_and_screens_for_routes_to_signs.json
+++ b/test/fixtures/places_and_screens_for_routes_to_signs.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "place-one",
+    "name": "Place One",
+    "routes": ["place-one-route"],
+    "screens": [
+      {
+        "id": "place-one-sign",
+        "label": null,
+        "type": "pa_ess",
+        "zone": "e",
+        "route_ids": ["place-one-route"],
+        "station_code": "place-one-station-code"
+      }
+    ]
+  },
+  {
+    "id": "place-two",
+    "name": "Place Two",
+    "routes": ["place-one-route"],
+    "screens": [
+      {
+        "id": "place-two-sign",
+        "label": null,
+        "type": "pa_ess",
+        "zone": "e",
+        "route_ids": ["place-two-route"],
+        "station_code": "place-two-station-code"
+      }
+    ]
+  },
+  {
+    "id": "place-three",
+    "name": "Place Three",
+    "routes": ["place-three-route"],
+    "screens": [
+      {
+        "id": "place-three-sign",
+        "label": null,
+        "type": "pa_ess",
+        "zone": "e",
+        "route_ids": ["place-three-route"],
+        "station_code": "place-three-station-code"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Derives a mapping of route id to pa/ess sign ids from the "places and screens" data.

Uses the mapping of routes to PA/ESS sign ids to expand the the sign filtering to include all signs for all of the routes included in the options passed.

Required adding a `route_ids` field to the `PaEssScreen` struct.
