### PR TITLE
validate that PA messages specify at least one day

### DIFF
--- a/assets/js/components/Dashboard/DaysPicker.tsx
+++ b/assets/js/components/Dashboard/DaysPicker.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Col, Dropdown, Form, Row } from "react-bootstrap";
 import fp from "lodash/fp";
+import cx from "classnames";
 
 enum DayItem {
   All = "All days",
@@ -38,9 +39,10 @@ const DAY_MAPPINGS = [
 interface Props {
   days: number[];
   onChangeDays: (days: number[]) => void;
+  error: string | null;
 }
 
-const DaysPicker = ({ days, onChangeDays }: Props) => {
+const DaysPicker = ({ days, onChangeDays, error }: Props) => {
   const [dayLabel, setDayLabel] = useState(
     fp.find(
       ({ value }) => fp.isEqual(value, fp.sortBy(fp.identity, days)),
@@ -53,7 +55,11 @@ const DaysPicker = ({ days, onChangeDays }: Props) => {
       <Form.Label className="label body--regular" htmlFor="days-picker">
         Days
       </Form.Label>
-      <Row md={1} lg="auto" className="align-items-center">
+      <Row
+        md={1}
+        lg="auto"
+        className={cx("align-items-center", { "is-invalid": !!error })}
+      >
         <Col>
           <Dropdown
             onSelect={(eventKey) => {
@@ -108,6 +114,7 @@ const DaysPicker = ({ days, onChangeDays }: Props) => {
           </Col>
         )}
       </Row>
+      <Form.Control.Feedback type="invalid">{error}</Form.Control.Feedback>
     </Form.Group>
   );
 };

--- a/assets/js/components/Dashboard/PaMessageForm/MainForm.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/MainForm.tsx
@@ -125,6 +125,7 @@ const MainForm = ({
 
     if (
       form.checkValidity() === false ||
+      days.length === 0 ||
       signIds.length === 0 ||
       audioState !== AudioPreview.Reviewed
     ) {
@@ -288,7 +289,13 @@ const MainForm = ({
               </Form.Group>
             </Row>
             <Row className="days">
-              <DaysPicker days={days} onChangeDays={setDays} />
+              <DaysPicker
+                days={days}
+                onChangeDays={setDays}
+                error={
+                  validated && !days.length ? "Select at least one day" : null
+                }
+              />
             </Row>
             <Row md="auto">
               <Col>

--- a/lib/screenplay/pa_messages/pa_message.ex
+++ b/lib/screenplay/pa_messages/pa_message.ex
@@ -67,6 +67,7 @@ defmodule Screenplay.PaMessages.PaMessage do
     ])
     |> validate_length(:sign_ids, min: 1)
     |> validate_subset(:days_of_week, 1..7)
+    |> validate_length(:days_of_week, min: 1)
     |> validate_number(:interval_in_minutes, greater_than: 0)
     |> validate_inclusion(:priority, 1..4)
     |> validate_start_date()


### PR DESCRIPTION
**Asana task**: [bug: Can create a PA message with no days selected](https://app.asana.com/0/1185117109217413/1208664128012801/f)

This adds client-side validation for the day-of-week picker, and also server-side for completeness.