### PR TITLE
validate PA message interval field

### DIFF
--- a/assets/js/components/Dashboard/IntervalPicker.tsx
+++ b/assets/js/components/Dashboard/IntervalPicker.tsx
@@ -18,12 +18,13 @@ const IntervalPicker = ({ interval, onChangeInterval, validated }: Props) => {
         className="m-0 interval"
         type="number"
         value={interval}
+        min={1}
         onChange={(input) => onChangeInterval(input.target.value)}
         required
-        isInvalid={validated && interval.length === 0}
+        isInvalid={validated && (!Number.isInteger(+interval) || +interval < 1)}
       />
       <Form.Control.Feedback type="invalid">
-        Interval value is required
+        Interval value must be a positive integer
       </Form.Control.Feedback>
     </Form.Group>
   );

--- a/lib/screenplay/pa_messages/pa_message.ex
+++ b/lib/screenplay/pa_messages/pa_message.ex
@@ -67,6 +67,8 @@ defmodule Screenplay.PaMessages.PaMessage do
     ])
     |> validate_length(:sign_ids, min: 1)
     |> validate_subset(:days_of_week, 1..7)
+    |> validate_number(:interval_in_minutes, greater_than: 0)
+    |> validate_inclusion(:priority, 1..4)
     |> validate_start_date()
     |> validate_end_date()
     |> maybe_unpause()


### PR DESCRIPTION
**Asana task**: [bug: PA messages accept negative interval](https://app.asana.com/0/1185117109217413/1208634633982716/f)

This fixes an issue where PA messages would allow setting a negative interval. Enforces validation on the front and back end. Also validates the `priority` field for completeness.