### PR TITLE
Added data model and API for Prediction Suppression

### DIFF
--- a/lib/screenplay/suppressed_predictions.ex
+++ b/lib/screenplay/suppressed_predictions.ex
@@ -1,0 +1,74 @@
+defmodule Screenplay.SuppressedPredictions do
+  @moduledoc """
+  Module for functions dealing with `SuppressedPredictions` and the `suppressed_predictions` database 
+  """
+
+  alias Screenplay.Repo
+  alias Screenplay.SuppressedPredictions.SuppressedPrediction
+
+  @doc """
+  Gets a single suppressed prediction with the given ID.
+  """
+  @spec get_suppressed_prediction(
+          location_id :: String.t(),
+          route_id :: String.t(),
+          direction_id :: integer()
+        ) ::
+          {:ok, SuppressedPrediction.t()} | {:error, :not_found}
+  def get_suppressed_prediction(location_id, route_id, direction_id) do
+    case Repo.get_by(SuppressedPrediction,
+           location_id: location_id,
+           route_id: route_id,
+           direction_id: direction_id
+         ) do
+      nil ->
+        {:error, :not_found}
+
+      suppressed_prediction ->
+        {:ok, suppressed_prediction}
+    end
+  end
+
+  @doc """
+  Get all suppressed predictions
+  """
+  @spec get_all_suppressed_predictions() :: [SuppressedPrediction.t()]
+  def get_all_suppressed_predictions do
+    SuppressedPrediction
+    |> Repo.all()
+  end
+
+  @doc """
+  Create a suppression for predictions at a station
+  """
+  @spec create_suppressed_prediction(params :: map()) ::
+          {:ok, SuppressedPrediction.t()} | {:error, Ecto.Changeset.t()}
+  def create_suppressed_prediction(params) do
+    %SuppressedPrediction{}
+    |> SuppressedPrediction.changeset(params)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a suppression for prediction
+  """
+  @spec update_suppressed_prediction(
+          suppressed_prediction :: SuppressedPrediction.t(),
+          changes :: map()
+        ) ::
+          {:ok, SuppressedPrediction.t()} | {:error, Ecto.Changeset.t()}
+  def update_suppressed_prediction(suppressed_prediction, changes) do
+    suppressed_prediction
+    |> SuppressedPrediction.changeset(changes)
+    |> Repo.update()
+  end
+
+  @doc """
+  Delete a suppressed prediction
+  """
+  @spec delete_suppressed_prediction(suppressed_prediction :: SuppressedPrediction.t()) ::
+          {:ok, SuppressedPrediction.t()} | {:error, Ecto.Changeset.t()}
+  def delete_suppressed_prediction(suppressed_prediction) do
+    Repo.delete(suppressed_prediction)
+  end
+end

--- a/lib/screenplay/suppressed_predictions/suppressed_prediction.ex
+++ b/lib/screenplay/suppressed_predictions/suppressed_prediction.ex
@@ -1,0 +1,160 @@
+defmodule Screenplay.SuppressedPredictions.SuppressedPrediction do
+  @moduledoc """
+  Represents a Suppressed Prediction for a given location
+  """
+  alias Screenplay.Places
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @jfk_umass_ashmont_place "jfk_umass_ashmont_platform"
+  @jfk_umass_braintree_place "jfk_umass_braintree_platform"
+  @green_line_routes ["Green-B", "Green-C", "Green-D", "Green-E"]
+  @valid_silver_line_routes ["741", "742", "743", "746"]
+
+  @derive {Jason.Encoder, except: [:__meta__]}
+
+  @type t() :: %__MODULE__{
+          location_id: String.t(),
+          route_id: String.t(),
+          direction_id: integer(),
+          clear_at_end_of_day: boolean()
+        }
+
+  @primary_key false
+  schema "suppressed_predictions" do
+    field(:location_id, :string, primary_key: true)
+    field(:route_id, :string, primary_key: true)
+    field(:direction_id, :integer, primary_key: true)
+    field(:clear_at_end_of_day, :boolean)
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(suppressed_prediction, attrs \\ %{}) do
+    places = Places.get()
+
+    suppressed_prediction
+    |> cast(attrs, [
+      :location_id,
+      :route_id,
+      :direction_id,
+      :clear_at_end_of_day
+    ])
+    |> validate_required([
+      :location_id,
+      :route_id,
+      :direction_id,
+      :clear_at_end_of_day
+    ])
+    |> validate_number(:direction_id,
+      less_than_or_equal_to: 1,
+      greater_than_or_equal_to: 0,
+      message: "Location Direction ID must be 0 or 1"
+    )
+    |> validate_edge_cases()
+    |> validate_location(places)
+    |> validate_routes(places)
+  end
+
+  defp validate_edge_cases(changeset) do
+    location_id = get_field(changeset, :location_id)
+    route_id = get_field(changeset, :route_id)
+
+    cond do
+      # JFK/UMass has the Ashmont/Braintree split, we ask for those stop ids rather than the parent id
+      location_id == "place-jfk" ->
+        add_error(
+          changeset,
+          :location_id,
+          "Please provide either the Ashmont or Braintree platform location_id: (#{@jfk_umass_ashmont_place} or #{@jfk_umass_braintree_place})"
+        )
+
+      # We don't handle separate Green Line and Silver Line branching route_ids
+      # That is populated when we pass data to Transit Data
+      # For internal use we just use "Green" or "Silver" to show all green/silver line routes
+      route_id in @green_line_routes ->
+        add_error(
+          changeset,
+          :route_id,
+          "Please provide just `Green` as the route_id for handling all Green Line routes"
+        )
+
+      true ->
+        changeset
+    end
+  end
+
+  defp validate_location(changeset, places) do
+    location_id = get_field(changeset, :location_id)
+
+    if places |> Enum.any?(&(&1.id == location_id)) do
+      changeset
+    else
+      add_error(changeset, :location_id, "Location `#{location_id}` does not exist")
+    end
+  end
+
+  defp validate_routes(changeset, places) do
+    unchecked_location_id = get_field(changeset, :location_id)
+    route_id = get_field(changeset, :route_id)
+
+    location_id =
+      if unchecked_location_id in [@jfk_umass_ashmont_place, @jfk_umass_braintree_place] do
+        "place-jfk"
+      else
+        unchecked_location_id
+      end
+
+    places
+    |> Enum.find(fn place -> place.id == location_id end)
+    |> case do
+      nil ->
+        add_error(
+          changeset,
+          :route_id,
+          "Location `#{location_id}` does not exist"
+        )
+
+      place ->
+        valid_route? =
+          case route_id do
+            "Silver" ->
+              # For Silver Line, we make sure that the routes are all valid routes in Screenplay
+              # In this case, 741, 742, 743 and 746 within @valid_silver_line_routes
+              Enum.any?(
+                place.screens,
+                fn
+                  %Screenplay.Places.Place.PaEssScreen{routes: routes} ->
+                    Enum.any?(
+                      routes,
+                      fn route -> route.id in @valid_silver_line_routes end
+                    )
+
+                  _ ->
+                    false
+                end
+              )
+
+            "Green" ->
+              # For Green Line, double check that a branch exists within the routes
+              Enum.any?(
+                place.routes,
+                &String.starts_with?(&1, "Green")
+              )
+
+            _ ->
+              route_id in place.routes
+          end
+
+        if valid_route? do
+          changeset
+        else
+          add_error(
+            changeset,
+            :route_id,
+            "Route ID is invalid"
+          )
+        end
+    end
+  end
+end

--- a/lib/screenplay_web/auth_manager.ex
+++ b/lib/screenplay_web/auth_manager.ex
@@ -4,12 +4,17 @@ defmodule ScreenplayWeb.AuthManager do
   use Guardian, otp_app: :screenplay
 
   @type access_level ::
-          :emergency_admin | :screens_config_admin | :screens_admin | :pa_message_admin
+          :emergency_admin
+          | :screens_config_admin
+          | :screens_admin
+          | :pa_message_admin
+          | :suppression_admin
 
   @roles %{
     "screenplay-emergency-admin" => :emergency_admin,
     "screens-admin" => :screens_admin,
-    "pa-message-admin" => :pa_message_admin
+    "pa-message-admin" => :pa_message_admin,
+    "suppression-admin" => :suppression_admin
   }
 
   @max_session_time Application.compile_env!(:screenplay, [__MODULE__, :max_session_time])

--- a/lib/screenplay_web/controllers/fallback_controller.ex
+++ b/lib/screenplay_web/controllers/fallback_controller.ex
@@ -7,4 +7,10 @@ defmodule ScreenplayWeb.FallbackController do
     |> put_view(json: ScreenplayWeb.ChangesetJSON)
     |> render(:error, changeset: changeset)
   end
+
+  def call(conn, {:error, :not_found}) do
+    conn
+    |> put_status(404)
+    |> json(%{error: "not_found"})
+  end
 end

--- a/lib/screenplay_web/controllers/suppressed_predictions_api_controller.ex
+++ b/lib/screenplay_web/controllers/suppressed_predictions_api_controller.ex
@@ -1,0 +1,68 @@
+defmodule ScreenplayWeb.SuppressedPredictionsApiController do
+  use ScreenplayWeb, :controller
+
+  action_fallback ScreenplayWeb.FallbackController
+
+  alias Screenplay.SuppressedPredictions
+
+  def index(conn, _params) do
+    json(conn, SuppressedPredictions.get_all_suppressed_predictions())
+  end
+
+  def create(conn, params) do
+    with {:ok, suppressed_prediction} <-
+           SuppressedPredictions.create_suppressed_prediction(params) do
+      log_suppressed_prediction("suppressed_prediction_created", suppressed_prediction, conn)
+      json(conn, suppressed_prediction)
+    end
+  end
+
+  def update(
+        conn,
+        params = %{
+          "location_id" => location_id,
+          "route_id" => route_id,
+          "direction_id" => direction_id
+        }
+      ) do
+    with(
+      {:ok, suppressed_prediction} <-
+        SuppressedPredictions.get_suppressed_prediction(location_id, route_id, direction_id),
+      {:ok, updated_suppressed_prediction} <-
+        SuppressedPredictions.update_suppressed_prediction(suppressed_prediction, params)
+    ) do
+      log_suppressed_prediction(
+        "suppressed_prediction_updated",
+        updated_suppressed_prediction,
+        conn
+      )
+
+      json(conn, updated_suppressed_prediction)
+    end
+  end
+
+  def delete(
+        conn,
+        _delete_suppressed_params = %{
+          "location_id" => location_id,
+          "route_id" => route_id,
+          "direction_id" => direction_id
+        }
+      ) do
+    with {:ok, suppressed_prediction} <-
+           SuppressedPredictions.get_suppressed_prediction(location_id, route_id, direction_id),
+         {:ok, delete_suppressed_prediction} <-
+           SuppressedPredictions.delete_suppressed_prediction(suppressed_prediction) do
+      json(conn, delete_suppressed_prediction)
+    end
+  end
+
+  defp log_suppressed_prediction(event, suppressed_prediction, conn) do
+    Screenplay.Util.log(event,
+      location_id: suppressed_prediction.location_id,
+      direction_id: suppressed_prediction.direction_id,
+      clear_at_end_of_day: suppressed_prediction.clear_at_end_of_day,
+      user: get_session(conn, "username") |> Screenplay.Util.trim_username()
+    )
+  end
+end

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -36,6 +36,7 @@ defmodule ScreenplayWeb.Router do
   pipeline :ensure_outfront_admin, do: plug(EnsureRole, :emergency_admin)
   pipeline :ensure_pa_message_admin, do: plug(EnsureRole, :pa_message_admin)
   pipeline :ensure_screens_admin, do: plug(EnsureRole, :screens_admin)
+  pipeline :ensure_suppression_admin, do: plug(EnsureRole, :suppression_admin)
 
   # Load balancer health check, exempt from authentication, SSL redirects, etc.
   scope "/_health", ScreenplayWeb do
@@ -101,6 +102,22 @@ defmodule ScreenplayWeb.Router do
     pipe_through([:api, :authenticate, :ensure_pa_message_admin])
 
     resources("/", PaMessagesApiController, only: [:create, :update])
+  end
+
+  # Prediction Suppression
+  scope "/api/suppressed-predictions", ScreenplayWeb do
+    pipe_through([:api, :authenticate])
+
+    get("/", SuppressedPredictionsApiController, :index)
+  end
+
+  scope "/api/suppressed-predictions", ScreenplayWeb do
+    pipe_through([:api, :authenticate, :ensure_suppression_admin])
+
+    post("/", SuppressedPredictionsApiController, :create)
+    put("/", SuppressedPredictionsApiController, :update)
+    patch("/", SuppressedPredictionsApiController, :update)
+    delete("/", SuppressedPredictionsApiController, :delete)
   end
 
   # Permanent Configuration

--- a/lib/screenplay_web/templates/layout/app.html.heex
+++ b/lib/screenplay_web/templates/layout/app.html.heex
@@ -29,6 +29,9 @@
     <%= if :pa_message_admin in @roles do %>
         <meta name="is-pa-message-admin" content={true}>
     <% end %>
+    <%= if :suppresion_admin in @roles do %>
+        <meta name="is-suppression-admin" content={true}>
+    <% end %>
     <%= if @fullstory_org_id do %>
         <meta name="fullstory-org-id" content={@fullstory_org_id}>
     <% end %>

--- a/priv/repo/migrations/20250317165509_create_suppressed_predictions_table.exs
+++ b/priv/repo/migrations/20250317165509_create_suppressed_predictions_table.exs
@@ -1,0 +1,16 @@
+defmodule Screenplay.Repo.Migrations.AddSuppressedPredictions do
+  use Ecto.Migration
+
+  def change do
+    create table("suppressed_predictions", primary_key: false) do
+      add :location_id, :string, primary_key: true
+      add :route_id, :string, primary_key: true
+      add :direction_id, :integer, primary_key: true
+      add :clear_at_end_of_day, :boolean
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index("suppressed_predictions", :location_id)
+  end
+end

--- a/test/fixtures/places_and_screens_for_routes_to_signs.json
+++ b/test/fixtures/places_and_screens_for_routes_to_signs.json
@@ -43,5 +43,35 @@
         "station_code": "place-three-station-code"
       }
     ]
+  },
+  {
+    "id": "place-four",
+    "name": "Green Line Test",
+    "routes": ["Green-B"],
+    "screens": [
+      {
+        "id": "place-four-sign",
+        "label": null,
+        "type": "pa_ess",
+        "zone": "e",
+        "routes": [{ "id": "Green-B", "direction_id": 0 }],
+        "station_code": "place-four-station-code"
+      }
+    ]
+  },
+  {
+    "id": "place-five",
+    "name": "Silver Line Test",
+    "routes": ["Silver"],
+    "screens": [
+      {
+        "id": "place-five-sign",
+        "label": null,
+        "type": "pa_ess",
+        "zone": "e",
+        "routes": [{ "id": "747", "direction_id": 0 }],
+        "station_code": "place-five-station-code"
+      }
+    ]
   }
 ]

--- a/test/screenplay/suppressed_predictions_test.exs
+++ b/test/screenplay/suppressed_predictions_test.exs
@@ -1,0 +1,42 @@
+defmodule Screenplay.SuppressedPredictionsTest do
+  alias Screenplay.PlaceCacheHelpers
+  alias Screenplay.SuppressedPredictions
+  use ScreenplayWeb.DataCase
+
+  import Screenplay.Factory
+
+  setup_all do
+    start_supervised!(Screenplay.Places.Cache)
+    :ok
+  end
+
+  describe "suppressed_predictions" do
+    setup do
+      PlaceCacheHelpers.seed_place_cache()
+      :ok
+    end
+
+    test "get_suppressed_predictions/1 nil with invalid id" do
+      insert(:suppressed_predictions, %{
+        location_id: "place-one",
+        route_id: "place-one-route",
+        direction_id: 1,
+        clear_at_end_of_day: true,
+        inserted_at: ~U[2024-05-01T01:00:00Z],
+        updated_at: ~U[2024-05-01T01:00:00Z]
+      })
+
+      insert(:suppressed_predictions, %{
+        location_id: "place-two",
+        route_id: "place-two-route",
+        direction_id: 0,
+        clear_at_end_of_day: true,
+        inserted_at: ~U[2024-05-01T01:00:00Z],
+        updated_at: ~U[2024-05-01T01:00:00Z]
+      })
+
+      assert {:error, :not_found} ==
+               SuppressedPredictions.get_suppressed_prediction("place_typo", "place-one-route", 1)
+    end
+  end
+end

--- a/test/screenplay_web/controllers/pa_messages_api_controller_test.exs
+++ b/test/screenplay_web/controllers/pa_messages_api_controller_test.exs
@@ -2,8 +2,7 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
   use ScreenplayWeb.ConnCase
 
   alias Screenplay.AlertsCacheHelpers
-  alias Screenplay.Places.{Cache, Place}
-  alias Screenplay.Places.Place.PaEssScreen
+  alias Screenplay.PlaceCacheHelpers
 
   import Screenplay.Factory
 
@@ -210,24 +209,7 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
 
   describe "GET /api/pa-messages with route filters" do
     setup do
-      fixture_path =
-        Path.join(~w[#{File.cwd!()} test fixtures places_and_screens_for_routes_to_signs.json])
-
-      contents =
-        fixture_path
-        |> File.read!()
-        |> Jason.decode!(keys: :atoms)
-        |> Enum.map(fn %{screens: screens} = place ->
-          struct(Place, %{place | screens: Enum.map(screens, &struct(PaEssScreen, &1))})
-        end)
-
-      contents
-      |> Enum.map(&{&1.id, &1})
-      |> Cache.put_all()
-
-      on_exit(fn ->
-        Cache.delete_all()
-      end)
+      PlaceCacheHelpers.seed_place_cache()
     end
 
     @tag :authenticated

--- a/test/screenplay_web/controllers/suppressed_predictions_api_controller_test.exs
+++ b/test/screenplay_web/controllers/suppressed_predictions_api_controller_test.exs
@@ -1,0 +1,240 @@
+defmodule ScreenplayWeb.SuppressedPredictionsApiControllerTest do
+  alias Screenplay.PlaceCacheHelpers
+  use ScreenplayWeb.ConnCase
+
+  import Screenplay.PlaceCacheHelpers
+  import Screenplay.Factory
+
+  setup_all do
+    start_supervised!(Screenplay.Places.Cache)
+    :ok
+  end
+
+  describe "GET /api/suppressed-predictions with index/2" do
+    test "responds 403 if not authenticated", %{conn: conn} do
+      conn =
+        conn
+        |> get("/api/suppressed-predictions")
+
+      assert %{status: 403, halted: true, resp_body: "Session expired"} = conn
+    end
+
+    @tag :authenticated
+    test "responds with a list of suppressed predictions", %{conn: conn} do
+      assert [] = conn |> get("/api/suppressed-predictions") |> json_response(200)
+
+      insert(:suppressed_predictions, %{
+        location_id: "pa-ess",
+        route_id: "place-route",
+        direction_id: 0,
+        clear_at_end_of_day: true,
+        inserted_at: ~U[2024-05-01T01:00:00Z],
+        updated_at: ~U[2024-05-01T01:00:00Z]
+      })
+
+      insert(:suppressed_predictions, %{
+        location_id: "pa-ess",
+        route_id: "place-route",
+        direction_id: 1,
+        clear_at_end_of_day: true,
+        inserted_at: ~U[2024-05-01T01:00:00Z],
+        updated_at: ~U[2024-05-01T01:00:00Z]
+      })
+
+      assert 2 =
+               conn |> get("/api/suppressed-predictions") |> json_response(200) |> length()
+    end
+  end
+
+  describe "POST /api/suppressed-predictions with create/2" do
+    setup do
+      PlaceCacheHelpers.seed_place_cache()
+      :ok
+    end
+
+    @valid_params %{
+      location_id: "place-three",
+      route_id: "place-three-route",
+      direction_id: 1,
+      clear_at_end_of_day: true
+    }
+
+    @tag :authenticated
+    test "returns error when user is not a suppression admin admin", %{conn: conn} do
+      conn = post(conn, "/api/suppressed-predictions", @valid_params)
+      assert response(conn, 401)
+    end
+
+    @tag :authenticated_suppression_admin
+    test "creates a new SuppressedPrediction", %{conn: conn} do
+      assert %{
+               "location_id" => "place-three",
+               "route_id" => "place-three-route",
+               "direction_id" => 1,
+               "clear_at_end_of_day" => true
+             } =
+               conn
+               |> post("/api/suppressed-predictions", @valid_params)
+               |> json_response(200)
+    end
+
+    @tag :authenticated_suppression_admin
+    test "returns an error when passing in a Green Line branch route instead of Green", %{
+      conn: conn
+    } do
+      assert %{
+               "errors" => %{
+                 "route_id" => [
+                   "Please provide just `Green` as the route_id for handling all Green Line routes"
+                 ]
+               }
+             } =
+               conn
+               |> post("/api/suppressed-predictions", %{
+                 @valid_params
+                 | route_id: "Green-B",
+                   location_id: "place-four"
+               })
+               |> json_response(422)
+    end
+
+    @tag :authenticated_suppression_admin
+    test "returns an error when passing in a Silver Line route that is not 741, 742, 743 or 746",
+         %{
+           conn: conn
+         } do
+      assert %{
+               "errors" => %{
+                 "route_id" => [
+                   "Route ID is invalid"
+                 ]
+               }
+             } =
+               conn
+               |> post("/api/suppressed-predictions", %{
+                 @valid_params
+                 | route_id: "Silver",
+                   location_id: "place-five"
+               })
+               |> json_response(422)
+    end
+
+    @tag :authenticated_suppression_admin
+    test "returns an error when passed invalid location id", %{conn: conn} do
+      assert %{"errors" => _} =
+               conn
+               |> post("/api/suppressed-predictions", %{
+                 @valid_params
+                 | location_id: "wrong_location"
+               })
+               |> json_response(422)
+    end
+
+    @tag :authenticated_suppression_admin
+    test "returns an error when passed invalid direction id", %{conn: conn} do
+      assert %{"errors" => _} =
+               conn
+               |> post("/api/suppressed-predictions", %{
+                 @valid_params
+                 | direction_id: 3
+               })
+               |> json_response(422)
+    end
+  end
+
+  describe("PUT /api/suppressed-predictions with update/2") do
+    setup do
+      seed_place_cache()
+
+      insert(:suppressed_predictions, %{
+        location_id: "place-three",
+        route_id: "place-three-route",
+        direction_id: 1,
+        clear_at_end_of_day: true,
+        inserted_at: ~U[2024-05-01T01:00:00Z],
+        updated_at: ~U[2024-05-01T01:00:00Z]
+      })
+
+      :ok
+    end
+
+    @valid_params %{
+      location_id: "place-three",
+      route_id: "place-three-route",
+      direction_id: 1,
+      clear_at_end_of_day: false
+    }
+
+    @invalid_id_param %{
+      location_id: "invalid_location_id",
+      route_id: "place-three-route",
+      direction_id: 1,
+      clear_at_end_of_day: false
+    }
+
+    @tag :authenticated_suppression_admin
+    test "updates an existing SuppressedPrediction", %{conn: conn} do
+      assert %{"clear_at_end_of_day" => false} =
+               conn
+               |> put("/api/suppressed-predictions", @valid_params)
+               |> json_response(200)
+    end
+
+    @tag :authenticated_suppression_admin
+    test "returns 404 when SuppressedPrediction with id is not found", %{conn: conn} do
+      assert %{"error" => "not_found"} =
+               conn
+               |> put("/api/suppressed-predictions", @invalid_id_param)
+               |> json_response(404)
+    end
+  end
+
+  describe("DELETE /api/suppressed-predictions with delete/2") do
+    @valid_params %{
+      location_id: "place-three",
+      route_id: "place-three-route",
+      direction_id: 1
+    }
+
+    @invalid_params %{
+      location_id: "invalid_location_id",
+      route_id: "place-three-route",
+      direction_id: 1
+    }
+
+    setup do
+      insert(:suppressed_predictions, %{
+        location_id: "place-three",
+        route_id: "place-three-route",
+        direction_id: 1,
+        clear_at_end_of_day: true,
+        inserted_at: ~U[2024-05-01T01:00:00Z],
+        updated_at: ~U[2024-05-01T01:00:00Z]
+      })
+
+      :ok
+    end
+
+    @tag :authenticated_suppression_admin
+    test "deletes an existing SuppressedPrediction", %{conn: conn} do
+      assert(
+        %{
+          "location_id" => "place-three",
+          "direction_id" => 1,
+          "clear_at_end_of_day" => true
+        } =
+          conn
+          |> delete("/api/suppressed-predictions", @valid_params)
+          |> json_response(200)
+      )
+    end
+
+    @tag :authenticated_suppression_admin
+    test "returns 404 when SuppressedPrediction with id is not found", %{conn: conn} do
+      assert %{"error" => "not_found"} =
+               conn
+               |> delete("/api/suppressed-predictions", @invalid_params)
+               |> json_response(404)
+    end
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -97,6 +97,20 @@ defmodule ScreenplayWeb.ConnCase do
 
           {conn, user}
 
+        tags[:authenticated_suppression_admin] ->
+          user = "test_user"
+
+          conn =
+            Phoenix.ConnTest.build_conn()
+            |> Plug.Test.init_test_session(%{})
+            |> Guardian.Plug.sign_in(ScreenplayWeb.AuthManager, user, %{
+              "roles" => ["suppression-admin"]
+            })
+            |> Plug.Conn.put_session(:username, user)
+            |> Plug.run([{ScreenplayWeb.Plugs.Metadata, []}])
+
+          {conn, user}
+
         tags[:api_authenticated] ->
           conn =
             Phoenix.ConnTest.build_conn()

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -19,4 +19,12 @@ defmodule Screenplay.Factory do
       message_type: ""
     }
   end
+
+  def suppressed_predictions_factory do
+    %Screenplay.SuppressedPredictions.SuppressedPrediction{
+      location_id: "",
+      direction_id: 0,
+      clear_at_end_of_day: false
+    }
+  end
 end

--- a/test/support/place_cache_helpers.ex
+++ b/test/support/place_cache_helpers.ex
@@ -1,0 +1,30 @@
+defmodule Screenplay.PlaceCacheHelpers do
+  @moduledoc """
+  Helper function for seeding Screenplay.Places
+  """
+
+  import ExUnit.Callbacks
+  alias Screenplay.Places.{Cache, Place}
+  alias Screenplay.Places.Place.PaEssScreen
+
+  def seed_place_cache do
+    fixture_path =
+      Path.join(~w[#{File.cwd!()} test fixtures places_and_screens_for_routes_to_signs.json])
+
+    contents =
+      fixture_path
+      |> File.read!()
+      |> Jason.decode!(keys: :atoms)
+      |> Enum.map(fn %{screens: screens} = place ->
+        struct(Place, %{place | screens: Enum.map(screens, &struct(PaEssScreen, &1))})
+      end)
+
+    contents
+    |> Enum.map(&{&1.id, &1})
+    |> Cache.put_all()
+
+    on_exit(fn ->
+      Cache.delete_all()
+    end)
+  end
+end


### PR DESCRIPTION
**Asana task**: [Prediction suppression: Backend data model and API](https://app.asana.com/0/1185117109217413/1209637020443922/f)

- Added suppressed predictions migration for creating table
- Added `suppressed_prediction.ex` DataModel containing `location_id`, `direction_id` and `clear_at_end_of_day` boolean
- Added `suppressed_predictions.ex` Ecto.Repo bridge, with create, update, delete and get/get all functions
- Added `suppressed_predictions_api_controller` handling the calls from `router.ex`
- ~Tests coming soon~

- [x] For features with a design/UX component, deployed branch to dev-green and let product know it's ready for review.
