### PR TITLE
fix: Disabled text box styles

### DIFF
--- a/assets/css/pa-messages.module.scss
+++ b/assets/css/pa-messages.module.scss
@@ -90,11 +90,6 @@
   margin-top: 141px;
 }
 
-.audioText {
-  height: 250px;
-  resize: none;
-}
-
 .reviewAudioCard {
   height: 250px;
   background-color: $cool-gray-15;
@@ -174,6 +169,13 @@
       color: $text-secondary;
     }
   }
+}
+
+.messageTextBox {
+  height: 250px;
+  resize: none;
+  --bs-secondary-bg: #{$bg-elevation-4};
+  --bs-border-color: #{$cool-gray-30};
 }
 
 .startEndItem {

--- a/assets/js/components/Dashboard/MessageTextBox.tsx
+++ b/assets/js/components/Dashboard/MessageTextBox.tsx
@@ -34,7 +34,10 @@ const MessageTextBox = ({
       <Form.Control
         required={required}
         id={id}
-        className={cx(paMessageStyles.audioText, paMessageStyles.inputField)}
+        className={cx(
+          paMessageStyles.messageTextBox,
+          paMessageStyles.inputField,
+        )}
         maxLength={maxLength}
         as="textarea"
         value={text}


### PR DESCRIPTION
Looks like in the switch to CSS modules, the app no longer used the correct BG color for disabled text boxes. Fixed the bg and border colors to match the designs.