### PR TITLE
Change PA announcement priority from 1, 2, 3, 4 to 1, 3, 4, 5

### DIFF
--- a/assets/js/components/Dashboard/PaMessageForm/PaMessageForm.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/PaMessageForm.tsx
@@ -58,7 +58,7 @@ const PaMessageForm = ({
 }: Props) => {
   const [page, setPage] = useState<Page>(Page.MAIN);
   const now = moment();
-  const defaultPriority = 2;
+  const defaultPriority = 3;
 
   const [associatedAlert, setAssociatedAlert] = useState<Alert | string | null>(
     () => {
@@ -184,9 +184,9 @@ const PaMessageForm = ({
   useEffect(() => {
     const priorityToIntervalMap: { [priority: number]: string } = {
       1: "1",
-      2: "4",
-      3: "10",
-      4: "12",
+      3: "4",
+      4: "10",
+      5: "12",
     };
     setInterval(priorityToIntervalMap[priority]);
   }, [priority]);
@@ -297,7 +297,7 @@ const PaMessageForm = ({
             setSelectedTemplate(template);
             setVisualText(template.visual_text);
             setPhoneticText(template.audio_text);
-            setPriority(template.type === "psa" ? 4 : 1);
+            setPriority(template.type === "psa" ? 5 : 1);
             setAudioState(AudioPreview.Reviewed);
             setPage(Page.MAIN);
           }}

--- a/assets/js/components/Dashboard/PriorityPicker.tsx
+++ b/assets/js/components/Dashboard/PriorityPicker.tsx
@@ -12,6 +12,18 @@ const PriorityPicker = ({
   onSelectPriority,
   disabled = false,
 }: Props) => {
+  const MESSAGE_PRIORITY_MAP: Map<string, number> = new Map<string, number>([
+    ["Emergency Test", 1],
+    ["Ongoing service disruption", 3],
+    ["Upcoming service disruption", 4],
+    ["PSA Message", 5],
+  ]);
+
+  // Non-PA messages need a priority in between Emergency (1) and Current service Disruption (2)
+  // But here we want to just show the labels as is, 1 2 3 4 rather than 1 3 4 5 so adjust here
+  const adjustPriorityForLabel = (priority: number): number =>
+    priority == 1 ? priority : priority - 1;
+
   return (
     <Form.Group>
       <Form.Label
@@ -26,25 +38,21 @@ const PriorityPicker = ({
           onSelect={(eventKey) => onSelectPriority(Number(eventKey))}
         >
           <Dropdown.Toggle id="priority-picker" disabled={disabled}>
-            {priority}
+            {adjustPriorityForLabel(priority)}
           </Dropdown.Toggle>
           <Dropdown.Menu role="listbox">
-            {[
-              "Emergency",
-              "Ongoing service disruption",
-              "Upcoming service disruption",
-              "PSA Message",
-            ].map((label, index) => {
-              const priorityIndex = index + 1;
+            {Array.from(MESSAGE_PRIORITY_MAP).map((value: [string, number]) => {
+              const label = value[0];
+              const messagePriority = value[1];
 
               return (
                 <Dropdown.Item
                   role="option"
-                  key={label}
-                  eventKey={priorityIndex}
-                  active={priority === priorityIndex}
+                  key={messagePriority}
+                  eventKey={messagePriority}
+                  active={priority === messagePriority}
                 >
-                  <div>{priorityIndex}</div>
+                  <div>{adjustPriorityForLabel(messagePriority)}</div>
                   <div className={paMessageStyles.smaller}>{label}</div>
                 </Dropdown.Item>
               );

--- a/lib/screenplay/pa_messages/pa_message.ex
+++ b/lib/screenplay/pa_messages/pa_message.ex
@@ -75,7 +75,7 @@ defmodule Screenplay.PaMessages.PaMessage do
     |> validate_subset(:days_of_week, 1..7)
     |> validate_length(:days_of_week, min: 1)
     |> validate_number(:interval_in_minutes, greater_than: 0)
-    |> validate_inclusion(:priority, 1..4)
+    |> validate_inclusion(:priority, 1..5)
     |> validate_start_date()
     |> validate_end_date()
     |> maybe_unpause()

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -72,7 +72,7 @@ defmodule Random do
   end
 
   def priority do
-    Enum.random(1..4)
+    Enum.random([1, 3, 4, 5])
   end
 
   def text do

--- a/test/screenplay/pa_messages_test.exs
+++ b/test/screenplay/pa_messages_test.exs
@@ -141,7 +141,7 @@ defmodule Screenplay.PaMessagesTest do
         end_datetime: nil,
         days_of_week: [22],
         sign_ids: [],
-        priority: 1,
+        priority: 5,
         visual_text: "",
         audio_text: "Audio Text"
       }


### PR DESCRIPTION
**Asana task**: [Fix announcement priority for migrated SCUs](https://app.asana.com/0/1185117109217413/1209272297071108)

- Allow non-PA messages to take priority of 2, seems like we already do that in [realtime signs](https://github.com/mbta/realtime_signs/blob/5a5cbb9fea548cd5ab3cd69777ac74fc35432b60/lib/signs/utilities/audio.ex#L187)
- Keep display numbers the same, effectively everything will remain the same but if you look at the API calls underneath to `pa-messages`, priority will now be adjusted when you pick 2, 3, or 4. 

- [ ] For features with a design/UX component, deployed branch to dev-green and let product know it's ready for review.
