### PR TITLE
fix: text wrapping inside selected station tags

### DIFF
--- a/assets/css/dashboard/new-pa-message/selected-stations-summary.scss
+++ b/assets/css/dashboard/new-pa-message/selected-stations-summary.scss
@@ -1,7 +1,7 @@
 .selected-stations-summary {
+  flex-shrink: 0;
   display: flex;
   align-items: center;
-  height: 52px;
   border-radius: 8px;
   background-color: $cool-gray-30;
   margin: 40px 40px 0 40px;
@@ -9,6 +9,7 @@
   font-weight: 500;
   font-size: 20px;
   line-height: 30px;
+  white-space: nowrap;
 
   .label {
     margin-right: 8px;
@@ -20,5 +21,17 @@
 
   .geo-alt-fill-icon {
     margin-right: 7px;
+  }
+
+  .no-tags {
+    // same height as the tags; avoids layout jumping when number of tags goes
+    // from 0 to 1 or vice-versa
+    line-height: 36px;
+  }
+
+  .selected-stations-tags {
+    display: flex;
+    flex-wrap: wrap;
+    row-gap: 4px;
   }
 }

--- a/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectedStationsSummary.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectedStationsSummary.tsx
@@ -21,14 +21,16 @@ const SelectedStationsSummary = ({
       <GeoAltFill className="geo-alt-fill-icon" width={12} />
       <div className="label">Stations selected:</div>
       {value.length === 0 ? (
-        <span>None</span>
+        <div className="no-tags">None</div>
       ) : (
-        <SelectedSignsByRouteTags
-          places={places}
-          value={value}
-          onChange={onChange}
-          busRoutes={busRoutes}
-        />
+        <div className="selected-stations-tags">
+          <SelectedSignsByRouteTags
+            places={places}
+            value={value}
+            onChange={onChange}
+            busRoutes={busRoutes}
+          />
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
Within the "select stations" dialog, the station summary tags now wrap onto a new line instead of the text within them wrapping (and spilling out of their borders).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208142586199816