### PR TITLE
chore: Add direction_id to PA/ESS sign configs

### DIFF
--- a/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/RouteColumn.tsx
+++ b/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/RouteColumn.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import fp from "lodash/fp";
 import type { Place } from "Models/place";
-import { sortByStationOrder } from "../../../../util";
+import { getRouteIdsForSign, sortByStationOrder } from "../../../../util";
 import { Form } from "react-bootstrap";
 
 const RouteColumn = ({
@@ -24,7 +24,8 @@ const RouteColumn = ({
   const signsIdsAtRoutes = places.flatMap((place) =>
     place.screens
       .filter(
-        (screen) => fp.intersection(routeIds, screen.route_ids).length > 0,
+        (screen) =>
+          fp.intersection(routeIds, getRouteIdsForSign(screen)).length > 0,
       )
       .map((screen) => screen.id),
   );
@@ -52,7 +53,8 @@ const RouteColumn = ({
           const signIdsAtPlace = place.screens
             .filter(
               (screen) =>
-                fp.intersection(routeIds, screen.route_ids).length > 0,
+                fp.intersection(routeIds, getRouteIdsForSign(screen)).length >
+                0,
             )
             .map((screen) => screen.id);
           return (

--- a/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/SelectStationsPage.tsx
+++ b/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/SelectStationsPage.tsx
@@ -19,6 +19,7 @@ import {
 } from "./StationGroups";
 import { Page } from "../types";
 import { useRouteToRouteIDsMap } from "Hooks/useRouteToRouteIDsMap";
+import { getRouteIdsForSign } from "../../../../util";
 
 const ROUTE_TO_CLASS_NAMES_MAP: { [key: string]: string } = {
   Red: "route-col--red",
@@ -56,7 +57,8 @@ const SelectStationsPage = ({
         if (
           place.screens.some(
             (screen) =>
-              fp.intersection(groupedRoutes, screen.route_ids).length > 0,
+              fp.intersection(groupedRoutes, getRouteIdsForSign(screen))
+                .length > 0,
           )
         ) {
           acc[route] = [...(acc[route] || []), place];
@@ -73,7 +75,8 @@ const SelectStationsPage = ({
         place.screens
           .filter(
             (screen) =>
-              fp.intersection(GREEN_LINE_ROUTES, screen.route_ids).length > 0,
+              fp.intersection(GREEN_LINE_ROUTES, getRouteIdsForSign(screen))
+                .length > 0,
           )
           .map((screen) => screen.id),
     ),

--- a/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/SelectZonesPage.tsx
+++ b/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/SelectZonesPage.tsx
@@ -3,9 +3,9 @@ import { Page } from "../types";
 import { Button } from "react-bootstrap";
 import { Place } from "Models/place";
 import fp from "lodash/fp";
-import { Screen } from "Models/screen";
 import {
   getPlacesFromFilter,
+  getRouteIdsForSign,
   signIDs,
   signsByZone,
   sortByStationOrder,
@@ -48,7 +48,7 @@ const SelectZonesPage = ({
       fp.flatMap((place: Place) =>
         place.screens.filter((s) => value.includes(s.id)),
       ),
-      fp.flatMap((screen: Screen) => screen.route_ids),
+      fp.flatMap(getRouteIdsForSign),
       fp.uniq,
       fp.groupBy((routeID: string) => {
         if (routeID.startsWith("Green")) {
@@ -132,8 +132,10 @@ const SelectZonesPage = ({
   const allScreens = filteredPlaces.flatMap((p) => {
     return p.screens.filter(
       (s) =>
-        fp.intersection(routeToRouteIDMap[selectedRouteFilter], s.route_ids)
-          .length > 0,
+        fp.intersection(
+          routeToRouteIDMap[selectedRouteFilter],
+          getRouteIdsForSign(s),
+        ).length > 0,
     );
   });
 
@@ -177,7 +179,9 @@ const SelectZonesPage = ({
 
   const getSignsFromPlaceForRouteId = (place: Place, routeId: string) => {
     return place.screens.filter((screen) =>
-      screen.route_ids?.some((id) => routeToRouteIDMap[routeId].includes(id)),
+      getRouteIdsForSign(screen).some((id) =>
+        routeToRouteIDMap[routeId].includes(id),
+      ),
     );
   };
 
@@ -330,7 +334,10 @@ const SelectZonesPage = ({
                       ? fp
                           .uniq(
                             allSignsForRouteFilterAtPlace.flatMap((s) =>
-                              fp.map((r) => r.split("-")[1], s.route_ids),
+                              fp.map(
+                                (r) => r.split("-")[1],
+                                getRouteIdsForSign(s),
+                              ),
                             ),
                           )
                           .sort()

--- a/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/StationGroupCheckbox.tsx
+++ b/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/StationGroupCheckbox.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import fp from "lodash/fp";
 import { Place } from "Models/place";
 import { Form } from "react-bootstrap";
+import { getRouteIdsForSign } from "../../../../util";
 
 interface Props {
   title: string;
@@ -27,7 +28,8 @@ const StationGroupCheckbox = ({
     .flatMap((place) =>
       place.screens
         .filter(
-          (screen) => fp.intersection(routes, screen.route_ids).length > 0,
+          (screen) =>
+            fp.intersection(routes, getRouteIdsForSign(screen)).length > 0,
         )
         .map((screen) => screen.id),
     );

--- a/assets/js/models/screen.ts
+++ b/assets/js/models/screen.ts
@@ -7,5 +7,7 @@ export interface Screen {
   label?: string;
   location?: string;
   hidden?: boolean;
-  route_ids?: string[];
+  routes?: PaEssSignRoutes[];
 }
+
+type PaEssSignRoutes = { id: string; direction_id: 0 | 1 };

--- a/assets/js/util.ts
+++ b/assets/js/util.ts
@@ -309,9 +309,7 @@ export const getAlertEarliestStartLatestEnd = (
 
 export const allRouteIdsAtPlaces = (places: Place[]) => {
   return fp.uniq(
-    places.flatMap((place) =>
-      place.screens.flatMap((screen) => screen.route_ids ?? []),
-    ),
+    places.flatMap((place) => place.screens.flatMap(getRouteIdsForSign)),
   );
 };
 
@@ -348,6 +346,9 @@ export const getPlacesFromFilter = (
   filterFn: (routeId: string) => boolean,
 ) => {
   return places.filter((place) =>
-    place.screens.some((screen) => screen.route_ids?.some(filterFn)),
+    place.screens.some((screen) => getRouteIdsForSign(screen).some(filterFn)),
   );
 };
+
+export const getRouteIdsForSign = (screen: Screen) =>
+  screen.routes ? screen.routes.map((route) => route.id) : [];

--- a/lib/screenplay/config/places_and_screens.ex
+++ b/lib/screenplay/config/places_and_screens.ex
@@ -11,16 +11,18 @@ defmodule Screenplay.Config.PlaceAndScreens do
 
     @derive Jason.Encoder
 
+    @type route :: %{id: String.t(), direction_id: 0 | 1}
+
     @type t :: %__MODULE__{
             id: String.t(),
             label: String.t() | nil,
             station_code: String.t(),
             type: String.t(),
             zone: String.t(),
-            route_ids: [String.t()]
+            routes: [route()]
           }
 
-    @enforce_keys [:id, :label, :station_code, :type, :zone, :route_ids]
+    @enforce_keys [:id, :label, :station_code, :type, :zone, :routes]
     defstruct @enforce_keys
 
     def new(map) do

--- a/lib/screenplay/config/routes_to_signs.ex
+++ b/lib/screenplay/config/routes_to_signs.ex
@@ -25,7 +25,7 @@ defmodule Screenplay.Config.RoutesToSigns do
     routes_to_signs =
       pa_ess_screens
       |> Enum.flat_map(fn screen ->
-        Enum.map(screen.route_ids, &{&1, screen.id})
+        Enum.map(screen.routes, &{&1["id"], screen.id})
       end)
       |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
 

--- a/lib/screenplay/pa_messages.ex
+++ b/lib/screenplay/pa_messages.ex
@@ -38,7 +38,7 @@ defmodule Screenplay.PaMessages do
         %ListParams{}
         |> cast(attrs, [:state, :now, :signs, :routes])
         |> validate_length(:signs, min: 1, message: "must include at least one sign")
-        |> validate_length(:routes, min: 1, message: "must include at least on route")
+        |> validate_length(:routes, min: 1, message: "must include at least one route")
 
       case apply_action(changeset, :insert) do
         {:ok, opts} -> {:ok, Map.drop(opts, [:__struct__, :__meta__])}

--- a/scripts/build_places.exs
+++ b/scripts/build_places.exs
@@ -576,7 +576,7 @@ get_routes_for_pa_ess = fn config ->
   for source <- get_sources.(config),
       route <- source["routes"] || List.wrap(source["route_id"]),
       uniq: true do
-    route
+    %{id: route, direction_id: source["direction_id"]}
   end
 end
 
@@ -602,7 +602,7 @@ pa_ess_screens =
         zone: zone,
         type: "pa_ess",
         label: pa_ess_label.(config),
-        route_ids: get_routes_for_pa_ess.(config)
+        routes: get_routes_for_pa_ess.(config)
       }
     }
   end)

--- a/test/fixtures/places_and_screens_for_routes_to_signs.json
+++ b/test/fixtures/places_and_screens_for_routes_to_signs.json
@@ -9,7 +9,7 @@
         "label": null,
         "type": "pa_ess",
         "zone": "e",
-        "route_ids": ["place-one-route"],
+        "routes": [{ "id": "place-one-route", "direction_id": 0 }],
         "station_code": "place-one-station-code"
       }
     ]
@@ -24,7 +24,7 @@
         "label": null,
         "type": "pa_ess",
         "zone": "e",
-        "route_ids": ["place-two-route"],
+        "routes": [{ "id": "place-two-route", "direction_id": 0 }],
         "station_code": "place-two-station-code"
       }
     ]
@@ -39,7 +39,7 @@
         "label": null,
         "type": "pa_ess",
         "zone": "e",
-        "route_ids": ["place-three-route"],
+        "routes": [{ "id": "place-three-route", "direction_id": 0 }],
         "station_code": "place-three-station-code"
       }
     ]


### PR DESCRIPTION
When importing locations from alerts, I need to know what direction a sign is configured to show for the route. This change should add this info without breaking any existing code that looked at `route_ids`. This info will also be useful when we fix column organization on the Select Zones page.