### PR TITLE
feat: start_time changeset validator

### DIFF
--- a/lib/screenplay/pa_messages/pa_message.ex
+++ b/lib/screenplay/pa_messages/pa_message.ex
@@ -67,7 +67,19 @@ defmodule Screenplay.PaMessages.PaMessage do
     ])
     |> validate_length(:sign_ids, min: 1)
     |> validate_subset(:days_of_week, 1..7)
+    |> validate_start_date()
     |> validate_end_date()
+  end
+
+  defp validate_start_date(changeset) do
+    start_time = get_field(changeset, :start_time)
+    end_time = get_field(changeset, :end_time)
+
+    if not is_nil(end_time) and DateTime.after?(start_time, end_time) do
+      add_error(changeset, :start_time, "start time must be before end time")
+    else
+      changeset
+    end
   end
 
   defp validate_end_date(changeset) do

--- a/test/screenplay/pa_messages_test.exs
+++ b/test/screenplay/pa_messages_test.exs
@@ -160,7 +160,7 @@ defmodule Screenplay.PaMessagesTest do
 
       new_message = %{
         start_time: now,
-        end_time: DateTime.add(now, 60),
+        end_time: nil,
         days_of_week: [22],
         sign_ids: [],
         priority: 1,
@@ -173,6 +173,20 @@ defmodule Screenplay.PaMessagesTest do
       assert {_, _} = changeset.errors[:sign_ids]
       assert {_, _} = changeset.errors[:interval_in_minutes]
       assert {_, _} = changeset.errors[:visual_text]
+      assert {_, _} = changeset.errors[:end_time]
+
+      new_message = %{
+        start_time: DateTime.add(now, 61),
+        end_time: DateTime.add(now, 60),
+        days_of_week: [1],
+        sign_ids: ["test_sign"],
+        priority: 1,
+        visual_text: "Visual Text",
+        audio_text: "Audio Text"
+      }
+
+      assert {:error, %Ecto.Changeset{} = changeset} = PaMessages.create_message(new_message)
+      assert {_, _} = changeset.errors[:start_time]
     end
   end
 


### PR DESCRIPTION
Added a changeset validator for `start_time`. The client should catch this, but in case it doesn't we will prevent it from being inserted.