### PR TITLE
ci: Updated action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # cache the ASDF directory, using the values from .tool-versions
       - name: ASDF cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.asdf
-          key: ${{ runner.os }}-asdf-v2-${{ hashFiles('.tool-versions') }}
+          key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
         id: asdf-cache
       # only run `asdf install` if we didn't hit the cache
-      - uses: asdf-vm/actions/install@v1
+      - uses: asdf-vm/actions/install@v3
         if: steps.asdf-cache.outputs.cache-hit != 'true'
 
   build:
@@ -47,12 +47,12 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     needs: asdf
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: ASDF cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.asdf
-          key: ${{ runner.os }}-asdf-v2-${{ hashFiles('.tool-versions') }}
+          key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
         id: asdf-cache
       - uses: mbta/actions/reshim-asdf@v1
       # The asdf job should have prepared the cache. exit if it didn't for some reason
@@ -60,7 +60,7 @@ jobs:
         if: steps.asdf-cache.outputs.cache-hit != 'true'
       - name: Restore dependencies cache
         id: deps-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
@@ -93,4 +93,4 @@ jobs:
       - run: npm --prefix assets run check
       - run: npm --prefix assets test
 
-      - uses: mbta/actions/dialyzer@v1
+      - uses: mbta/actions/dialyzer@v2


### PR DESCRIPTION
Copying from https://github.com/mbta/screens-config-lib/pull/52 (insert Write That Down GIF here)

but more or less updating action versions from failing CI runs