### PR TITLE
feat: api endpoint to update an existing pa message

### DIFF
--- a/lib/screenplay/pa_messages.ex
+++ b/lib/screenplay/pa_messages.ex
@@ -94,11 +94,30 @@ defmodule Screenplay.PaMessages do
   end
 
   @doc """
+  Gets a PaMessage with the given ID.
+  """
+  @spec get_message(id :: String.t()) :: PaMessage.t() | nil
+  def get_message(id) do
+    Repo.get(PaMessage, id)
+  end
+
+  @doc """
   Creates a new PA Message.
   """
   @spec create_message(message :: map()) ::
           {:ok, PaMessage.t()} | {:error, Ecto.Changeset.t()}
   def create_message(message) do
     %PaMessage{} |> PaMessage.changeset(message) |> Repo.insert()
+  end
+
+  @doc """
+  Updates an existing PA Message.
+  """
+  @spec update_message(pa_message :: PaMessage.t(), changes :: map()) ::
+          {:ok, PaMessage.t()} | {:error, Ecto.Changeset.t()}
+  def update_message(pa_message, changes) do
+    pa_message
+    |> PaMessage.changeset(changes)
+    |> Repo.update()
   end
 end

--- a/lib/screenplay_web/controllers/pa_messages_api_controller.ex
+++ b/lib/screenplay_web/controllers/pa_messages_api_controller.ex
@@ -6,13 +6,6 @@ defmodule ScreenplayWeb.PaMessagesApiController do
   alias Screenplay.PaMessages
   alias Screenplay.PaMessages.ListParams
 
-  def index(conn, params) do
-    with {:ok, opts} <- ListParams.parse(params) do
-      pa_messages = PaMessages.list_pa_messages(opts)
-      json(conn, pa_messages)
-    end
-  end
-
   def active(conn, _params) do
     json(conn, PaMessages.get_active_messages())
   end
@@ -27,9 +20,28 @@ defmodule ScreenplayWeb.PaMessagesApiController do
     end
   end
 
+  def index(conn, params) do
+    with {:ok, opts} <- ListParams.parse(params) do
+      pa_messages = PaMessages.list_pa_messages(opts)
+      json(conn, pa_messages)
+    end
+  end
+
   def create(conn, params) do
     with {:ok, _} <- PaMessages.create_message(params) do
       json(conn, %{success: true})
+    end
+  end
+
+  def update(conn, params = %{"id" => id}) do
+    if pa_message = PaMessages.get_message(id) do
+      with {:ok, updated_pa_message} <- PaMessages.update_message(pa_message, params) do
+        json(conn, updated_pa_message)
+      end
+    else
+      conn
+      |> put_status(404)
+      |> json(%{error: "not_found"})
     end
   end
 end

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -101,8 +101,7 @@ defmodule ScreenplayWeb.Router do
       :ensure_pa_message_admin
     ]
 
-    get "/api/pa-messages", PaMessagesApiController, :index
-    post "/api/pa-messages", PaMessagesApiController, :create
+    resources "/api/pa-messages", PaMessagesApiController, only: [:index, :create, :update]
   end
 
   scope "/", ScreenplayWeb do

--- a/test/fixtures/places_and_screens.json
+++ b/test/fixtures/places_and_screens.json
@@ -1,1 +1,1 @@
-[{"id":"place-test","name":"Test Place","routes":["Green-B"],"screens":[]}]
+[{"id":"place-test","name":"Test Place","screens":[],"routes":["Green-B"]}]

--- a/test/screenplay/pa_messages_test.exs
+++ b/test/screenplay/pa_messages_test.exs
@@ -129,7 +129,7 @@ defmodule Screenplay.PaMessagesTest do
     assert [%PaMessage{id: 1}] = PaMessages.get_active_messages(now)
   end
 
-  describe "create/1" do
+  describe "create_message/1" do
     test "creates new message" do
       now = ~U[2024-08-07T12:12:12Z]
 
@@ -187,6 +187,36 @@ defmodule Screenplay.PaMessagesTest do
 
       assert {:error, %Ecto.Changeset{} = changeset} = PaMessages.create_message(new_message)
       assert {_, _} = changeset.errors[:start_datetime]
+    end
+  end
+
+  describe "update_message/2" do
+    setup do
+      pa_message =
+        insert(:pa_message, %{
+          start_datetime: DateTime.utc_now(),
+          end_datetime: DateTime.utc_now() |> DateTime.add(1, :day),
+          visual_text: "Foobar",
+          audio_text: "Foo bar",
+          sign_ids: ["sign-1", "sign-2"]
+        })
+
+      [pa_message: pa_message]
+    end
+
+    test "updates an existing message", %{pa_message: pa_message} do
+      id = pa_message.id
+
+      assert {:ok, %PaMessage{id: ^id, visual_text: "Hello, World!"}} =
+               PaMessages.update_message(pa_message, %{
+                 visual_text: "Hello, World!"
+               })
+    end
+
+    test "returns an error changeset tuple if passed invalid update data", %{
+      pa_message: pa_message
+    } do
+      assert {:error, %Ecto.Changeset{}} = PaMessages.update_message(pa_message, %{sign_ids: []})
     end
   end
 

--- a/test/screenplay_web/controllers/pa_messages_api_controller_test.exs
+++ b/test/screenplay_web/controllers/pa_messages_api_controller_test.exs
@@ -308,4 +308,34 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
                |> json_response(422)
     end
   end
+
+  describe "PUT /api/pa-messages/:id" do
+    @tag :authenticated_pa_message_admin
+    test "updates a pa message and returns the updated pa message", %{conn: conn} do
+      insert(:pa_message, %{
+        id: 1,
+        start_datetime: ~U[2024-05-01T01:00:00Z],
+        end_datetime: ~U[2024-05-01T13:00:00Z],
+        days_of_week: [1, 2, 3, 4, 5, 6, 7],
+        inserted_at: ~U[2024-05-01T01:00:00Z],
+        visual_text: "Visual Text",
+        audio_text: "Audio Text"
+      })
+
+      assert %{"id" => 1, "visual_text" => "Updated Visual Text"} =
+               conn
+               |> put("/api/pa-messages/1", %{
+                 visual_text: "Updated Visual Text"
+               })
+               |> json_response(200)
+    end
+
+    @tag :authenticated_pa_message_admin
+    test "returns a 404 when the pa message does not exist", %{conn: conn} do
+      assert %{"error" => "not_found"} ==
+               conn
+               |> put("/api/pa-messages/1337", %{visual_text: "Updated Visual Text"})
+               |> json_response(404)
+    end
+  end
 end


### PR DESCRIPTION
Adds a new API endpoint that allows updating existing PA Messages.

Uses `resources/4` macro to define the index, create, and update methods for the PA Messages API in a standardized way.
