### PR TITLE
chore: Fix sign columns

### DIFF
--- a/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/SelectZonesPage.tsx
+++ b/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/SelectZonesPage.tsx
@@ -146,15 +146,11 @@ const SelectZonesPage = ({
       ),
     ).every(isSelected);
 
-  const selectDirectionGroup = (directionIds: (0 | 1)[]) => {
+  const selectDirectionGroup = (directionId: 0 | 1) => {
     const signsWithoutSelectedRoute = fp.without(signIDs(allScreens), value);
 
-    const newScreens = allScreens.filter(
-      (s) =>
-        fp.intersection(
-          s.routes?.map((r) => r.direction_id),
-          directionIds,
-        ).length > 0,
+    const newScreens = allScreens.filter((s) =>
+      s.routes?.map((r) => r.direction_id).includes(directionId),
     );
 
     onChange(fp.uniq([...signsWithoutSelectedRoute, ...signIDs(newScreens)]));
@@ -274,7 +270,9 @@ const SelectZonesPage = ({
                   className={cx("button-secondary-outline", {
                     "button-active": isAllSelected,
                   })}
-                  onClick={() => selectDirectionGroup([0, 1])}
+                  onClick={() =>
+                    onChange(fp.uniq([...value, ...signIDs(allScreens)]))
+                  }
                 >
                   {massSelectButtonLabels.left}
                 </Button>
@@ -282,7 +280,7 @@ const SelectZonesPage = ({
                   className={cx("button-secondary-outline", {
                     "button-active": isLeftSelected,
                   })}
-                  onClick={() => selectDirectionGroup([0])}
+                  onClick={() => selectDirectionGroup(0)}
                 >
                   {massSelectButtonLabels.middle}
                 </Button>
@@ -290,7 +288,7 @@ const SelectZonesPage = ({
                   className={cx("button-secondary-outline", {
                     "button-active": isRightSelected,
                   })}
-                  onClick={() => selectDirectionGroup([1])}
+                  onClick={() => selectDirectionGroup(1)}
                 >
                   {massSelectButtonLabels.right}
                 </Button>

--- a/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/SelectZonesPage.tsx
+++ b/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/SelectZonesPage.tsx
@@ -7,7 +7,7 @@ import {
   getPlacesFromFilter,
   getRouteIdsForSign,
   signIDs,
-  signsByZone,
+  signsByDirection,
   sortByStationOrder,
   sortRoutes,
 } from "../../../../util";
@@ -322,13 +322,13 @@ const SelectZonesPage = ({
                   const allBusSignsForRouteAtPlace =
                     getSignsFromPlaceForRouteId(place, "Bus");
 
-                  const signsGroupedByZone = signsByZone(
+                  const signsGroupedByZone = signsByDirection(
                     allSignsForRouteFilterAtPlace,
                   );
                   const busSignsGroupedByZone =
                     selectedRouteFilter === "Bus"
                       ? signsGroupedByZone
-                      : signsByZone(allBusSignsForRouteAtPlace);
+                      : signsByDirection(allBusSignsForRouteAtPlace);
 
                   const branches =
                     selectedRouteFilter === "Green"

--- a/assets/js/constants/constants.ts
+++ b/assets/js/constants/constants.ts
@@ -83,7 +83,3 @@ export const BASE_ROUTE_NAME_TO_ROUTE_IDS: { [key: string]: string[] } = {
   Mattapan: ["Mattapan"],
   Silver: SILVER_LINE_ROUTES,
 };
-
-export const LEFT_ZONES = ["s", "w"] as const;
-export const MIDDLE_ZONES = ["c", "m"] as const;
-export const RIGHT_ZONES = ["n", "e"] as const;

--- a/assets/js/util.ts
+++ b/assets/js/util.ts
@@ -1,8 +1,4 @@
-import {
-  BASE_ROUTE_NAME_TO_ROUTE_IDS,
-  LEFT_ZONES,
-  MIDDLE_ZONES,
-} from "Constants/constants";
+import { BASE_ROUTE_NAME_TO_ROUTE_IDS } from "Constants/constants";
 import {
   CannedMessage,
   CustomMessage,
@@ -185,12 +181,13 @@ export const placesWithSelectedAlert = (
     : [];
 };
 
-export const signsByZone = (signs: Screen[]) => {
+export const signsByDirection = (signs: Screen[]) => {
   const groupedSigns = fp.groupBy((sign) => {
-    if (fp.includes(sign.zone, LEFT_ZONES)) {
-      return "left";
-    } else if (fp.includes(sign.zone, MIDDLE_ZONES)) {
+    const directionIds = sign.routes?.map((r) => r.direction_id);
+    if (fp.intersection(directionIds, [0, 1]).length === 2) {
       return "middle";
+    } else if (directionIds?.includes(0)) {
+      return "left";
     } else {
       return "right";
     }


### PR DESCRIPTION
In the original implementation, I designed the page to organize the signs by zone in the same way SignsUI does. This was a misunderstanding and the signs should actually be organized by direction ID. I changed up the logic so the left column is direction 0, middle is 0 and 1, right is 1. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208030889228580