### PR TITLE
chore: Change column name to match its type.

### DIFF
--- a/assets/js/components/Dashboard/ErrorToast.tsx
+++ b/assets/js/components/Dashboard/ErrorToast.tsx
@@ -17,9 +17,9 @@ const ErrorToast = ({ errorMessage, errors, onClose }: Props) => {
         return "Visual Text";
       case "audio_text":
         return "Phoentic Audio";
-      case "start_time":
+      case "start_datetime":
         return "Start date/time";
-      case "end_time":
+      case "end_datetime":
         return "End date/time";
       default:
         return "";

--- a/assets/js/components/Dashboard/NewPaMessage/NewPaMessage.tsx
+++ b/assets/js/components/Dashboard/NewPaMessage/NewPaMessage.tsx
@@ -51,8 +51,8 @@ const NewPaMessage = () => {
   const onSubmit = async () => {
     const newMessage: PaMessage = {
       alert_id: associatedAlert.id,
-      start_time: startDateTime.toISOString(),
-      end_time: endWithEffectPeriod ? null : endDateTime.toISOString(),
+      start_datetime: startDateTime.toISOString(),
+      end_datetime: endWithEffectPeriod ? null : endDateTime.toISOString(),
       days_of_week: days,
       sign_ids: signIds,
       priority,

--- a/assets/js/components/Dashboard/NewPaMessage/NewPaMessagePage.tsx
+++ b/assets/js/components/Dashboard/NewPaMessage/NewPaMessagePage.tsx
@@ -134,7 +134,6 @@ const NewPaMessagePage = ({
     event.preventDefault();
 
     const form = event.currentTarget;
-    onSubmit();
 
     if (
       form.checkValidity() === false ||

--- a/assets/js/components/Dashboard/PaMessagesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessagesPage.tsx
@@ -183,8 +183,9 @@ interface PaMessageRowProps {
 const PaMessageRow: ComponentType<PaMessageRowProps> = ({
   paMessage,
 }: PaMessageRowProps) => {
-  const start = new Date(paMessage.start_time);
-  const end = paMessage.end_time === null ? null : new Date(paMessage.end_time);
+  const start = new Date(paMessage.start_datetime);
+  const end =
+    paMessage.end_datetime === null ? null : new Date(paMessage.end_datetime);
 
   return (
     <tr>

--- a/assets/js/models/pa_message.ts
+++ b/assets/js/models/pa_message.ts
@@ -1,8 +1,8 @@
 export interface PaMessage {
   id?: number;
   alert_id: string | null;
-  start_time: string;
-  end_time: string | null;
+  start_datetime: string;
+  end_datetime: string | null;
   days_of_week: number[];
   sign_ids: string[];
   priority: number;

--- a/assets/js/utils/api.ts
+++ b/assets/js/utils/api.ts
@@ -4,6 +4,7 @@ import { ScreenConfiguration } from "../models/screen_configuration";
 import { ScreensByAlert } from "../models/screensByAlert";
 import { PlaceIdsAndNewScreens } from "../components/Dashboard/PermanentConfiguration/Workflows/GlEink/ConfigureScreensPage";
 import getCsrfToken from "../csrf";
+import { PaMessage } from "Models/pa_message";
 
 export const fetchPlaces = async (): Promise<Place[]> => {
   const response = await fetch("/api/dashboard");

--- a/lib/screenplay/pa_messages/pa_message.ex
+++ b/lib/screenplay/pa_messages/pa_message.ex
@@ -9,8 +9,8 @@ defmodule Screenplay.PaMessages.PaMessage do
 
   @type t() :: %__MODULE__{
           alert_id: String.t() | nil,
-          start_time: DateTime.t(),
-          end_time: DateTime.t() | nil,
+          start_datetime: DateTime.t(),
+          end_datetime: DateTime.t() | nil,
           days_of_week: [integer()] | nil,
           sign_ids: [String.t()],
           priority: integer(),
@@ -26,8 +26,8 @@ defmodule Screenplay.PaMessages.PaMessage do
 
   schema "pa_message" do
     field(:alert_id, :string)
-    field(:start_time, :utc_datetime)
-    field(:end_time, :utc_datetime)
+    field(:start_datetime, :utc_datetime)
+    field(:end_datetime, :utc_datetime)
     field(:days_of_week, {:array, :integer})
     field(:sign_ids, {:array, :string})
     field(:priority, :integer)
@@ -45,8 +45,8 @@ defmodule Screenplay.PaMessages.PaMessage do
     message
     |> cast(attrs, [
       :alert_id,
-      :start_time,
-      :end_time,
+      :start_datetime,
+      :end_datetime,
       :days_of_week,
       :sign_ids,
       :priority,
@@ -57,7 +57,7 @@ defmodule Screenplay.PaMessages.PaMessage do
       :saved
     ])
     |> validate_required([
-      :start_time,
+      :start_datetime,
       :days_of_week,
       :sign_ids,
       :priority,
@@ -72,22 +72,22 @@ defmodule Screenplay.PaMessages.PaMessage do
   end
 
   defp validate_start_date(changeset) do
-    start_time = get_field(changeset, :start_time)
-    end_time = get_field(changeset, :end_time)
+    start_datetime = get_field(changeset, :start_datetime)
+    end_datetime = get_field(changeset, :end_datetime)
 
-    if not is_nil(end_time) and DateTime.after?(start_time, end_time) do
-      add_error(changeset, :start_time, "start time must be before end time")
+    if not is_nil(end_datetime) and DateTime.after?(start_datetime, end_datetime) do
+      add_error(changeset, :start_datetime, "start time must be before end time")
     else
       changeset
     end
   end
 
   defp validate_end_date(changeset) do
-    end_time = get_field(changeset, :end_time)
+    end_datetime = get_field(changeset, :end_datetime)
     alert_id = get_field(changeset, :alert_id)
 
-    if is_nil(end_time) and is_nil(alert_id) do
-      add_error(changeset, :end_time, "cannot have an end time if associated with an alert")
+    if is_nil(end_datetime) and is_nil(alert_id) do
+      add_error(changeset, :end_datetime, "cannot have an end time if associated with an alert")
     else
       changeset
     end

--- a/lib/screenplay/pa_messages/pa_message/queries.ex
+++ b/lib/screenplay/pa_messages/pa_message/queries.ex
@@ -31,18 +31,19 @@ defmodule Screenplay.PaMessages.PaMessage.Queries do
     from m in q,
       where:
         ^current_service_day_of_week in m.days_of_week and
-          m.start_time <= ^now and
-          ((is_nil(m.end_time) and m.alert_id in ^alert_ids) or m.end_time >= ^now)
+          m.start_datetime <= ^now and
+          ((is_nil(m.end_datetime) and m.alert_id in ^alert_ids) or m.end_datetime >= ^now)
   end
 
   @doc "Limit the query to only PaMessages that are in the past"
   def past(q \\ PaMessage, alert_ids, now) do
-    from m in q, where: m.end_time < ^now or (is_nil(m.end_time) and m.alert_id not in ^alert_ids)
+    from m in q,
+      where: m.end_datetime < ^now or (is_nil(m.end_datetime) and m.alert_id not in ^alert_ids)
   end
 
   @doc "Limit the query to only PaMessages that are scheduled for the future"
   def future(q \\ PaMessage, now) do
-    from m in q, where: ^now < m.start_time
+    from m in q, where: ^now < m.start_datetime
   end
 
   @doc """

--- a/priv/repo/migrations/20240812182216_change_datetime_column_names.exs
+++ b/priv/repo/migrations/20240812182216_change_datetime_column_names.exs
@@ -1,0 +1,15 @@
+defmodule Screenplay.Repo.Migrations.ChangeDatetimeColumnNames do
+  use Ecto.Migration
+
+  def change do
+    rename table("pa_message"), :start_time, to: :start_datetime
+    rename table("pa_message"), :end_time, to: :end_datetime
+
+    rename(
+      index(:pa_message, [:start_datetime, :end_datetime],
+        name: "pa_message_start_time_end_time_index"
+      ),
+      to: "pa_message_start_datetime_end_datetime_index"
+    )
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -79,23 +79,23 @@ defmodule Random do
     Faker.Lorem.paragraph()
   end
 
-  def start_and_end_times(window \\ 7) do
-    start_time = window |> Faker.DateTime.backward() |> DateTime.truncate(:second)
-    end_time = window |> Faker.DateTime.forward() |> DateTime.truncate(:second)
+  def start_and_end_datetimes(window \\ 7) do
+    start_datetime = window |> Faker.DateTime.backward() |> DateTime.truncate(:second)
+    end_datetime = window |> Faker.DateTime.forward() |> DateTime.truncate(:second)
 
-    {start_time, end_time}
+    {start_datetime, end_datetime}
   end
 
-  def past_start_and_end_times(window \\ 7) do
-    {start_time, end_time} = start_and_end_times(window)
+  def past_start_and_end_datetimes(window \\ 7) do
+    {start_datetime, end_datetime} = start_and_end_datetimes(window)
 
-    {DateTime.add(start_time, -window, :day), DateTime.add(end_time, -window, :day)}
+    {DateTime.add(start_datetime, -window, :day), DateTime.add(end_datetime, -window, :day)}
   end
 
-  def future_start_and_end_times(window \\ 7) do
-    {start_time, end_time} = start_and_end_times(window)
+  def future_start_and_end_datetimes(window \\ 7) do
+    {start_datetime, end_datetime} = start_and_end_datetimes(window)
 
-    {DateTime.add(start_time, window, :day), DateTime.add(end_time, window, :day)}
+    {DateTime.add(start_datetime, window, :day), DateTime.add(end_datetime, window, :day)}
   end
 
   def days_of_week do
@@ -110,12 +110,12 @@ end
 
 # Past PaMessages
 for _ <- 1..100 do
-  {start_time, end_time} = Random.past_start_and_end_times()
+  {start_datetime, end_datetime} = Random.past_start_and_end_datetimes()
   text = Random.text()
 
   Repo.insert!(%PaMessage{
-    start_time: start_time,
-    end_time: end_time,
+    start_datetime: start_datetime,
+    end_datetime: end_datetime,
     sign_ids: Random.sign_ids(),
     priority: Random.priority(),
     days_of_week: Random.days_of_week(),
@@ -127,12 +127,12 @@ end
 
 # Current PaMessages
 for _ <- 1..100 do
-  {start_time, end_time} = Random.start_and_end_times()
+  {start_datetime, end_datetime} = Random.start_and_end_datetimes()
   text = Random.text()
 
   Repo.insert!(%PaMessage{
-    start_time: start_time,
-    end_time: end_time,
+    start_datetime: start_datetime,
+    end_datetime: end_datetime,
     sign_ids: Random.sign_ids(),
     priority: Random.priority(),
     days_of_week: Random.days_of_week(),
@@ -144,12 +144,12 @@ end
 
 # Future PaMessages
 for _ <- 1..100 do
-  {start_time, end_time} = Random.future_start_and_end_times()
+  {start_datetime, end_datetime} = Random.future_start_and_end_datetimes()
   text = Random.text()
 
   Repo.insert!(%PaMessage{
-    start_time: start_time,
-    end_time: end_time,
+    start_datetime: start_datetime,
+    end_datetime: end_datetime,
     sign_ids: Random.sign_ids(),
     priority: Random.priority(),
     days_of_week: Random.days_of_week(),

--- a/test/screenplay/pa_messages_test.exs
+++ b/test/screenplay/pa_messages_test.exs
@@ -10,24 +10,24 @@ defmodule Screenplay.PaMessagesTest do
     test "returns all messages with most recent first" do
       insert(:pa_message, %{
         id: 1,
-        start_time: ~U[2024-05-01T01:00:00Z],
-        end_time: ~U[2024-05-01T13:00:00Z],
+        start_datetime: ~U[2024-05-01T01:00:00Z],
+        end_datetime: ~U[2024-05-01T13:00:00Z],
         days_of_week: [3],
         inserted_at: ~U[2024-05-01T01:00:00Z]
       })
 
       insert(:pa_message, %{
         id: 2,
-        start_time: ~U[2024-05-02T12:00:00Z],
-        end_time: ~U[2024-05-02T12:00:00Z],
+        start_datetime: ~U[2024-05-02T12:00:00Z],
+        end_datetime: ~U[2024-05-02T12:00:00Z],
         days_of_week: [3],
         inserted_at: ~U[2024-05-02T12:00:00Z]
       })
 
       insert(:pa_message, %{
         id: 3,
-        start_time: ~U[2024-05-02T12:00:00Z],
-        end_time: ~U[2024-05-02T12:00:00Z],
+        start_datetime: ~U[2024-05-02T12:00:00Z],
+        end_datetime: ~U[2024-05-02T12:00:00Z],
         days_of_week: [3],
         inserted_at: ~U[2024-05-03T12:00:00Z]
       })
@@ -57,13 +57,13 @@ defmodule Screenplay.PaMessagesTest do
 
       insert(:pa_message, %{
         alert_id: "1",
-        start_time: ~U[2024-05-01T01:00:00Z],
+        start_datetime: ~U[2024-05-01T01:00:00Z],
         days_of_week: [2]
       })
 
       insert(:pa_message, %{
         alert_id: "2",
-        start_time: ~U[2024-05-01T04:00:00Z],
+        start_datetime: ~U[2024-05-01T04:00:00Z],
         days_of_week: [2]
       })
 
@@ -78,15 +78,15 @@ defmodule Screenplay.PaMessagesTest do
 
       insert(:pa_message, %{
         id: 1,
-        start_time: ~U[2024-05-01T01:00:00Z],
-        end_time: ~U[2024-05-01T13:00:00Z],
+        start_datetime: ~U[2024-05-01T01:00:00Z],
+        end_datetime: ~U[2024-05-01T13:00:00Z],
         days_of_week: [3]
       })
 
       insert(:pa_message, %{
         id: 2,
-        start_time: ~U[2024-05-02T12:00:00Z],
-        end_time: ~U[2024-05-02T12:00:00Z],
+        start_datetime: ~U[2024-05-02T12:00:00Z],
+        end_datetime: ~U[2024-05-02T12:00:00Z],
         days_of_week: [3]
       })
 
@@ -113,16 +113,16 @@ defmodule Screenplay.PaMessagesTest do
     insert(:pa_message, %{
       id: 1,
       alert_id: "1",
-      start_time: ~U[2024-05-01T04:00:00Z],
-      end_time: ~U[2024-05-02T04:00:00Z],
+      start_datetime: ~U[2024-05-01T04:00:00Z],
+      end_datetime: ~U[2024-05-02T04:00:00Z],
       days_of_week: [3]
     })
 
     insert(:pa_message, %{
       id: 2,
       alert_id: "2",
-      start_time: ~U[2024-05-02T04:00:00Z],
-      end_time: ~U[2024-05-02T05:00:00Z],
+      start_datetime: ~U[2024-05-02T04:00:00Z],
+      end_datetime: ~U[2024-05-02T05:00:00Z],
       days_of_week: [3]
     })
 
@@ -134,8 +134,8 @@ defmodule Screenplay.PaMessagesTest do
       now = ~U[2024-08-07T12:12:12Z]
 
       new_message = %{
-        start_time: now,
-        end_time: DateTime.add(now, 60),
+        start_datetime: now,
+        end_datetime: DateTime.add(now, 60),
         days_of_week: [1, 2, 3],
         sign_ids: ["test_sign"],
         priority: 1,
@@ -145,8 +145,8 @@ defmodule Screenplay.PaMessagesTest do
       }
 
       assert {:ok, actual} = PaMessages.create_message(new_message)
-      assert actual.start_time == new_message.start_time
-      assert actual.end_time == new_message.end_time
+      assert actual.start_datetime == new_message.start_datetime
+      assert actual.end_datetime == new_message.end_datetime
       assert actual.days_of_week == new_message.days_of_week
       assert actual.sign_ids == new_message.sign_ids
       assert actual.priority == new_message.priority
@@ -159,8 +159,8 @@ defmodule Screenplay.PaMessagesTest do
       now = DateTime.utc_now()
 
       new_message = %{
-        start_time: now,
-        end_time: nil,
+        start_datetime: now,
+        end_datetime: nil,
         days_of_week: [22],
         sign_ids: [],
         priority: 1,
@@ -173,11 +173,11 @@ defmodule Screenplay.PaMessagesTest do
       assert {_, _} = changeset.errors[:sign_ids]
       assert {_, _} = changeset.errors[:interval_in_minutes]
       assert {_, _} = changeset.errors[:visual_text]
-      assert {_, _} = changeset.errors[:end_time]
+      assert {_, _} = changeset.errors[:end_datetime]
 
       new_message = %{
-        start_time: DateTime.add(now, 61),
-        end_time: DateTime.add(now, 60),
+        start_datetime: DateTime.add(now, 61),
+        end_datetime: DateTime.add(now, 60),
         days_of_week: [1],
         sign_ids: ["test_sign"],
         priority: 1,
@@ -186,7 +186,7 @@ defmodule Screenplay.PaMessagesTest do
       }
 
       assert {:error, %Ecto.Changeset{} = changeset} = PaMessages.create_message(new_message)
-      assert {_, _} = changeset.errors[:start_time]
+      assert {_, _} = changeset.errors[:start_datetime]
     end
   end
 

--- a/test/screenplay_web/controllers/pa_messages_api_controller_test.exs
+++ b/test/screenplay_web/controllers/pa_messages_api_controller_test.exs
@@ -45,16 +45,16 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
 
       insert(:pa_message, %{
         id: 1,
-        start_time: ~U[2024-05-01T01:00:00Z],
-        end_time: ~U[2024-05-01T13:00:00Z],
+        start_datetime: ~U[2024-05-01T01:00:00Z],
+        end_datetime: ~U[2024-05-01T13:00:00Z],
         days_of_week: [1, 2, 3, 4, 5, 6, 7],
         inserted_at: ~U[2024-05-01T01:00:00Z]
       })
 
       insert(:pa_message, %{
         id: 2,
-        start_time: ~U[2024-05-02T12:00:00Z],
-        end_time: ~U[2024-05-02T12:00:00Z],
+        start_datetime: ~U[2024-05-02T12:00:00Z],
+        end_datetime: ~U[2024-05-02T12:00:00Z],
         days_of_week: [1, 2, 3, 4, 5, 6, 7],
         inserted_at: ~U[2024-05-02T12:00:00Z]
       })
@@ -72,22 +72,22 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
       insert(:pa_message, %{
         id: 1,
         days_of_week: [1, 2, 3, 4, 5, 6, 7],
-        start_time: ~U[2024-08-04 00:00:00Z],
-        end_time: ~U[2024-08-05 23:59:59Z]
+        start_datetime: ~U[2024-08-04 00:00:00Z],
+        end_datetime: ~U[2024-08-05 23:59:59Z]
       })
 
       insert(:pa_message, %{
         id: 2,
         days_of_week: [1, 2, 3, 4, 5, 6, 7],
-        start_time: ~U[2024-08-05 00:00:00Z],
-        end_time: ~U[2024-08-06 23:59:59Z]
+        start_datetime: ~U[2024-08-05 00:00:00Z],
+        end_datetime: ~U[2024-08-06 23:59:59Z]
       })
 
       insert(:pa_message, %{
         id: 3,
         days_of_week: [1, 2, 3, 4, 5, 6, 7],
-        start_time: ~U[2024-08-07 00:00:00Z],
-        end_time: ~U[2024-08-08 23:59:59Z]
+        start_datetime: ~U[2024-08-07 00:00:00Z],
+        end_datetime: ~U[2024-08-08 23:59:59Z]
       })
 
       assert [%{"id" => 2}] =
@@ -103,22 +103,22 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
       insert(:pa_message, %{
         id: 1,
         days_of_week: [1, 2, 3, 4, 5, 6, 7],
-        start_time: ~U[2024-08-04 00:00:00Z],
-        end_time: ~U[2024-08-05 23:59:59Z]
+        start_datetime: ~U[2024-08-04 00:00:00Z],
+        end_datetime: ~U[2024-08-05 23:59:59Z]
       })
 
       insert(:pa_message, %{
         id: 2,
         days_of_week: [1, 2, 3, 4, 5, 6, 7],
-        start_time: ~U[2024-08-05 00:00:00Z],
-        end_time: ~U[2024-08-06 23:59:59Z]
+        start_datetime: ~U[2024-08-05 00:00:00Z],
+        end_datetime: ~U[2024-08-06 23:59:59Z]
       })
 
       insert(:pa_message, %{
         id: 3,
         days_of_week: [1, 2, 3, 4, 5, 6, 7],
-        start_time: ~U[2024-08-07 00:00:00Z],
-        end_time: ~U[2024-08-08 23:59:59Z]
+        start_datetime: ~U[2024-08-07 00:00:00Z],
+        end_datetime: ~U[2024-08-08 23:59:59Z]
       })
 
       assert [%{"id" => 1}] =
@@ -134,22 +134,22 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
       insert(:pa_message, %{
         id: 1,
         days_of_week: [1, 2, 3, 4, 5, 6, 7],
-        start_time: ~U[2024-08-04 00:00:00Z],
-        end_time: ~U[2024-08-05 23:59:59Z]
+        start_datetime: ~U[2024-08-04 00:00:00Z],
+        end_datetime: ~U[2024-08-05 23:59:59Z]
       })
 
       insert(:pa_message, %{
         id: 2,
         days_of_week: [1, 2, 3, 4, 5, 6, 7],
-        start_time: ~U[2024-08-05 00:00:00Z],
-        end_time: ~U[2024-08-06 23:59:59Z]
+        start_datetime: ~U[2024-08-05 00:00:00Z],
+        end_datetime: ~U[2024-08-06 23:59:59Z]
       })
 
       insert(:pa_message, %{
         id: 3,
         days_of_week: [1, 2, 3, 4, 5, 6, 7],
-        start_time: ~U[2024-08-07 00:00:00Z],
-        end_time: ~U[2024-08-08 23:59:59Z]
+        start_datetime: ~U[2024-08-07 00:00:00Z],
+        end_datetime: ~U[2024-08-08 23:59:59Z]
       })
 
       assert [%{"id" => 3}] =
@@ -164,24 +164,24 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
         id: 1,
         sign_ids: ~w[a b],
         days_of_week: [1, 2, 3, 4, 5, 6, 7],
-        start_time: ~U[2024-08-04 00:00:00Z],
-        end_time: ~U[2024-08-05 23:59:59Z]
+        start_datetime: ~U[2024-08-04 00:00:00Z],
+        end_datetime: ~U[2024-08-05 23:59:59Z]
       })
 
       insert(:pa_message, %{
         id: 2,
         sign_ids: ~w[b],
         days_of_week: [1, 2, 3, 4, 5, 6, 7],
-        start_time: ~U[2024-08-05 00:00:00Z],
-        end_time: ~U[2024-08-06 23:59:59Z]
+        start_datetime: ~U[2024-08-05 00:00:00Z],
+        end_datetime: ~U[2024-08-06 23:59:59Z]
       })
 
       insert(:pa_message, %{
         id: 3,
         sign_ids: ~w[b c],
         days_of_week: [1, 2, 3, 4, 5, 6, 7],
-        start_time: ~U[2024-08-07 00:00:00Z],
-        end_time: ~U[2024-08-08 23:59:59Z]
+        start_datetime: ~U[2024-08-07 00:00:00Z],
+        end_datetime: ~U[2024-08-08 23:59:59Z]
       })
 
       assert [%{"id" => 1}, %{"id" => 2}, %{"id" => 3}] =
@@ -225,8 +225,8 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
         id: 1,
         sign_ids: ~w[place-one-sign place-two-sign],
         days_of_week: [1, 2, 3, 4, 5, 6, 7],
-        start_time: ~U[2024-08-04 00:00:00Z],
-        end_time: ~U[2024-08-05 23:59:59Z]
+        start_datetime: ~U[2024-08-04 00:00:00Z],
+        end_datetime: ~U[2024-08-05 23:59:59Z]
       })
 
       # Red and Blue
@@ -234,8 +234,8 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
         id: 2,
         sign_ids: ~w[place-two-sign],
         days_of_week: [1, 2, 3, 4, 5, 6, 7],
-        start_time: ~U[2024-08-05 00:00:00Z],
-        end_time: ~U[2024-08-06 23:59:59Z]
+        start_datetime: ~U[2024-08-05 00:00:00Z],
+        end_datetime: ~U[2024-08-06 23:59:59Z]
       })
 
       # Orange
@@ -243,8 +243,8 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
         id: 3,
         sign_ids: ~w[place-three-sign],
         days_of_week: [1, 2, 3, 4, 5, 6, 7],
-        start_time: ~U[2024-08-07 00:00:00Z],
-        end_time: ~U[2024-08-08 23:59:59Z]
+        start_datetime: ~U[2024-08-07 00:00:00Z],
+        end_datetime: ~U[2024-08-08 23:59:59Z]
       })
 
       assert [%{"id" => 1}] =
@@ -277,8 +277,8 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
       assert %{"success" => true} =
                conn
                |> post("/api/pa-messages", %{
-                 start_time: now,
-                 end_time: DateTime.add(now, 60),
+                 start_datetime: now,
+                 end_datetime: DateTime.add(now, 60),
                  days_of_week: [1, 2, 3],
                  sign_ids: ["test_sign"],
                  priority: 1,
@@ -296,8 +296,8 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
       assert %{"errors" => _} =
                conn
                |> post("/api/pa-messages", %{
-                 start_time: now,
-                 end_time: DateTime.add(now, 60),
+                 start_datetime: now,
+                 end_datetime: DateTime.add(now, 60),
                  days_of_week: [1, 2, 3, 90],
                  sign_ids: ["test_sign"],
                  priority: 1,

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -6,8 +6,8 @@ defmodule Screenplay.Factory do
   def pa_message_factory do
     %Screenplay.PaMessages.PaMessage{
       alert_id: nil,
-      start_time: nil,
-      end_time: nil,
+      start_datetime: nil,
+      end_datetime: nil,
       days_of_week: [],
       sign_ids: [],
       priority: 0,


### PR DESCRIPTION
This PR changes the columns `start_time` and `end_time` to `x_datetime`. There was a lot of mix and matching between `date`, `time`, and `datetime` so this will align our names for better clarity.