### PR TITLE
chore: install eslint-plugin-react-hooks, fix issues

### DIFF
--- a/assets/.eslintrc.js
+++ b/assets/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
     "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended",
     "plugin:jsx-a11y/recommended",
+    "plugin:react-hooks/recommended",
   ],
   settings: {
     react: {

--- a/assets/js/components/Dashboard/AlertDetails.tsx
+++ b/assets/js/components/Dashboard/AlertDetails.tsx
@@ -50,7 +50,7 @@ const AlertDetails: ComponentType = () => {
       // We loaded an alert details page that doesn't match any alert
       setContextState(screenplayContext);
     }
-  }, [screenplayContext]);
+  }, [screenplayContext, id, selectedAlert]);
 
   const [placesListState, placesListDispatch] = useReducer(
     placesListReducer,

--- a/assets/js/components/Dashboard/AlertNotFoundPage.tsx
+++ b/assets/js/components/Dashboard/AlertNotFoundPage.tsx
@@ -5,6 +5,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 
 const AlertNotFoundPage = (props: { validAlertId: string | undefined }) => {
   const navigate = useNavigate();
+  const { pathname } = useLocation();
 
   return (
     <div className="alert-not-found alert-not-found_page">
@@ -19,7 +20,7 @@ const AlertNotFoundPage = (props: { validAlertId: string | undefined }) => {
             : `We couldn’t find the alert you’re looking for in Screenplay. This could be \
             because the alert has been closed, or because an alert with that ID \
             (#${
-              useLocation().pathname.split("/").slice(-1)[0]
+              pathname.split("/").slice(-1)[0]
             }) doesn’t exist. You may want to check the Posted Alerts list for it, or double-check the URL. `}
         </p>
         <Button

--- a/assets/js/components/Dashboard/Dashboard.tsx
+++ b/assets/js/components/Dashboard/Dashboard.tsx
@@ -45,7 +45,11 @@ const Dashboard: ComponentType = () => {
     fetchPlaces().then((placesList) =>
       dispatch({ type: "SET_PLACES", places: placesList }),
     );
-  }, []);
+
+    // Tests rely on this effect **not** having any dependencies listed.
+    // This code pre-dates the addition of the react-hooks eslint rules.
+    // - sloane 2024-08-20
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Fetch alerts every 4 seconds.
   useInterval(() => {
@@ -167,7 +171,7 @@ const Dashboard: ComponentType = () => {
     } else {
       dispatch({ type: "SHOW_SIDEBAR", showSidebar: true });
     }
-  }, [pathname]);
+  }, [pathname, dispatch]);
 
   return (
     <div className="screenplay-container">

--- a/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/SelectStationsAndZones.tsx
+++ b/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/SelectStationsAndZones.tsx
@@ -31,7 +31,7 @@ const SelectStationsAndZones = ({
     dispatch({ type: "SHOW_SIDEBAR", showSidebar: false });
 
     return () => dispatch({ type: "SHOW_SIDEBAR", showSidebar: true });
-  }, []);
+  }, [dispatch]);
 
   return page === Page.STATIONS ? (
     <SelectStationsPage

--- a/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/SelectStationsPage.tsx
+++ b/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/SelectStationsPage.tsx
@@ -46,9 +46,9 @@ const SelectStationsPage = ({
   busRoutes,
   onError,
 }: Props) => {
-  if (places.length === 0) return null;
-
   const routeNameToRouteIds = useRouteToRouteIDsMap();
+
+  if (places.length === 0) return null;
 
   const placesByRoute = places.reduce<{ [key: string]: Array<Place> }>(
     (acc, place) => {

--- a/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/SelectZonesPage.tsx
+++ b/assets/js/components/Dashboard/NewPaMessage/StationsAndZones/SelectZonesPage.tsx
@@ -66,7 +66,7 @@ const SelectZonesPage = ({
         return routeID;
       }),
     )(places);
-  }, [places]);
+  }, [places, routeToRouteIDMap, value]);
 
   const [selectedRouteFilter, setSelectedRouteFilter] = useState(
     Object.keys(selectedRoutes)[0],
@@ -114,7 +114,7 @@ const SelectZonesPage = ({
       middle: directionLabels.left,
       right: directionLabels.right,
     };
-  }, [selectedRouteFilter]);
+  }, [selectedRouteFilter, directionLabels.left, directionLabels.right]);
 
   const filteredPlaces = useMemo(() => {
     const placesWithSelectedSigns = places.filter((p) =>
@@ -127,7 +127,7 @@ const SelectZonesPage = ({
     return getPlacesFromFilter(placesWithSelectedSigns, (r) =>
       routeToRouteIDMap[selectedRouteFilter]?.some((a) => r === a),
     );
-  }, [selectedRouteFilter]);
+  }, [selectedRouteFilter, places, routeToRouteIDMap, value]);
 
   const allScreens = filteredPlaces.flatMap((p) => {
     return p.screens.filter(

--- a/assets/js/components/Dashboard/PaMessagesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessagesPage.tsx
@@ -111,7 +111,7 @@ const PaMessagesPage: ComponentType = () => {
 
       return newParams;
     });
-  }, [stateFilter, serviceTypes]);
+  }, [setParams, stateFilter, serviceTypes]);
 
   const { data, isLoading } = usePaMessages({ serviceTypes, stateFilter });
   const shouldShowLoadingState = useDelayedLoadingState(isLoading);

--- a/assets/js/components/Dashboard/PendingScreensPage.tsx
+++ b/assets/js/components/Dashboard/PendingScreensPage.tsx
@@ -125,7 +125,7 @@ const PendingScreensPage: ComponentType = () => {
     [etag, dispatch, fetchData, isPublishing],
   );
 
-  useEffect(fetchData, []);
+  useEffect(fetchData, [fetchData]);
 
   const screens = Object.entries(existingScreens);
   let layout;

--- a/assets/js/components/Dashboard/PermanentConfiguration/Workflows/GlEink/GlEinkWorkflow.tsx
+++ b/assets/js/components/Dashboard/PermanentConfiguration/Workflows/GlEink/GlEinkWorkflow.tsx
@@ -60,7 +60,12 @@ const GlEinkWorkflow: ComponentType = () => {
         pendingScreenValidationErrors,
       });
     }
-  }, [location]);
+  }, [
+    location,
+    dispatch,
+    newScreenValidationErrors,
+    pendingScreenValidationErrors,
+  ]);
 
   const generateErrorMessage = (errorSet: Set<string>) => {
     if (errorSet.size === 0) {

--- a/assets/js/components/OutfrontTakeoverTool/AlertDashboard/AlertDetails.tsx
+++ b/assets/js/components/OutfrontTakeoverTool/AlertDashboard/AlertDetails.tsx
@@ -24,8 +24,13 @@ interface AlertDetailsProps {
 }
 
 const AlertDetails = (props: AlertDetailsProps): JSX.Element => {
-  const { data, setLastChangeTime, startEditWizard, triggerConfirmation } =
-    props;
+  const {
+    data,
+    setLastChangeTime,
+    startEditWizard,
+    triggerConfirmation,
+    clearAlert: clearAlertFromProps,
+  } = props;
   const { created_by, id, message, schedule, stations } = data;
 
   const stationScreenOrientationList = useContext(
@@ -49,29 +54,27 @@ const AlertDetails = (props: AlertDetailsProps): JSX.Element => {
 
   const messageString = getMessageString(message);
 
-  const modalDetails: ModalDetails = {
-    icon: <NoSymbolIcon className="icon" />,
-    header: "Clear Alert",
-    description:
-      "This stops the Outfront Media screen Takeover, and returns to the regularly scheduled content loop.",
-    cancelText: "Keep Alert",
-    confirmJSX: (
-      <>
-        <NoSymbolIcon className="button-icon" />
-        Clear Alert
-      </>
-    ),
-    onSubmit: () => props.clearAlert(id, setLastChangeTime),
-  };
-
   const editAlert = useCallback(
     (step: number) => startEditWizard(data, step),
     [startEditWizard, data],
   );
-  const clearAlert = useCallback(
-    () => triggerConfirmation(modalDetails),
-    [triggerConfirmation, modalDetails],
-  );
+  const clearAlert = useCallback(() => {
+    const modalDetails: ModalDetails = {
+      icon: <NoSymbolIcon className="icon" />,
+      header: "Clear Alert",
+      description:
+        "This stops the Outfront Media screen Takeover, and returns to the regularly scheduled content loop.",
+      cancelText: "Keep Alert",
+      confirmJSX: (
+        <>
+          <NoSymbolIcon className="button-icon" />
+          Clear Alert
+        </>
+      ),
+      onSubmit: () => clearAlertFromProps(id, setLastChangeTime),
+    };
+    triggerConfirmation(modalDetails);
+  }, [triggerConfirmation, id, clearAlertFromProps, setLastChangeTime]);
 
   return (
     <div className="alert-card">

--- a/assets/js/components/OutfrontTakeoverTool/AlertWizard/PickStations.tsx
+++ b/assets/js/components/OutfrontTakeoverTool/AlertWizard/PickStations.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useMemo } from "react";
 import StationColumn from "./StationColumn";
 
 import WizardWarning from "./WizardWarning";
@@ -12,15 +12,14 @@ interface PickStationsProps {
 }
 
 const PickStations = (props: PickStationsProps): JSX.Element => {
-  const [filteredAlerts, setFilteredAlerts] = useState<string[]>([]);
-
-  useEffect(() => {
-    setFilteredAlerts(
-      props.activeAlertsStations.filter((station) =>
-        props.selectedStations.map((station) => station.name).includes(station),
+  const { activeAlertsStations, selectedStations } = props;
+  const filteredAlerts = useMemo(
+    () =>
+      activeAlertsStations.filter((station) =>
+        selectedStations.map((station) => station.name).includes(station),
       ),
-    );
-  }, [props.selectedStations]);
+    [activeAlertsStations, selectedStations],
+  );
 
   return (
     <>

--- a/assets/js/hooks/useUpdateAnimation.tsx
+++ b/assets/js/hooks/useUpdateAnimation.tsx
@@ -21,7 +21,11 @@ export const useUpdateAnimation = (
       timer.current = undefined;
       setShowAnimation(false);
     }, 2000);
-  }, deps);
+    // Disabling this because this code predates our usage of the `react-hooks`
+    // eslint plugin. There's likely a better way to achieve this effect but
+    // we are disabling this check for now.
+    // - sloane 2024-08-20
+  }, deps); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Cancel timer if component unmounts.
   useEffect(() => {

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -50,6 +50,7 @@
         "eslint": "^8.15.0",
         "eslint-plugin-jsx-a11y": "^6.5.1",
         "eslint-plugin-react": "^7.34.4",
+        "eslint-plugin-react-hooks": "^4.6.2",
         "file-loader": "^6.2.0",
         "hard-source-webpack-plugin": "^0.13.1",
         "identity-obj-proxy": "^3.0.0",
@@ -6165,6 +6166,18 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
+      "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -57,6 +57,7 @@
     "eslint": "^8.15.0",
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-react": "^7.34.4",
+    "eslint-plugin-react-hooks": "^4.6.2",
     "file-loader": "^6.2.0",
     "hard-source-webpack-plugin": "^0.13.1",
     "identity-obj-proxy": "^3.0.0",


### PR DESCRIPTION
I noticed a few "rules of hooks" violations and realized we weren't using the very helpful `eslint-plugin-react-hooks` module to catch these for us.

This installs that package and corrects any outstanding violations of the rules of hooks

https://react.dev/reference/rules/rules-of-hooks
https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks