### PR TITLE
fix current PA message filter

### DIFF
--- a/test/screenplay_web/controllers/pa_messages_api_controller_test.exs
+++ b/test/screenplay_web/controllers/pa_messages_api_controller_test.exs
@@ -82,7 +82,7 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
 
       insert(:pa_message, %{
         id: 2,
-        days_of_week: [1, 2, 3, 4, 5, 6, 7],
+        days_of_week: [1],
         start_datetime: ~U[2024-08-05 00:00:00Z],
         end_datetime: ~U[2024-08-06 23:59:59Z]
       })


### PR DESCRIPTION
**Asana task**: [bug: Can't see PA messages that don't play on the current day](https://app.asana.com/0/1185117109217422/1208664128012797/f)

This fixes an issue where the `current` filter wouldn't show messages that don't play on the current day. Moves the day condition to the `active` filter so it continues to apply there.
