### PR TITLE
fix: disappearing places on SelectZonesPage

### DIFF
--- a/assets/.eslintrc.js
+++ b/assets/.eslintrc.js
@@ -41,7 +41,6 @@ module.exports = {
         unnamedComponents: "arrow-function",
       },
     ],
-    "react/hook-use-state": "error",
     "react/no-danger": "error",
     "jsx-a11y/no-static-element-interactions": "off",
     "jsx-a11y/click-events-have-key-events": "off",

--- a/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectZonesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectZonesPage.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useMemo, useRef, useState } from "react";
+import React, { Fragment, useMemo, useState } from "react";
 import { Page } from "../types";
 import { Button } from "react-bootstrap";
 import { Place } from "Models/place";
@@ -42,9 +42,11 @@ const SelectZonesPage = ({
   places,
 }: Props) => {
   const routeToRouteIDMap = useRouteToRouteIDsMap();
+  const getInitialPlacesWithSelectedSigns = () =>
+    places.filter((p) => p.screens.some((s) => value.includes(s.id)));
 
-  const { current: initialPlacesWithSelectedSigns } = useRef(
-    places.filter((p) => p.screens.some((s) => value.includes(s.id))),
+  const [initialPlacesWithSelectedSigns] = useState<Place[]>(
+    getInitialPlacesWithSelectedSigns,
   );
 
   const getInitialRoutes = () => {

--- a/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectZonesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectZonesPage.tsx
@@ -43,12 +43,7 @@ const SelectZonesPage = ({
 }: Props) => {
   const routeToRouteIDMap = useRouteToRouteIDsMap();
   const getInitialPlacesWithSelectedSigns = () =>
-    places.filter((p) =>
-      places
-        .filter((p) => p.screens.some((s) => value.includes(s.id)))
-        .map((p) => p.id)
-        .includes(p.id),
-    );
+    places.filter((p) => p.screens.some((s) => value.includes(s.id)));
 
   const getInitialRoutes = () => {
     return fp.flow(

--- a/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectZonesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectZonesPage.tsx
@@ -45,12 +45,14 @@ const SelectZonesPage = ({
   const getInitialPlacesWithSelectedSigns = () =>
     places.filter((p) => p.screens.some((s) => value.includes(s.id)));
 
+  // eslint-disable-next-line react/hook-use-state
+  const [initialPlacesWithSelectedSigns] = useState<Place[]>(
+    getInitialPlacesWithSelectedSigns,
+  );
+
   const getInitialRoutes = () => {
     return fp.flow(
-      fp.flatMap((place: Place) =>
-        place.screens.filter((s) => value.includes(s.id)),
-      ),
-      fp.flatMap(getRouteIdsForSign),
+      fp.flatMap((place: Place) => place.screens.flatMap(getRouteIdsForSign)),
       fp.uniq,
       fp.groupBy((routeID: string) => {
         if (routeID.startsWith("Green")) {
@@ -67,16 +69,10 @@ const SelectZonesPage = ({
 
         return routeID;
       }),
-    )(places);
+    )(initialPlacesWithSelectedSigns);
   };
 
-  // eslint-disable-next-line react/hook-use-state
-  const [initialPlacesWithSelectedSigns] = useState<Place[]>(
-    getInitialPlacesWithSelectedSigns,
-  );
-
-  // eslint-disable-next-line react/hook-use-state
-  const [initialRoutes] = useState(getInitialRoutes);
+  const initialRoutes = getInitialRoutes();
 
   const [selectedRouteFilter, setSelectedRouteFilter] = useState(
     Object.keys(initialRoutes)[0],

--- a/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectZonesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectZonesPage.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useMemo, useState } from "react";
+import React, { Fragment, useMemo, useRef, useState } from "react";
 import { Page } from "../types";
 import { Button } from "react-bootstrap";
 import { Place } from "Models/place";
@@ -42,12 +42,9 @@ const SelectZonesPage = ({
   places,
 }: Props) => {
   const routeToRouteIDMap = useRouteToRouteIDsMap();
-  const getInitialPlacesWithSelectedSigns = () =>
-    places.filter((p) => p.screens.some((s) => value.includes(s.id)));
 
-  // eslint-disable-next-line react/hook-use-state
-  const [initialPlacesWithSelectedSigns] = useState<Place[]>(
-    getInitialPlacesWithSelectedSigns,
+  const { current: initialPlacesWithSelectedSigns } = useRef(
+    places.filter((p) => p.screens.some((s) => value.includes(s.id))),
   );
 
   const getInitialRoutes = () => {

--- a/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectZonesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectZonesPage.tsx
@@ -116,15 +116,17 @@ const SelectZonesPage = ({
     };
   }, [selectedRouteFilter, directionLabels.left, directionLabels.right]);
 
-  const filteredPlaces = useMemo(() => {
-    const placesWithSelectedSigns = places.filter((p) =>
+  const initialPlacesWithSelectedSigns = useMemo(() => {
+    return places.filter((p) =>
       places
         .filter((p) => p.screens.some((s) => value.includes(s.id)))
         .map((p) => p.id)
         .includes(p.id),
     );
+  }, [places]);
 
-    return getPlacesFromFilter(placesWithSelectedSigns, (r) =>
+  const filteredPlaces = useMemo(() => {
+    return getPlacesFromFilter(initialPlacesWithSelectedSigns, (r) =>
       routeToRouteIDMap[selectedRouteFilter]?.some((a) => r === a),
     );
   }, [selectedRouteFilter, places, routeToRouteIDMap, value]);

--- a/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectZonesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectZonesPage.tsx
@@ -71,11 +71,12 @@ const SelectZonesPage = ({
   };
 
   // eslint-disable-next-line react/hook-use-state
-  const [initialPlacesWithSelectedSigns, _setInitialPlacesWithSelectedSigns] =
-    useState<Place[]>(getInitialPlacesWithSelectedSigns);
+  const [initialPlacesWithSelectedSigns] = useState<Place[]>(
+    getInitialPlacesWithSelectedSigns,
+  );
 
   // eslint-disable-next-line react/hook-use-state
-  const [initialRoutes, _setInitialRoutes] = useState(getInitialRoutes);
+  const [initialRoutes] = useState(getInitialRoutes);
 
   const [selectedRouteFilter, setSelectedRouteFilter] = useState(
     Object.keys(initialRoutes)[0],

--- a/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectZonesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectZonesPage.tsx
@@ -42,8 +42,15 @@ const SelectZonesPage = ({
   places,
 }: Props) => {
   const routeToRouteIDMap = useRouteToRouteIDsMap();
+  const getInitialPlacesWithSelectedSigns = () =>
+    places.filter((p) =>
+      places
+        .filter((p) => p.screens.some((s) => value.includes(s.id)))
+        .map((p) => p.id)
+        .includes(p.id),
+    );
 
-  const selectedRoutes = useMemo(() => {
+  const getInitialRoutes = () => {
     return fp.flow(
       fp.flatMap((place: Place) =>
         place.screens.filter((s) => value.includes(s.id)),
@@ -66,10 +73,17 @@ const SelectZonesPage = ({
         return routeID;
       }),
     )(places);
-  }, [places, routeToRouteIDMap, value]);
+  };
+
+  // eslint-disable-next-line react/hook-use-state
+  const [initialPlacesWithSelectedSigns, _setInitialPlacesWithSelectedSigns] =
+    useState<Place[]>(getInitialPlacesWithSelectedSigns);
+
+  // eslint-disable-next-line react/hook-use-state
+  const [initialRoutes, _setInitialRoutes] = useState(getInitialRoutes);
 
   const [selectedRouteFilter, setSelectedRouteFilter] = useState(
-    Object.keys(selectedRoutes)[0],
+    Object.keys(initialRoutes)[0],
   );
 
   const isSelected = (id: string) => value.includes(id);
@@ -116,20 +130,11 @@ const SelectZonesPage = ({
     };
   }, [selectedRouteFilter, directionLabels.left, directionLabels.right]);
 
-  const initialPlacesWithSelectedSigns = useMemo(() => {
-    return places.filter((p) =>
-      places
-        .filter((p) => p.screens.some((s) => value.includes(s.id)))
-        .map((p) => p.id)
-        .includes(p.id),
-    );
-  }, [places]);
-
   const filteredPlaces = useMemo(() => {
     return getPlacesFromFilter(initialPlacesWithSelectedSigns, (r) =>
       routeToRouteIDMap[selectedRouteFilter]?.some((a) => r === a),
     );
-  }, [selectedRouteFilter, places, routeToRouteIDMap, value]);
+  }, [selectedRouteFilter, routeToRouteIDMap, initialPlacesWithSelectedSigns]);
 
   const allScreens = filteredPlaces.flatMap((p) => {
     return p.screens.filter(
@@ -215,10 +220,10 @@ const SelectZonesPage = ({
         <div className="filters-container">
           <div>Service type</div>
           <div className="filters">
-            {sortRoutes(Object.keys(selectedRoutes)).map((routeID) => {
+            {sortRoutes(Object.keys(initialRoutes)).map((routeID) => {
               const branchFilters =
                 routeID === "Green"
-                  ? selectedRoutes["Green"].sort().map((branchID) => {
+                  ? initialRoutes["Green"].sort().map((branchID) => {
                       const branch = branchID.split("-")[1];
 
                       return (


### PR DESCRIPTION
Hoping to squash this bug once and for all. Tl;dr, unselecting all signs for a place would cause the place to disappear when changing the route filter. I think the problem was some of the logic in the original `useMemo` needs to change much less frequently than what is returned. I split out that piece into its own and places are no longer disappearing.