### PR TITLE
chore: move NewMessagePage hooks to top level

### DIFF
--- a/assets/js/components/Dashboard/NewPaMessage/NewPaMessage.tsx
+++ b/assets/js/components/Dashboard/NewPaMessage/NewPaMessage.tsx
@@ -5,7 +5,7 @@ import NewPaMessagePage from "./NewPaMessagePage";
 import AssociateAlertPage from "./AssociateAlertPage";
 import { Alert } from "Models/alert";
 import SelectStationsAndZones from "./StationsAndZones/SelectStationsAndZones";
-import { usePlacesWithPaEss } from "./hooks";
+import { usePlacesWithPaEss } from "Hooks/usePlacesWithPaEss";
 import { busRouteIdsAtPlaces } from "../../../util";
 import { Alert as AlertToast } from "react-bootstrap";
 import { ExclamationTriangleFill } from "react-bootstrap-icons";

--- a/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/SelectStationsPage.tsx
+++ b/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/SelectStationsPage.tsx
@@ -18,7 +18,7 @@ import {
   RED_TRUNK,
 } from "./StationGroups";
 import { Page } from "../types";
-import { useRouteToRouteIDsMap } from "../hooks";
+import { useRouteToRouteIDsMap } from "Hooks/useRouteToRouteIDsMap";
 
 const ROUTE_TO_CLASS_NAMES_MAP: { [key: string]: string } = {
   Red: "route-col--red",

--- a/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/SelectZonesPage.tsx
+++ b/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/SelectZonesPage.tsx
@@ -12,7 +12,7 @@ import {
 } from "../../../../util";
 import cx from "classnames";
 import { Dot } from "react-bootstrap-icons";
-import { useRouteToRouteIDsMap } from "../hooks";
+import { useRouteToRouteIDsMap } from "Hooks/useRouteToRouteIDsMap";
 import PlaceZonesRow from "./PlaceZonesRow";
 import { LEFT_ZONES, MIDDLE_ZONES, RIGHT_ZONES } from "Constants/constants";
 

--- a/assets/js/components/Dashboard/NewPaMessage/hooks.tsx
+++ b/assets/js/components/Dashboard/NewPaMessage/hooks.tsx
@@ -1,22 +1,5 @@
 import { useMemo } from "react";
 import { Place } from "Models/place";
-import { useScreenplayContext } from "Hooks/useScreenplayContext";
-import { busRouteIdsAtPlaces } from "../../../util";
-import { BASE_ROUTE_NAME_TO_ROUTE_IDS } from "Constants/constants";
-
-export const usePlacesWithPaEss = () => {
-  const { places } = useScreenplayContext();
-  return useMemo(
-    () =>
-      places
-        .map((place) => ({
-          ...place,
-          screens: place.screens.filter((screen) => screen.type === "pa_ess"),
-        }))
-        .filter((place: Place) => place.screens.length > 0),
-    [places],
-  );
-};
 
 export const usePlacesWithSelectedScreens = (
   places: Place[],
@@ -30,14 +13,4 @@ export const usePlacesWithSelectedScreens = (
       }))
       .filter((place) => place.screens.length > 0);
   }, [places, signIds]);
-};
-
-export const useRouteToRouteIDsMap = (): { [key: string]: string[] } => {
-  const places = usePlacesWithPaEss();
-  return useMemo(() => {
-    return {
-      ...BASE_ROUTE_NAME_TO_ROUTE_IDS,
-      Bus: busRouteIdsAtPlaces(places),
-    };
-  }, [places]);
 };

--- a/assets/js/hooks/usePlacesWithPaEss.ts
+++ b/assets/js/hooks/usePlacesWithPaEss.ts
@@ -1,0 +1,17 @@
+import { useMemo } from "react";
+import { Place } from "Models/place";
+import { useScreenplayContext } from "Hooks/useScreenplayContext";
+
+export const usePlacesWithPaEss = () => {
+  const { places } = useScreenplayContext();
+  return useMemo(
+    () =>
+      places
+        .map((place) => ({
+          ...place,
+          screens: place.screens.filter((screen) => screen.type === "pa_ess"),
+        }))
+        .filter((place: Place) => place.screens.length > 0),
+    [places],
+  );
+};

--- a/assets/js/hooks/useRouteToRouteIDsMap.ts
+++ b/assets/js/hooks/useRouteToRouteIDsMap.ts
@@ -1,0 +1,14 @@
+import { useMemo } from "react";
+import { busRouteIdsAtPlaces } from "../util";
+import { BASE_ROUTE_NAME_TO_ROUTE_IDS } from "Constants/constants";
+import { usePlacesWithPaEss } from "Hooks/usePlacesWithPaEss";
+
+export const useRouteToRouteIDsMap = (): { [key: string]: string[] } => {
+  const places = usePlacesWithPaEss();
+  return useMemo(() => {
+    return {
+      ...BASE_ROUTE_NAME_TO_ROUTE_IDS,
+      Bus: busRouteIdsAtPlaces(places),
+    };
+  }, [places]);
+};


### PR DESCRIPTION
Moves `usePlacesWithPaEss` and `useRouteToRouteIDsMap` to the top-level hooks directory because these are useful beyond just the New PA Message page.

---

I'm using these in #431 and felt like I should move them out of the `NewMessagePage` directory