### PR TITLE
chore: Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,36 @@ Enables OIOs to view and manage screens that provide transit info to riders.
 
 ## Prerequisites
 
-Screenplay requires Postgres. If you don't already have Postgres installed, and you're on a Mac, [Postgres.app](https://postgresapp.com/downloads.html) is an easy way to get started. However, any Postgres instance to which you can connect and in which you have sufficient privileges should work.
+### Postgres
 
-## Development
+If you don't already have Postgres installed, and you're on a Mac, [Postgres.app](https://postgresapp.com/downloads.html) is an easy way to get started. However, any Postgres instance to which you can connect and in which you have sufficient privileges should work.
 
-## Setup
+### Screens
 
-#### Install tools
+Screenplay requires the Screens config to be available at `../screens/priv/local.json`. To generate this file, follow these steps:
+
+1. `cd ..`
+1. `git clone git@github.com:mbta/screens.git`
+1. `cd screens`
+1. Follow the [Getting Started docs](https://github.com/mbta/screens/blob/main/docs/getting_started.md#getting-started) to generate the files needed by Screenplay.
+
+### Realtime-Signs
+
+This repo expects Realtime Signs to be cloned and for `realtime_signs/priv/signs.json` to be available. This can be done by doing the following:
+
+1. `cd ..`
+1. `git clone git@github.com:mbta/realtime_signs.git`
+
+## Local Development Setup
+
+### Install tools
 
 1. Install [`asdf`](https://github.com/asdf-vm/asdf)
 1. Install language build dependencies: `brew install coreutils`
 1. `asdf plugin-add ...` for each tool listed in `.tool-versions`
 1. `asdf install`
 
-#### Set up environment
+### Set up environment
 
 1. Install [`direnv`](https://direnv.net/)
 1. `cp .envrc.template .envrc`
@@ -29,7 +45,7 @@ Note the various `_URL` values in `.envrc`, which default to the production
 environments of the relevant apps — change these to e.g. point Screenplay to
 your own local instances.
 
-#### Copy configuration
+### Copy configuration
 
 1. Install the `aws` CLI and configure with your AWS credentials
    - To verify everything works, try: `aws s3 ls mbta-ctd-config`
@@ -38,7 +54,7 @@ your own local instances.
 To copy config files from a different Screenplay environment, replace `prod` in
 the command above.
 
-#### Start the server
+### Start the server
 
 1. `mix deps.get`
 1. `mix ecto.create` to stand up DB used by PA Messaging features
@@ -46,7 +62,7 @@ the command above.
 1. `mix phx.server`
 1. Visit <http://localhost:4444>
 
-#### Optional: AWS credentials
+### Optional: AWS credentials
 
 In deployed environments, the app uses S3 for its configuration. If you ever
 want to replicate this behavior locally, you'll need to provide the environment

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Screenplay requires the Screens config to be available at `../screens/priv/local
 
 ### Realtime-Signs
 
-This repo expects Realtime Signs to be cloned and for `realtime_signs/priv/signs.json` to be available. This can be done by doing the following:
+This repo expects Realtime Signs to be cloned and for `../realtime_signs/priv/signs.json` to be available. This can be done by doing the following:
 
 1. `cd ..`
 1. `git clone git@github.com:mbta/realtime_signs.git`


### PR DESCRIPTION
When I created the `Builder`, I should have added notes to the README that a local version of Screens and RTS is required for the data to build successfully. Added steps to help users do that correctly.