### PR TITLE
Update dashboard links

### DIFF
--- a/assets/js/components/Dashboard/PaMessagesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessagesPage.tsx
@@ -143,7 +143,15 @@ const PaMessagesPage: ComponentType = () => {
                 target="_blank"
                 className="system-log-link"
               >
-                <span className="link-text">System Log</span>
+                <span className="link-text">Announcement Log</span>
+                <BoxArrowUpRight />
+              </Link>
+              <Link
+                to="https://mbta.splunkcloud.com/en-US/app/search/paess_device_status_by_station_clone"
+                target="_blank"
+                className="system-log-link"
+              >
+                <span className="link-text">Device Status</span>
                 <BoxArrowUpRight />
               </Link>
             </section>


### PR DESCRIPTION
**Asana task**: [Station PA/ESS Status Dashboard Extensions](https://app.asana.com/0/1185117109217413/1207154235176794/f)

Description
Updates the link text for the announcement log and adds a link to the updated device dashboard which includes a new column indicating whether a station's SCU is legacy or new.

- [ ] For features with a design/UX component, deployed branch to dev-green and let product know it's ready for review.
