### PR TITLE
feat: support editing pa messages

### DIFF
--- a/assets/css/dashboard/new-pa-message/new-pa-message-page.scss
+++ b/assets/css/dashboard/new-pa-message/new-pa-message-page.scss
@@ -283,11 +283,16 @@
       height: 24px;
     }
 
-    .effect-period {
+    .effect-period,
+    .alert-ended {
       margin-top: 4px;
       font-size: 14px;
       font-weight: 400;
       width: 100%;
+    }
+
+    .alert-ended {
+      color: $text-error;
     }
   }
 

--- a/assets/css/dashboard/pa-messages-page.scss
+++ b/assets/css/dashboard/pa-messages-page.scss
@@ -78,6 +78,7 @@
 .pa-message-table {
   margin: 16px 14px;
   background-color: $cool-gray-15;
+  max-width: 1096px;
 
   th,
   td {
@@ -92,6 +93,16 @@
 
   td {
     border-bottom: 1px solid $bg-elevation-4;
+  }
+
+  tr:hover {
+    background-color: $cool-gray-20;
+    cursor: pointer;
+  }
+
+  &__text {
+    color: $text-primary;
+    text-decoration: none;
   }
 
   &__start-end {

--- a/assets/js/components/App.tsx
+++ b/assets/js/components/App.tsx
@@ -21,6 +21,7 @@ const SelectScreenTypeComponent = React.lazy(
 );
 const PaMessagesPage = React.lazy(() => import("Components/PaMessagesPage"));
 const NewPaMessage = React.lazy(() => import("Components/NewPaMessage"));
+const EditPaMessage = React.lazy(() => import("Components/EditPaMessage"));
 
 class AppRoutes extends React.Component {
   render() {
@@ -49,6 +50,7 @@ class AppRoutes extends React.Component {
             </Route>
             <Route path="pa-messages" element={<PaMessagesPage />} />
             <Route path="pa-messages/new" element={<NewPaMessage />} />
+            <Route path="pa-messages/:id/edit" element={<EditPaMessage />} />
           </Route>
         </Routes>
       </React.Suspense>

--- a/assets/js/components/Dashboard/EditPaMessage/EditPaMessage.tsx
+++ b/assets/js/components/Dashboard/EditPaMessage/EditPaMessage.tsx
@@ -1,0 +1,125 @@
+import React, { useEffect, useMemo, useState } from "react";
+import useSWR, { mutate } from "swr";
+import { useNavigate, useParams } from "react-router-dom";
+import { PaMessage } from "Models/pa_message";
+import PaMessageForm from "../PaMessageForm";
+import { updateExistingPaMessage } from "Utils/api";
+import { Alert } from "Models/alert";
+import { AudioPreview } from "Components/PaMessageForm/types";
+
+const useAlert = (id: string | null | undefined) => {
+  const { data: alerts, isLoading } = useSWR<Array<Alert>>(
+    id ? "/api/alerts/non_access_alerts" : null,
+    async (url: string | null) => {
+      if (url == null) return [];
+
+      const response = await fetch(url);
+      const { alerts } = await response.json();
+      return alerts;
+    },
+  );
+
+  const alert = useMemo(() => {
+    if (id == null) return null;
+    return alerts?.find((a) => a.id === id);
+  }, [id, alerts]);
+
+  return {
+    alert,
+    isLoading,
+  };
+};
+
+const usePaMessage = (id: string | number) => {
+  const {
+    data: paMessage,
+    isLoading,
+    error,
+  } = useSWR<PaMessage>(`/api/pa-messages/${id}`, async (url: string) => {
+    const response = await fetch(url);
+    const body = await response.json();
+
+    if (400 <= response.status) throw response;
+    return body;
+  });
+
+  return {
+    paMessage,
+    isLoading,
+    error,
+  };
+};
+
+const FetchPaMessage = ({ id }: { id: string | number }) => {
+  const navigate = useNavigate();
+  const { paMessage, isLoading, error } = usePaMessage(id);
+
+  useEffect(() => {
+    if (error?.status === 404) navigate("/pa-messages");
+  }, [error, navigate]);
+
+  if (isLoading || error || paMessage == null) return null;
+
+  return <FetchAlert paMessage={paMessage} />;
+};
+
+const FetchAlert = ({ paMessage }: { paMessage: PaMessage }) => {
+  const { alert, isLoading } = useAlert(paMessage.alert_id);
+
+  if (isLoading) return null;
+
+  return <EditPaMessage paMessage={paMessage} alert={alert} />;
+};
+
+const EditPaMessageContainer = () => {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+
+  useEffect(() => {
+    if (!id) navigate("/pa-messages");
+  }, [id, navigate]);
+
+  if (!id) return;
+
+  return <FetchPaMessage id={id} />;
+};
+
+interface Props {
+  paMessage: PaMessage;
+  alert?: Alert | null;
+}
+
+const EditPaMessage = ({ paMessage, alert }: Props) => {
+  const navigate = useNavigate();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [errors, setErrors] = useState<string[]>([]);
+
+  return (
+    <PaMessageForm
+      key={paMessage.updated_at}
+      title="Edit PA/ESS message"
+      errors={errors}
+      errorMessage={errorMessage}
+      onError={setErrorMessage}
+      onErrorsChange={setErrors}
+      defaultValues={paMessage}
+      defaultAlert={alert ?? paMessage.alert_id}
+      defaultAudioState={AudioPreview.Reviewed}
+      onSubmit={async (data) => {
+        const result = await updateExistingPaMessage(paMessage.id, data);
+
+        if (result.status === 200) {
+          mutate(`/api/pa-messages/${paMessage.id}`);
+          navigate("/pa-messages");
+        } else if (result.status === 422) {
+          setErrorMessage("Correct the following errors:");
+          setErrors(Object.keys(result.body.errors));
+        } else {
+          setErrorMessage("Something went wrong. Please try again.");
+        }
+      }}
+    />
+  );
+};
+
+export default EditPaMessageContainer;

--- a/assets/js/components/Dashboard/EditPaMessage/index.ts
+++ b/assets/js/components/Dashboard/EditPaMessage/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./EditPaMessage";

--- a/assets/js/components/Dashboard/PaMessageForm/AssociateAlert.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/AssociateAlert.tsx
@@ -22,12 +22,12 @@ import { Page } from "./types";
 import moment from "moment";
 
 interface AssociateAlertPageProps {
-  associatedAlert: Alert;
+  associatedAlert: Alert | string | null;
   endWithEffectPeriod: boolean;
   onImportMessage: (message: string) => void;
   onImportLocations: (informedEntities: InformedEntity[]) => void;
   navigateTo: (page: Page) => void;
-  setAssociatedAlert: Dispatch<SetStateAction<Alert>>;
+  setAssociatedAlert: Dispatch<SetStateAction<Alert | string | null>>;
   setEndWithEffectPeriod: Dispatch<SetStateAction<boolean>>;
 }
 
@@ -54,7 +54,7 @@ const AssociateAlert = ({
     useState<string>("active");
   const [selectedServiceType, setSelectedServiceType] = useState<string>("All");
   const [showAlertModal, setShowAlertModal] = useState<boolean>(
-    associatedAlert.id !== undefined,
+    associatedAlert != null,
   );
 
   const serviceTypes = [
@@ -158,10 +158,14 @@ const AssociateAlert = ({
                 Alert ID:{" "}
               </div>
               <div className="alert-description__header-id">
-                {associatedAlert.id}
+                {typeof associatedAlert === "string"
+                  ? associatedAlert
+                  : associatedAlert?.id}
               </div>
             </div>
-            {associatedAlert.header}
+            {typeof associatedAlert === "string"
+              ? null
+              : associatedAlert?.header}
           </div>
           <div className="checkbox">
             <Form.Check
@@ -205,6 +209,11 @@ const AssociateAlert = ({
           </Button>
           <Button
             onClick={() => {
+              if (
+                associatedAlert == null ||
+                typeof associatedAlert === "string"
+              )
+                return;
               if (importMessage) {
                 onImportMessage(associatedAlert.header);
               }
@@ -227,7 +236,7 @@ interface AssociateAlertsTableProps {
   alerts: Alert[];
   messageStateFilter: string;
   serviceTypeFilter: string;
-  setAssociatedAlert: Dispatch<SetStateAction<Alert>>;
+  setAssociatedAlert: Dispatch<SetStateAction<Alert | string | null>>;
   setShowAlertModal: Dispatch<SetStateAction<boolean>>;
 }
 
@@ -302,7 +311,7 @@ const AssociateAlertsTable: ComponentType<AssociateAlertsTableProps> = ({
 
 interface AssociateAlertsTableRowProps {
   alert: Alert;
-  setAssociatedAlert: Dispatch<SetStateAction<Alert>>;
+  setAssociatedAlert: Dispatch<SetStateAction<Alert | string | null>>;
   setShowAlertModal: Dispatch<SetStateAction<boolean>>;
 }
 

--- a/assets/js/components/Dashboard/PaMessageForm/types.ts
+++ b/assets/js/components/Dashboard/PaMessageForm/types.ts
@@ -1,3 +1,10 @@
+export enum AudioPreview {
+  Unreviewed,
+  Playing,
+  Reviewed,
+  Outdated,
+}
+
 export enum Page {
   MAIN = "main",
   STATIONS = "stations",

--- a/assets/js/components/Dashboard/PaMessagesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessagesPage.tsx
@@ -9,7 +9,7 @@ import {
 } from "react-bootstrap";
 import { PlusCircleFill } from "react-bootstrap-icons";
 import { PaMessage } from "Models/pa_message";
-import { Link, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import cx from "classnames";
 import useSWR from "swr";
 import { useRouteToRouteIDsMap } from "Hooks/useRouteToRouteIDsMap";
@@ -243,12 +243,13 @@ interface PaMessageRowProps {
 const PaMessageRow: ComponentType<PaMessageRowProps> = ({
   paMessage,
 }: PaMessageRowProps) => {
+  const navigate = useNavigate();
   const start = new Date(paMessage.start_datetime);
   const end =
     paMessage.end_datetime === null ? null : new Date(paMessage.end_datetime);
 
   return (
-    <tr>
+    <tr onClick={() => navigate(`/pa-messages/${paMessage.id}/edit`)}>
       <td>{paMessage.visual_text}</td>
       <td>{paMessage.interval_in_minutes} min</td>
       <td className="pa-message-table__start-end">

--- a/assets/js/models/pa_message.ts
+++ b/assets/js/models/pa_message.ts
@@ -12,10 +12,11 @@ export interface PaMessage {
   paused: boolean;
   saved: boolean;
   inserted_at: string;
+  updated_at: string;
 }
 
 export type NewPaMessageBody = Omit<
   PaMessage,
-  "id" | "paused" | "saved" | "inserted_at"
+  "id" | "paused" | "saved" | "inserted_at" | "updated_at"
 >;
 export type UpdatePaMessageBody = Partial<PaMessage>;

--- a/assets/js/utils/api.ts
+++ b/assets/js/utils/api.ts
@@ -4,7 +4,7 @@ import { ScreenConfiguration } from "../models/screen_configuration";
 import { ScreensByAlert } from "../models/screensByAlert";
 import { PlaceIdsAndNewScreens } from "../components/Dashboard/PermanentConfiguration/Workflows/GlEink/ConfigureScreensPage";
 import getCsrfToken from "../csrf";
-import { NewPaMessageBody } from "Models/pa_message";
+import { NewPaMessageBody, UpdatePaMessageBody } from "Models/pa_message";
 
 export const fetchPlaces = async (): Promise<Place[]> => {
   const response = await fetch("/api/dashboard");
@@ -126,6 +126,26 @@ export const createNewPaMessage = async (message: NewPaMessageBody) => {
   return {
     status: response.status,
     errors: JSON.parse(await response.text()).errors,
+  };
+};
+
+export const updateExistingPaMessage = async (
+  id: string | number,
+  updates: UpdatePaMessageBody,
+) => {
+  const response = await fetch(`/api/pa-messages/${id}`, {
+    method: "PUT",
+    credentials: "include",
+    headers: {
+      "content-type": "application/json",
+      "x-csrf-token": getCsrfToken(),
+    },
+    body: JSON.stringify(updates),
+  });
+
+  return {
+    status: response.status,
+    body: await response.json(),
   };
 };
 

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -88,6 +88,7 @@ defmodule ScreenplayWeb.Router do
     get("/pa-messages", PaMessagesController, :index)
     get("/pa-messages/new", PaMessagesController, :index)
     get("/pa-messages/new/associate-alert", PaMessagesController, :index)
+    get("/pa-messages/:id/edit", PaMessagesController, :index)
     get("/api/pa-messages/preview_audio", PaMessagesApiController, :preview_audio)
   end
 


### PR DESCRIPTION
- Adds a new EditPaMessage page at `/pa-messages/:id/edit`.
- Fetches the current PA message and pre-populates the PaMessageForm
- Attempts to fetch an associated alert
- Handles the case when a PA message's associated alert has ended and is no longer in the feed.

**Asana task**: [Existing Message Edit Page](https://app.asana.com/0/1185117109217413/1207154234320382/f)
