### PR TITLE
fix: SelectZonesPage initial filter value

### DIFF
--- a/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectZonesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectZonesPage.tsx
@@ -49,9 +49,15 @@ const SelectZonesPage = ({
     getInitialPlacesWithSelectedSigns,
   );
 
+  const isSelected = (id: string) => value.includes(id);
+
   const getInitialRoutes = () => {
     return fp.flow(
-      fp.flatMap((place: Place) => place.screens.flatMap(getRouteIdsForSign)),
+      fp.flatMap((place: Place) =>
+        place.screens
+          .filter((s) => isSelected(s.id))
+          .flatMap(getRouteIdsForSign),
+      ),
       fp.uniq,
       fp.groupBy((routeID: string) => {
         if (routeID.startsWith("Green")) {

--- a/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectZonesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectZonesPage.tsx
@@ -77,11 +77,11 @@ const SelectZonesPage = ({
     )(initialPlacesWithSelectedSigns);
   };
 
-  const initialRoutes = getInitialRoutes();
-  const routeFilterLabels = sortRoutes(Object.keys(initialRoutes));
+  const routeFilterGroups = getInitialRoutes();
+  const routeFilterIds = sortRoutes(Object.keys(routeFilterGroups));
 
   const [selectedRouteFilter, setSelectedRouteFilter] = useState(
-    routeFilterLabels[0],
+    routeFilterIds[0],
   );
 
   const directionLabels = useMemo(() => {
@@ -216,10 +216,10 @@ const SelectZonesPage = ({
         <div className="filters-container">
           <div>Service type</div>
           <div className="filters">
-            {routeFilterLabels.map((routeID) => {
+            {routeFilterIds.map((routeID) => {
               const branchFilters =
                 routeID === "Green"
-                  ? initialRoutes["Green"].sort().map((branchID) => {
+                  ? routeFilterGroups["Green"].sort().map((branchID) => {
                       const branch = branchID.split("-")[1];
 
                       return (

--- a/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectZonesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectZonesPage.tsx
@@ -51,7 +51,7 @@ const SelectZonesPage = ({
 
   const isSelected = (id: string) => value.includes(id);
 
-  const getInitialRoutes = () => {
+  const getRouteFilterGroups = () => {
     return fp.flow(
       fp.flatMap((place: Place) =>
         place.screens
@@ -77,7 +77,7 @@ const SelectZonesPage = ({
     )(initialPlacesWithSelectedSigns);
   };
 
-  const routeFilterGroups = getInitialRoutes();
+  const routeFilterGroups = getRouteFilterGroups();
   const routeFilterIds = sortRoutes(Object.keys(routeFilterGroups));
 
   const [selectedRouteFilter, setSelectedRouteFilter] = useState(

--- a/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectZonesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectZonesPage.tsx
@@ -78,12 +78,11 @@ const SelectZonesPage = ({
   };
 
   const initialRoutes = getInitialRoutes();
+  const routeFilterLabels = sortRoutes(Object.keys(initialRoutes));
 
   const [selectedRouteFilter, setSelectedRouteFilter] = useState(
-    Object.keys(initialRoutes)[0],
+    routeFilterLabels[0],
   );
-
-  const isSelected = (id: string) => value.includes(id);
 
   const directionLabels = useMemo(() => {
     switch (selectedRouteFilter) {
@@ -217,7 +216,7 @@ const SelectZonesPage = ({
         <div className="filters-container">
           <div>Service type</div>
           <div className="filters">
-            {sortRoutes(Object.keys(initialRoutes)).map((routeID) => {
+            {routeFilterLabels.map((routeID) => {
               const branchFilters =
                 routeID === "Green"
                   ? initialRoutes["Green"].sort().map((branchID) => {


### PR DESCRIPTION
When rendering the `SelectZonesPage`, `selectedRouteFilter` was being assigned to the first route ID in `initialRoutes` before it was sorted. Initializing the labels earlier and using the same variable to initialize and render helps solve this.

I also fixed an issue with all routes showing in the filter list instead of just the routes for the selected screens.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208169473836920