### PR TITLE
feat: adds UI to filter PA messages on their current state

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -3,6 +3,7 @@
 @import "./alert-wizard.scss";
 @import "./variables.scss";
 @import "./stacked-stations.scss";
+@import "./components.scss";
 
 @import "~bootstrap/scss/functions";
 @import "~bootstrap/scss/variables";

--- a/assets/css/components.scss
+++ b/assets/css/components.scss
@@ -1,0 +1,2 @@
+@import "./components/button-group.scss";
+@import "./components/button.scss";

--- a/assets/css/components/button-group.scss
+++ b/assets/css/components/button-group.scss
@@ -1,0 +1,12 @@
+.button-group {
+  display: flex;
+  flex-direction: column;
+
+  button {
+    text-align: left;
+    height: 38px;
+    color: $text-secondary;
+    background-color: $cool-gray-20;
+    border: none;
+  }
+}

--- a/assets/css/components/button.scss
+++ b/assets/css/components/button.scss
@@ -1,0 +1,6 @@
+.button {
+  &.active {
+    color: #fff;
+    background: #d9d9d93d;
+  }
+}

--- a/assets/css/dashboard/pa-messages-page.scss
+++ b/assets/css/dashboard/pa-messages-page.scss
@@ -14,6 +14,21 @@
   margin: 0px 20px;
   margin-left: 40px;
   padding-right: 0px;
+  display: flex;
+  flex-direction: column;
+
+  gap: 48px;
+
+  section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+
+    header {
+      font-size: 16px;
+      line-height: 24px;
+    }
+  }
 }
 
 .pa-message-table-container {
@@ -99,5 +114,13 @@
     font-weight: bold;
     color: white;
     padding-left: 30px;
+  }
+
+  &__loading {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    margin-top: 48px;
   }
 }

--- a/assets/js/utils/api.ts
+++ b/assets/js/utils/api.ts
@@ -1,15 +1,9 @@
 import { Alert } from "../models/alert";
 import { Place } from "../models/place";
-import { PaMessage } from "../models/pa_message";
 import { ScreenConfiguration } from "../models/screen_configuration";
 import { ScreensByAlert } from "../models/screensByAlert";
 import { PlaceIdsAndNewScreens } from "../components/Dashboard/PermanentConfiguration/Workflows/GlEink/ConfigureScreensPage";
 import getCsrfToken from "../csrf";
-
-export const fetchPaMessages = async (): Promise<PaMessage[]> => {
-  const response = await fetch("/api/pa-messages");
-  return await response.json();
-};
 
 export const fetchPlaces = async (): Promise<Place[]> => {
   const response = await fetch("/api/dashboard");

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -25,7 +25,8 @@
         "react-router-dom": "^6.3.0",
         "react-search-autocomplete": "^8.5.2",
         "react-tooltip": "^4.2.21",
-        "regenerator-runtime": "^0.14.1"
+        "regenerator-runtime": "^0.14.1",
+        "swr": "^2.2.5"
       },
       "devDependencies": {
         "@babel/core": "^7.24.7",
@@ -4752,6 +4753,11 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -12334,6 +12340,18 @@
         "url": "https://opencollective.com/svgo"
       }
     },
+    "node_modules/swr": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.5.tgz",
+      "integrity": "sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==",
+      "dependencies": {
+        "client-only": "^0.0.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -13012,6 +13030,14 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -32,7 +32,8 @@
     "react-router-dom": "^6.3.0",
     "react-search-autocomplete": "^8.5.2",
     "react-tooltip": "^4.2.21",
-    "regenerator-runtime": "^0.14.1"
+    "regenerator-runtime": "^0.14.1",
+    "swr": "^2.2.5"
   },
   "devDependencies": {
     "@babel/core": "^7.24.7",

--- a/lib/screenplay/pa_messages.ex
+++ b/lib/screenplay/pa_messages.ex
@@ -61,8 +61,10 @@ defmodule Screenplay.PaMessages do
 
     signs_for_routes = RoutesToSigns.signs_for_routes(opts[:routes])
 
+    now = opts[:now] || DateTime.utc_now()
+
     PaMessage
-    |> PaMessage.Queries.state(opts[:state], alert_ids, opts[:now])
+    |> PaMessage.Queries.state(opts[:state], alert_ids, now)
     |> PaMessage.Queries.signs(opts[:signs])
     |> PaMessage.Queries.signs(signs_for_routes)
     |> order_by(desc: :inserted_at)


### PR DESCRIPTION
- Installs `swr` for data fetching
- Wires up page query param to local state for persisted filters
- Moves some button and button group styles into own stylesheets
- Adds filters to PA Messages page to select which state to limit the displayed PA messages to. Clicking a filter that is already applied clears the filter.


https://github.com/user-attachments/assets/3d3c7a59-2527-4e1a-8db6-ee8808f3a689

<details>
<summary>Loading state 📹 </summary>


https://github.com/user-attachments/assets/fb93e139-8802-4f9c-a57d-31203367ac14



</details>

---

https://swr.vercel.app/
