### PR TITLE
feat(api): get single pa message by id

### DIFF
--- a/lib/screenplay_web/controllers/pa_messages_api_controller.ex
+++ b/lib/screenplay_web/controllers/pa_messages_api_controller.ex
@@ -44,4 +44,14 @@ defmodule ScreenplayWeb.PaMessagesApiController do
       |> json(%{error: "not_found"})
     end
   end
+
+  def show(conn, %{"id" => id}) do
+    if pa_message = PaMessages.get_message(id) do
+      json(conn, pa_message)
+    else
+      conn
+      |> put_status(404)
+      |> json(%{error: "not_found"})
+    end
+  end
 end

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -92,19 +92,6 @@ defmodule ScreenplayWeb.Router do
   end
 
   scope "/", ScreenplayWeb do
-    pipe_through [
-      :redirect_prod_http,
-      :api,
-      :auth,
-      :ensure_auth,
-      :metadata,
-      :ensure_pa_message_admin
-    ]
-
-    resources "/api/pa-messages", PaMessagesApiController, only: [:index, :create, :update]
-  end
-
-  scope "/", ScreenplayWeb do
     pipe_through([
       :redirect_prod_http,
       :browser,
@@ -179,6 +166,19 @@ defmodule ScreenplayWeb.Router do
     pipe_through([:redirect_prod_http, :api, :ensure_api_auth])
 
     get("/active", PaMessagesApiController, :active)
+  end
+
+  scope "/", ScreenplayWeb do
+    pipe_through [
+      :redirect_prod_http,
+      :api,
+      :auth,
+      :ensure_auth,
+      :metadata,
+      :ensure_pa_message_admin
+    ]
+
+    resources "/api/pa-messages", PaMessagesApiController, only: [:index, :create, :update, :show]
   end
 
   # Enables LiveDashboard only for development

--- a/test/screenplay_web/controllers/pa_messages_api_controller_test.exs
+++ b/test/screenplay_web/controllers/pa_messages_api_controller_test.exs
@@ -338,4 +338,32 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
                |> json_response(404)
     end
   end
+
+  describe "GET /api/pa-messages/:id" do
+    @tag :authenticated_pa_message_admin
+    test "returns the PA message with the given ID", %{conn: conn} do
+      insert(:pa_message, %{
+        id: 1,
+        start_datetime: ~U[2024-05-01T01:00:00Z],
+        end_datetime: ~U[2024-05-01T13:00:00Z],
+        days_of_week: [1, 2, 3, 4, 5, 6, 7],
+        inserted_at: ~U[2024-05-01T01:00:00Z],
+        visual_text: "Visual Text",
+        audio_text: "Audio Text"
+      })
+
+      assert %{"id" => 1} =
+               conn
+               |> get("/api/pa-messages/1")
+               |> json_response(200)
+    end
+
+    @tag :authenticated_pa_message_admin
+    test "returns a 404 if the PA message doesn't exist", %{conn: conn} do
+      assert %{"error" => "not_found"} =
+               conn
+               |> get("/api/pa-messages/1234")
+               |> json_response(404)
+    end
+  end
 end


### PR DESCRIPTION
Adds a "show" endpoint for PA messages at /api/pa-messages/:id
