### PR TITLE
fix: Zone filter sorting

### DIFF
--- a/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/SelectZonesPage.tsx
+++ b/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/SelectZonesPage.tsx
@@ -222,44 +222,42 @@ const SelectZonesPage = ({
         <div className="filters-container">
           <div>Service type</div>
           <div className="filters">
-            {sortRoutes(Object.keys(ROUTE_TO_CLASS_NAMES_MAP)).map(
-              (routeID) => {
-                const branchFilters =
-                  routeID === "Green"
-                    ? selectedRoutes["Green"].sort().map((branchID) => {
-                        const branch = branchID.split("-")[1];
+            {sortRoutes(Object.keys(selectedRoutes)).map((routeID) => {
+              const branchFilters =
+                routeID === "Green"
+                  ? selectedRoutes["Green"].sort().map((branchID) => {
+                      const branch = branchID.split("-")[1];
 
-                        return (
-                          <Button
-                            key={`branch-filter-${branch}`}
-                            onClick={() => setSelectedRouteFilter(branchID)}
-                            className={cx("filter-button", {
-                              [ROUTE_TO_CLASS_NAMES_MAP["Green"]]:
-                                selectedRouteFilter === branchID,
-                            })}
-                          >
-                            <Dot /> {branch} Branch
-                          </Button>
-                        );
-                      })
-                    : null;
+                      return (
+                        <Button
+                          key={`branch-filter-${branch}`}
+                          onClick={() => setSelectedRouteFilter(branchID)}
+                          className={cx("filter-button", {
+                            [ROUTE_TO_CLASS_NAMES_MAP["Green"]]:
+                              selectedRouteFilter === branchID,
+                          })}
+                        >
+                          <Dot /> {branch} Branch
+                        </Button>
+                      );
+                    })
+                  : null;
 
-                return (
-                  <Fragment key={`route-filter-${routeID}`}>
-                    <Button
-                      onClick={() => setSelectedRouteFilter(routeID)}
-                      className={cx("filter-button", {
-                        [ROUTE_TO_CLASS_NAMES_MAP[routeID]]:
-                          selectedRouteFilter === routeID,
-                      })}
-                    >
-                      {routeID}
-                    </Button>
-                    {branchFilters}
-                  </Fragment>
-                );
-              },
-            )}
+              return (
+                <Fragment key={`route-filter-${routeID}`}>
+                  <Button
+                    onClick={() => setSelectedRouteFilter(routeID)}
+                    className={cx("filter-button", {
+                      [ROUTE_TO_CLASS_NAMES_MAP[routeID]]:
+                        selectedRouteFilter === routeID,
+                    })}
+                  >
+                    {routeID}
+                  </Button>
+                  {branchFilters}
+                </Fragment>
+              );
+            })}
           </div>
         </div>
         <div className="zones-table-container">


### PR DESCRIPTION
This PR addresses a big ole 🤦 . Accidentally changed a variable [here](https://github.com/mbta/screenplay/blob/a15c3ff18fc48fd705b07b53e02c74a727b36d63/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/SelectZonesPage.tsx#L225) that I shouldn't have. Was causing an error when a GL station was not selected.