### PR TITLE
fix: Permanent Config bugs

### DIFF
--- a/assets/css/dashboard/configure-screens-workflow-page.scss
+++ b/assets/css/dashboard/configure-screens-workflow-page.scss
@@ -53,7 +53,9 @@
         }
 
         .direction {
-          width: 269px;
+          button {
+            width: 138px;
+          }
         }
 
         .error-text {

--- a/assets/js/components/Dashboard/PermanentConfiguration/Workflows/GlEink/GlEinkWorkflow.tsx
+++ b/assets/js/components/Dashboard/PermanentConfiguration/Workflows/GlEink/GlEinkWorkflow.tsx
@@ -1,4 +1,9 @@
-import React, { ComponentType, useLayoutEffect, useState } from "react";
+import React, {
+  ComponentType,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from "react";
 import ConfigureScreensWorkflowPage, {
   PlaceIdsAndNewScreens,
 } from "Components/PermanentConfiguration/Workflows/GlEink/ConfigureScreensPage";
@@ -188,6 +193,11 @@ const GlEinkWorkflow: ComponentType = () => {
     });
   };
 
+  const filteredPlaces = useMemo(
+    () => places.filter((place) => selectedPlaces.has(place.id)),
+    [places, selectedPlaces],
+  );
+
   const handleVersionMismatchResponse = () => {
     setShowErrorModal(true);
   };
@@ -295,9 +305,7 @@ const GlEinkWorkflow: ComponentType = () => {
             </Modal.Footer>
           </Modal>
           <ConfigureScreensWorkflowPage
-            selectedPlaces={places.filter((place) =>
-              selectedPlaces.has(place.id),
-            )}
+            selectedPlaces={filteredPlaces}
             setPlacesAndScreensToUpdate={setPlacesAndScreensToUpdate}
             setConfigVersion={setConfigVersion}
             isEditing={isEditing}

--- a/lib/screenplay_web/controllers/config_html.ex
+++ b/lib/screenplay_web/controllers/config_html.ex
@@ -1,0 +1,5 @@
+defmodule ScreenplayWeb.ConfigHTML do
+  use ScreenplayWeb, :view
+
+  embed_templates "config_html/*"
+end

--- a/lib/screenplay_web/controllers/config_html/index.html.eex
+++ b/lib/screenplay_web/controllers/config_html/index.html.eex
@@ -1,0 +1,1 @@
+<div id="app"></div>


### PR DESCRIPTION
While checking out #487, I found some issues in Permanent Config that needed to be fixed.

1. There was an infinite rendering loop when fetching existing screens [here](https://github.com/mbta/screenplay/blob/b4268a540f151649031171da3c1189d955137a8c/assets/js/components/Dashboard/PermanentConfiguration/Workflows/GlEink/ConfigureScreensPage.tsx#L107). A prop in the parent component was constantly having it's reference changed after each fetch. Wrapping in `useMemo` stops it from updating unless it needs to.
2. Styling of the `direction` column was off and the button text was wrapping.
3. Back in #423, we updated the Phoenix view/template structure a bit. This means that any route you visit directly goes through the new `*_html` controller. This was being absent was likely just an oversight.