### PR TITLE
Language changes to filter PA/ESS and alerts by time

### DIFF
--- a/assets/js/components/Dashboard/PaMessageForm/AssociateAlert.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/AssociateAlert.tsx
@@ -65,7 +65,7 @@ const AssociateAlert = ({ onApply, onCancel }: AssociateAlertPageProps) => {
               selectedFilter={selectedMessageState}
               onFilterSelect={setSelectedMessageState}
               filters={[
-                { label: "Active", value: "active" },
+                { label: "Live", value: "active" },
                 { label: "Future", value: "future" },
               ]}
             />

--- a/assets/js/components/Dashboard/PaMessageForm/AssociateAlert.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/AssociateAlert.tsx
@@ -61,7 +61,7 @@ const AssociateAlert = ({ onApply, onCancel }: AssociateAlertPageProps) => {
           <Col className="associate-alert-filter-selection">
             <FilterGroup
               className="mb-5"
-              header="Message state"
+              header="Filter by message state"
               selectedFilter={selectedMessageState}
               onFilterSelect={setSelectedMessageState}
               filters={[
@@ -70,7 +70,7 @@ const AssociateAlert = ({ onApply, onCancel }: AssociateAlertPageProps) => {
               ]}
             />
             <FilterGroup
-              header="Service type"
+              header="Filter by service type"
               selectedFilter={selectedServiceType}
               onFilterSelect={setSelectedServiceType}
               filters={serviceTypes.map((serviceType) => {

--- a/assets/js/components/Dashboard/PaMessageForm/StaticTemplatePage.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/StaticTemplatePage.tsx
@@ -35,7 +35,7 @@ const StaticTemplatePage = ({ onCancel, onSelect }: Props) => {
         <Row className="static-template-page-body">
           <Col className="filter-group-col">
             <FilterGroup
-              header="Template type"
+              header="Filter by template type"
               selectedFilter={selectedTemplateType}
               onFilterSelect={(templateType) =>
                 setSelectedTemplateType(templateType as TemplateType)

--- a/assets/js/components/Dashboard/PaMessagesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessagesPage.tsx
@@ -161,7 +161,7 @@ const PaMessagesPage: ComponentType = () => {
             </section>
             <FilterGroup
               className="mb-5"
-              header="Message state"
+              header="Filter by message state"
               onFilterSelect={(selected) =>
                 setStateFilter(selected as StateFilter)
               }
@@ -173,7 +173,7 @@ const PaMessagesPage: ComponentType = () => {
               ]}
             />
             <FilterGroup
-              header="Service type"
+              header="Filter by service type"
               onFilterSelect={(selected) => {
                 const serviceType = selected as ServiceType;
                 if (serviceType === "All") {

--- a/assets/js/components/Dashboard/PaMessagesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessagesPage.tsx
@@ -161,19 +161,19 @@ const PaMessagesPage: ComponentType = () => {
             </section>
             <FilterGroup
               className="mb-5"
-              header="Filter by message state"
+              header="Message state"
               onFilterSelect={(selected) =>
                 setStateFilter(selected as StateFilter)
               }
               selectedFilter={stateFilter.toLowerCase()}
               filters={[
-                { label: "Now", value: "current" },
+                { label: "Live", value: "current" },
                 { label: "Future", value: "future" },
-                { label: "Done", value: "past" },
+                { label: "Past", value: "past" },
               ]}
             />
             <FilterGroup
-              header="Filter by service type"
+              header="Service type"
               onFilterSelect={(selected) => {
                 const serviceType = selected as ServiceType;
                 if (serviceType === "All") {

--- a/assets/js/components/Dashboard/PriorityPicker.tsx
+++ b/assets/js/components/Dashboard/PriorityPicker.tsx
@@ -31,8 +31,8 @@ const PriorityPicker = ({
           <Dropdown.Menu role="listbox">
             {[
               "Emergency",
-              "Current Service Disruption",
-              "Planned Service Disruption",
+              "Ongoing service disruption",
+              "Upcoming service disruption",
               "PSA Message",
             ].map((label, index) => {
               const priorityIndex = index + 1;


### PR DESCRIPTION
**Asana task**: [Language changes to filter PA/ESS and Alerts by time, and describe PA/ESS message type](https://app.asana.com/0/1185117109217413/1208918421836698)

Description
- "Now" switched to "Live"
- "Done" switched to "Past"
- "Current Service Disruption" to "Ongoing service disruption"
- "Planned Service Disruption" to "Upcoming service disruption"

- [ ] For features with a design/UX component, deployed branch to dev-green and let product know it's ready for review.

![Screenshot 2025-02-03 at 12 01 20 PM](https://github.com/user-attachments/assets/518923e4-b96e-4d5f-bd17-5dcda790a46e)
![Screenshot 2025-02-03 at 12 01 28 PM](https://github.com/user-attachments/assets/1a910c3b-b6e2-435a-b1c0-e65bed6887ce)
![Screenshot 2025-02-03 at 12 01 39 PM](https://github.com/user-attachments/assets/7a3de81f-f242-4602-a978-b52e0545006a)
