### PR TITLE
Changed the selected dropdown text to be button-secondary

### DIFF
--- a/assets/css/pa-messages.module.scss
+++ b/assets/css/pa-messages.module.scss
@@ -206,6 +206,7 @@
     --bs-dropdown-link-hover-color: #{$text-primary};
     --bs-dropdown-link-hover-bg: #{$cool-gray-20};
     --bs-dropdown-link-active-bg: #{$button-primary};
+    --bs-dropdown-link-active-color: #{button-secondary};
   }
 }
 


### PR DESCRIPTION
**Asana task**: [Use d﻿ark text for selected items in drop-down list so that the selected item is visible](https://app.asana.com/0/1185117109217413/1208918273737816)

Description
- Allows the selected item text to be more visible since the background color is light
- [ ] For features with a design/UX component, deployed branch to dev-green and let product know it's ready for review.

![Screenshot 2025-02-03 at 11 39 30 AM](https://github.com/user-attachments/assets/ea752449-e6f4-48f5-90cf-6044b6044fda)