### PR TITLE
fix: PaMessagesPage accessibility bug

### DIFF
--- a/assets/css/dashboard/pa-messages-page.scss
+++ b/assets/css/dashboard/pa-messages-page.scss
@@ -92,6 +92,11 @@
 
   &__message {
     width: 586px;
+
+    a {
+      color: $text-primary;
+      text-decoration: none;
+    }
   }
 
   &__interval {
@@ -100,11 +105,6 @@
 
   &__actions {
     width: 110px;
-  }
-
-  &__text {
-    color: $text-primary;
-    text-decoration: none;
   }
 
   &__start-end {

--- a/assets/js/components/Dashboard/KebabMenu.tsx
+++ b/assets/js/components/Dashboard/KebabMenu.tsx
@@ -72,7 +72,10 @@ const KebabMenu = ({ children, tooltipText }: Props) => {
     >
       <Dropdown.Toggle
         as={CustomToggle}
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={(e) => {
+          e.stopPropagation();
+          setIsOpen(!isOpen);
+        }}
         tooltipText={tooltipText}
       />
       <Dropdown.Menu className="kebab-menu-dropdown__menu">

--- a/assets/js/components/Dashboard/PaMessagesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessagesPage.tsx
@@ -379,10 +379,7 @@ const PaMessageRow: ComponentType<PaMessageRowProps> = ({
               </div>
             </div>
           </td>
-          <td
-            onClick={(e) => e.stopPropagation()}
-            className="pa-message-table__kebab"
-          >
+          <td className="pa-message-table__kebab">
             <KebabMenu>
               <Dropdown.Item
                 className="kebab-menu-dropdown__item"

--- a/assets/js/components/Dashboard/PaMessagesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessagesPage.tsx
@@ -345,7 +345,14 @@ const PaMessageRow: ComponentType<PaMessageRowProps> = ({
 
   return (
     <tr onClick={() => navigate(`/pa-messages/${paMessage.id}/edit`)}>
-      <td className="pa-message-table__message">{paMessage.visual_text}</td>
+      <td className="pa-message-table__message">
+        <a
+          href={`/pa-messages/${paMessage.id}/edit`}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {paMessage.visual_text}
+        </a>
+      </td>
       <td className="pa-message-table__interval">
         {paMessage.interval_in_minutes} min
       </td>


### PR DESCRIPTION
Looks like the recent ESLint update introduced a new rule that we were breaking. Fixed that by moving the `onClick` from a `td` to the kebab menu itself.

I also noticed that the rows are not part of tab navigation. This causes a mouse click to be the only way to navigate to the edit page. Resolved that by making the `Message` column a link.