### PR TITLE
feat: Import signs from alert informed_entities

### DIFF
--- a/assets/js/components/Dashboard/NewPaMessage/AssociateAlertPage.tsx
+++ b/assets/js/components/Dashboard/NewPaMessage/AssociateAlertPage.tsx
@@ -15,7 +15,7 @@ import {
   Form,
 } from "react-bootstrap";
 import { fetchActiveAndFutureAlerts } from "Utils/api";
-import { Alert } from "Models/alert";
+import { Alert, InformedEntity } from "Models/alert";
 import classNames from "classnames";
 import { getAlertEarliestStartLatestEnd } from "../../../util";
 import { Page } from "./types";
@@ -25,7 +25,7 @@ interface AssociateAlertPageProps {
   associatedAlert: Alert;
   endWithEffectPeriod: boolean;
   onImportMessage: (message: string) => void;
-  onImportLocations: () => void;
+  onImportLocations: (informedEntities: InformedEntity[]) => void;
   navigateTo: (page: Page) => void;
   setAssociatedAlert: Dispatch<SetStateAction<Alert>>;
   setEndWithEffectPeriod: Dispatch<SetStateAction<boolean>>;
@@ -209,7 +209,7 @@ const AssociateAlertPage = ({
                 onImportMessage(associatedAlert.header);
               }
               if (importLocations) {
-                onImportLocations();
+                onImportLocations(associatedAlert.informed_entities);
               }
               navigateTo(Page.NEW);
             }}

--- a/assets/js/components/Dashboard/NewPaMessage/NewPaMessage.tsx
+++ b/assets/js/components/Dashboard/NewPaMessage/NewPaMessage.tsx
@@ -53,11 +53,10 @@ const NewPaMessage = () => {
         : places;
 
       if (entity.route) {
+        const entityRoute = entity.route;
         let signsToAdd = informedPlaces
           .flatMap((place) => place.screens)
-          .filter((screen) =>
-            getRouteIdsForSign(screen).includes(entity.route ?? ""),
-          );
+          .filter((screen) => getRouteIdsForSign(screen).includes(entityRoute));
 
         const directionId = entity.direction_id;
         if (directionId !== null) {

--- a/assets/js/components/Dashboard/NewPaMessage/NewPaMessage.tsx
+++ b/assets/js/components/Dashboard/NewPaMessage/NewPaMessage.tsx
@@ -3,14 +3,15 @@ import moment, { type Moment } from "moment";
 import { Page } from "./types";
 import NewPaMessagePage from "./NewPaMessagePage";
 import AssociateAlertPage from "./AssociateAlertPage";
-import { Alert } from "Models/alert";
+import { Alert, InformedEntity } from "Models/alert";
 import SelectStationsAndZones from "./StationsAndZones/SelectStationsAndZones";
 import { usePlacesWithPaEss } from "Hooks/usePlacesWithPaEss";
-import { busRouteIdsAtPlaces } from "../../../util";
 import ErrorToast from "Components/ErrorToast";
 import { PaMessage } from "Models/pa_message";
 import { createNewPaMessage } from "Utils/api";
 import { useNavigate } from "react-router-dom";
+import { busRouteIdsAtPlaces, getRouteIdsForSign } from "../../../util";
+import fp from "lodash/fp";
 
 const NewPaMessage = () => {
   const [page, setPage] = useState<Page>(Page.NEW);
@@ -45,7 +46,36 @@ const NewPaMessage = () => {
     setVisualText(alertMessage);
   };
 
-  const onImportLocations = () => {};
+  const onImportLocations = (informedEntities: InformedEntity[]) => {
+    const importedSigns = informedEntities.reduce((acc, entity) => {
+      const informedPlaces = entity.stop
+        ? places.filter((place) => place.id === entity.stop)
+        : places;
+
+      if (entity.route) {
+        let signsToAdd = informedPlaces
+          .flatMap((place) => place.screens)
+          .filter((screen) =>
+            getRouteIdsForSign(screen).includes(entity.route ?? ""),
+          );
+
+        const directionId = entity.direction_id;
+        if (directionId !== null) {
+          signsToAdd = signsToAdd.filter((screen) =>
+            screen.routes
+              ?.map((route) => route.direction_id)
+              .includes(directionId),
+          );
+        }
+
+        return acc.concat(signsToAdd.map((screen) => screen.id));
+      }
+
+      return [];
+    }, signIds);
+
+    setSignIds(fp.uniq(importedSigns));
+  };
 
   const navigate = useNavigate();
   const onSubmit = async () => {

--- a/assets/js/components/Dashboard/NewPaMessage/NewPaMessage.tsx
+++ b/assets/js/components/Dashboard/NewPaMessage/NewPaMessage.tsx
@@ -47,7 +47,7 @@ const NewPaMessage = () => {
   };
 
   const onImportLocations = (informedEntities: InformedEntity[]) => {
-    const importedSigns = informedEntities.reduce((acc, entity) => {
+    const importedSigns = informedEntities.flatMap((entity) => {
       const informedPlaces = entity.stop
         ? places.filter((place) => place.id === entity.stop)
         : places;
@@ -68,11 +68,11 @@ const NewPaMessage = () => {
           );
         }
 
-        return acc.concat(signsToAdd.map((screen) => screen.id));
+        return signsToAdd.map((screen) => screen.id);
       }
 
       return [];
-    }, signIds);
+    });
 
     setSignIds(fp.uniq(importedSigns));
   };

--- a/assets/js/utils/api.ts
+++ b/assets/js/utils/api.ts
@@ -4,6 +4,7 @@ import { ScreenConfiguration } from "../models/screen_configuration";
 import { ScreensByAlert } from "../models/screensByAlert";
 import { PlaceIdsAndNewScreens } from "../components/Dashboard/PermanentConfiguration/Workflows/GlEink/ConfigureScreensPage";
 import getCsrfToken from "../csrf";
+import { PaMessage } from "Models/pa_message";
 
 export const fetchPlaces = async (): Promise<Place[]> => {
   const response = await fetch("/api/dashboard");


### PR DESCRIPTION
This PR adds the logic needed to select signs informed by an alert. It filters down by stop > route > direction (if provided in `informed_entities`).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208009646310782