### PR TITLE
chore: Add dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor"]
+    groups:
+      mix-patches:
+        applies-to: version-updates
+        update-types:
+          - "patch"
   - package-ecosystem: npm
     directory: "/assets"
     schedule:
@@ -19,10 +24,8 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor"]
     groups:
-      patches:
+      npm-patches:
         applies-to: version-updates
-        patterns:
-          - "*"
         update-types:
           - "patch"
       eslint:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
         update-types: ["version-update:semver-minor"]
     groups:
       mix-patches:
-        applies-to: version-updates
         update-types:
           - "patch"
   - package-ecosystem: npm
@@ -25,33 +24,27 @@ updates:
         update-types: ["version-update:semver-minor"]
     groups:
       npm-patches:
-        applies-to: version-updates
         update-types:
           - "patch"
       eslint:
-        applies-to: version-updates
         patterns:
           - "eslint*"
           - "@typescript-eslint*"
       react:
-        applies-to: version-updates
         patterns:
           - "react*"
           - "@types/react*"
       testing-tools:
-        applies-to: version-updates
         patterns:
           - "ts-jest"
           - "@types/jest"
           - "jest*"
           - "@testing-library*"
       babel:
-        applies-to: version-updates
         patterns:
           - "babel*"
           - "@babel*"
       webpack:
-        applies-to: version-updates
         patterns:
           - "webpack*"
           - "*webpack-plugin"
@@ -60,10 +53,8 @@ updates:
           - "css-loader"
           - "ts-loader"
       moment:
-        applies-to: version-updates
         patterns:
           - "moment*"
       sentry:
-        applies-to: version-updates
         patterns:
           - "@sentry/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,9 +22,9 @@ updates:
       patches:
         applies-to: version-updates
         patterns:
-        - "*"
+          - "*"
         update-types:
-        - "patch"
+          - "patch"
       eslint:
         applies-to: version-updates
         patterns:
@@ -35,28 +35,28 @@ updates:
         patterns:
           - "react*"
           - "@types/react*"
-     testing-tools:
+      testing-tools:
         applies-to: version-updates
         patterns:
           - "ts-jest"
           - "@types/jest"
           - "jest*"
           - "@testing-library*"
-     babel:
+      babel:
         applies-to: version-updates
         patterns:
           - "babel*"
           - "@babel*"
-     webpack:
+      webpack:
         applies-to: version-updates
         patterns:
           - "webpack*"
           - "*webpack-plugin"
-     moment:
+      moment:
         applies-to: version-updates
         patterns:
           - "moment*"
       sentry:
         applies-to: version-updates
         patterns:
-        - "@sentry/*"
+          - "@sentry/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,12 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor"]
     groups:
+      patches:
+        applies-to: version-updates
+        patterns:
+        - "*"
+        update-types:
+        - "patch"
       eslint:
         applies-to: version-updates
         patterns:
@@ -50,3 +56,7 @@ updates:
         applies-to: version-updates
         patterns:
           - "moment*"
+      sentry:
+        applies-to: version-updates
+        patterns:
+        - "@sentry/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,35 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor"]
+    groups:
+      eslint:
+        applies-to: version-updates
+        patterns:
+          - "eslint*"
+          - "@typescript-eslint*"
+      react:
+        applies-to: version-updates
+        patterns:
+          - "react*"
+          - "@types/react*"
+     testing-tools:
+        applies-to: version-updates
+        patterns:
+          - "ts-jest"
+          - "@types/jest"
+          - "jest*"
+          - "@testing-library*"
+     babel:
+        applies-to: version-updates
+        patterns:
+          - "babel*"
+          - "@babel*"
+     webpack:
+        applies-to: version-updates
+        patterns:
+          - "webpack*"
+          - "*webpack-plugin"
+     moment:
+        applies-to: version-updates
+        patterns:
+          - "moment*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,10 @@ updates:
         patterns:
           - "webpack*"
           - "*webpack-plugin"
+          - "file-loader"
+          - "sass-loader"
+          - "css-loader"
+          - "ts-loader"
       moment:
         applies-to: version-updates
         patterns:


### PR DESCRIPTION
I want to try out Dependabot's `groups` option so we can reduce the number of PRs it opens. Feel free to call out groups that should be added or groups I added that don't look right.