### PR TITLE
chore: OFM Reminders Job Processing Change

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -65,7 +65,8 @@ if env == "prod" do
     plugins: [
       {Oban.Plugins.Cron,
        crontab: [
-         {"0 7 * * *", Screenplay.Jobs.TakeoverToolTestingJob}
+         {"0 7 * * *", Screenplay.Jobs.TakeoverToolTestingJob},
+         {"* * * * *", Screenplay.Jobs.Reminders}
        ]},
       Oban.Plugins.Pruner,
       Oban.Plugins.Lifeline,

--- a/lib/screenplay/application.ex
+++ b/lib/screenplay/application.ex
@@ -19,7 +19,6 @@ defmodule Screenplay.Application do
         # Start the Endpoint (http/https)
         ScreenplayWeb.Endpoint,
         Screenplay.OutfrontTakeoverTool.Alerts.State,
-        Screenplay.OutfrontTakeoverTool.Alerts.Reminders,
         Screenplay.ScreensConfig
       ] ++
         if Application.get_env(:screenplay, :start_cache_processes) do

--- a/lib/screenplay/jobs/reminders.ex
+++ b/lib/screenplay/jobs/reminders.ex
@@ -49,7 +49,7 @@ defmodule Screenplay.Jobs.Reminders do
           type: "section",
           text: %{
             type: "mrkdwn",
-            text: "Please review this Alert: #{ScreenplayWeb.Endpoint.url()}"
+            text: "Please review this alert: #{ScreenplayWeb.Endpoint.url()}/emergency-takeover"
           }
         }
       ]

--- a/lib/screenplay/jobs/reminders.ex
+++ b/lib/screenplay/jobs/reminders.ex
@@ -1,30 +1,21 @@
-defmodule Screenplay.OutfrontTakeoverTool.Alerts.Reminders do
+defmodule Screenplay.Jobs.Reminders do
   @moduledoc """
-  Runs every minute and sends slack reminders to @pios in #ctd-pio-livepa if outdated alerts are still active.
+  Runs every minute and sends slack reminders to @oios in #tid-oio if outdated alerts are still active.
   """
+  use Oban.Worker, unique: true
+
   require Logger
-  use GenServer
 
   alias Screenplay.OutfrontTakeoverTool.Alerts.{Alert, State}
 
-  def start_link(_opts) do
-    GenServer.start_link(__MODULE__, %{})
-  end
-
-  def init(state) do
-    schedule_work()
-    {:ok, state}
-  end
-
-  def handle_info(:work, state) do
-    schedule_work()
-
+  @impl Oban.Worker
+  def perform(_) do
     case Application.get_env(:screenplay, :slack_webhook_url) do
       v when v in [nil, ""] -> Logger.info("No Slack Webhook URL found")
       url -> send_slack_messages_for_outdated_alerts(url)
     end
 
-    {:noreply, state}
+    :ok
   end
 
   defp send_slack_messages_for_outdated_alerts(url) do
@@ -79,10 +70,5 @@ defmodule Screenplay.OutfrontTakeoverTool.Alerts.Reminders do
           "Failed to send Slack message, error: '#{error}'"
         end)
     end
-  end
-
-  defp schedule_work do
-    # runs every minute
-    Process.send_after(self(), :work, 60 * 1000)
   end
 end


### PR DESCRIPTION
While fixing the webhook URL for the Slack app, I remembered this being another good candidate for Oban processing. It still runs once a minute but should only run a single time each minute now. Should prevent the reminder from going off twice when it needs to.