### PR TITLE
chore: SL Order for PA Messages

### DIFF
--- a/assets/js/constants/stationOrder.ts
+++ b/assets/js/constants/stationOrder.ts
@@ -242,7 +242,28 @@ const STATION_ORDER_BY_LINE: StationsByLine = {
   ],
   silver: [
     {
+      name: "Nubian",
+    },
+    {
+      name: "South Station",
+    },
+    {
+      name: "Courthouse",
+    },
+    {
       name: "World Trade Center",
+    },
+    {
+      name: "Eastern Avenue",
+    },
+    {
+      name: "Box District",
+    },
+    {
+      name: "Bellingham Square",
+    },
+    {
+      name: "Chelsea",
     },
   ],
   green: [


### PR DESCRIPTION
Added a station order for SL. This will only affect the select stations page for PA Messages. I thought about making it work on the Places tab as well but the sort order is alphabetical by default. This feels appropriate given that the filter includes multiple routes.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208030889228596