### PR TITLE
fix: re-enable review audio

### DIFF
--- a/assets/js/components/Dashboard/PaMessageForm/MainForm.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/MainForm.tsx
@@ -335,7 +335,12 @@ const MainForm = ({
                 <MessageTextBox
                   id="visual-text-box"
                   text={visualText}
-                  onChangeText={(text) => setVisualText(text)}
+                  onChangeText={(text) => {
+                    setVisualText(text);
+                    if (audioState !== AudioPreview.Unreviewed) {
+                      setAudioState(AudioPreview.Outdated);
+                    }
+                  }}
                   label="Text"
                   maxLength={MAX_TEXT_LENGTH}
                   required
@@ -364,7 +369,12 @@ const MainForm = ({
                     <MessageTextBox
                       id="phonetic-audio-text-box"
                       text={phoneticText}
-                      onChangeText={(text) => setPhoneticText(text)}
+                      onChangeText={(text) => {
+                        setPhoneticText(text);
+                        if (audioState !== AudioPreview.Unreviewed) {
+                          setAudioState(AudioPreview.Outdated);
+                        }
+                      }}
                       disabled={phoneticText.length === 0}
                       label="Phonetic Audio"
                       maxLength={MAX_TEXT_LENGTH}

--- a/assets/js/components/Dashboard/PaMessageForm/PaMessageForm.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/PaMessageForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import moment, { type Moment } from "moment";
 import MainForm from "./MainForm";
 import { AudioPreview, Page } from "./types";
@@ -80,10 +80,12 @@ const PaMessageForm = ({
       ? `${defaultValues?.interval_in_minutes}`
       : "4";
   });
-  const defaultVisualText = defaultValues?.visual_text ?? "";
-  const [visualText, setVisualText] = useState(defaultVisualText);
-  const defaultPhoneticText = defaultValues?.audio_text ?? "";
-  const [phoneticText, setPhoneticText] = useState(defaultPhoneticText);
+  const [visualText, setVisualText] = useState(
+    defaultValues?.visual_text ?? "",
+  );
+  const [phoneticText, setPhoneticText] = useState(
+    defaultValues?.audio_text ?? "",
+  );
 
   const [signIds, setSignIds] = useState<string[]>(() => {
     return defaultValues?.sign_ids ?? [];
@@ -95,23 +97,6 @@ const PaMessageForm = ({
     () => defaultAudioState ?? AudioPreview.Unreviewed,
   );
 
-  useEffect(() => {
-    if (
-      visualText !== defaultVisualText ||
-      phoneticText !== defaultPhoneticText
-    ) {
-      if (audioState !== AudioPreview.Unreviewed) {
-        setAudioState(AudioPreview.Outdated);
-      }
-    }
-  }, [
-    defaultPhoneticText,
-    defaultVisualText,
-    visualText,
-    phoneticText,
-    audioState,
-  ]);
-
   const onClearAssociatedAlert = () => {
     setEndDateTime(moment(startDateTime).add(1, "hour"));
     setAssociatedAlert(null);
@@ -119,6 +104,8 @@ const PaMessageForm = ({
   };
 
   const onImportMessage = (alertMessage: string) => {
+    if (audioState !== AudioPreview.Unreviewed)
+      setAudioState(AudioPreview.Outdated);
     setVisualText(alertMessage);
   };
 


### PR DESCRIPTION
The `useEffect` based updating of `audioState` was resetting the `audioState` to "outdated" if the message text or phonetic audio were different from their starting values.

This manually sets `audioState` in each place that should cause `audioState` to become "outdated" instead. This is how this state was updated prior to the `useEffect` based refactor.
