### PR TITLE
add data structure for prediction suppression page

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -26,7 +26,8 @@
       },
       checks: %{
         disabled: [
-          {Credo.Check.Refactor.Nesting, []}
+          {Credo.Check.Refactor.Nesting, []},
+          {Credo.Check.Refactor.CyclomaticComplexity, []}
         ],
         extra: []
       }

--- a/assets/js/components/Dashboard/Dashboard.tsx
+++ b/assets/js/components/Dashboard/Dashboard.tsx
@@ -8,7 +8,7 @@ import {
   useScreenplayDispatchContext,
 } from "Hooks/useScreenplayContext";
 import { useInterval } from "Hooks/useInterval";
-import { fetchAlerts, fetchPlaces } from "Utils/api";
+import { fetchAlerts, fetchPlaces, fetchServiceRecords } from "Utils/api";
 import AlertBanner from "Components/AlertBanner";
 import LinkCopiedToast from "Components/LinkCopiedToast";
 import ActionOutcomeToast from "Components/ActionOutcomeToast";
@@ -48,6 +48,10 @@ const Dashboard: ComponentType = () => {
     fetchPlaces().then((placesList) =>
       dispatch({ type: "SET_PLACES", places: placesList }),
     );
+
+    fetchServiceRecords().then((serviceRecords) => {
+      dispatch({ type: "SET_SERVICE_RECORDS", serviceRecords });
+    });
 
     // Tests rely on this effect **not** having any dependencies listed.
     // This code pre-dates the addition of the react-hooks eslint rules.

--- a/assets/js/components/Dashboard/Dashboard.tsx
+++ b/assets/js/components/Dashboard/Dashboard.tsx
@@ -8,7 +8,7 @@ import {
   useScreenplayDispatchContext,
 } from "Hooks/useScreenplayContext";
 import { useInterval } from "Hooks/useInterval";
-import { fetchAlerts, fetchPlaces, fetchServiceRecords } from "Utils/api";
+import { fetchAlerts, fetchPlaces, fetchLineStops } from "Utils/api";
 import AlertBanner from "Components/AlertBanner";
 import LinkCopiedToast from "Components/LinkCopiedToast";
 import ActionOutcomeToast from "Components/ActionOutcomeToast";
@@ -49,8 +49,8 @@ const Dashboard: ComponentType = () => {
       dispatch({ type: "SET_PLACES", places: placesList }),
     );
 
-    fetchServiceRecords().then((serviceRecords) => {
-      dispatch({ type: "SET_SERVICE_RECORDS", serviceRecords });
+    fetchLineStops().then((lineStops) => {
+      dispatch({ type: "SET_LINE_STOPS", lineStops });
     });
 
     // Tests rely on this effect **not** having any dependencies listed.

--- a/assets/js/hooks/useScreenplayContext.tsx
+++ b/assets/js/hooks/useScreenplayContext.tsx
@@ -4,6 +4,7 @@ import { Place } from "../models/place";
 import { Alert } from "../models/alert";
 import { DirectionID } from "../models/direction_id";
 import { ScreensByAlert } from "../models/screensByAlert";
+import { ServiceRecord } from "../models/service_record";
 import { ConfigValidationErrors } from "../models/configValidationErrors";
 import { useReducer } from "react";
 import {
@@ -23,6 +24,10 @@ type ReducerAction =
   | {
       type: "SET_PLACES";
       places: Place[];
+    }
+  | {
+      type: "SET_SERVICE_RECORDS";
+      serviceRecords: ServiceRecord[];
     }
   | {
       type: "SET_ALERTS";
@@ -105,6 +110,7 @@ interface AlertsListState {
 
 interface ScreenplayState {
   places: Place[];
+  serviceRecords: ServiceRecord[];
   alerts: Alert[];
   allAPIAlertIds: string[];
   screensByAlertMap: ScreensByAlert;
@@ -126,6 +132,8 @@ const reducer = (
   switch (action.type) {
     case "SET_PLACES":
       return { ...state, places: action.places };
+    case "SET_SERVICE_RECORDS":
+      return { ...state, serviceRecords: action.serviceRecords };
     case "SET_ALERTS":
       return {
         ...state,
@@ -250,6 +258,7 @@ const configValidationReducer = (
 
 const initialState: ScreenplayState = {
   places: [] as Place[],
+  serviceRecords: [],
   alerts: [] as Alert[],
   allAPIAlertIds: [] as string[],
   screensByAlertMap: {} as ScreensByAlert,

--- a/assets/js/hooks/useScreenplayContext.tsx
+++ b/assets/js/hooks/useScreenplayContext.tsx
@@ -4,7 +4,7 @@ import { Place } from "../models/place";
 import { Alert } from "../models/alert";
 import { DirectionID } from "../models/direction_id";
 import { ScreensByAlert } from "../models/screensByAlert";
-import { ServiceRecord } from "../models/service_record";
+import { LineStop } from "../models/line_stop";
 import { ConfigValidationErrors } from "../models/configValidationErrors";
 import { useReducer } from "react";
 import {
@@ -26,8 +26,8 @@ type ReducerAction =
       places: Place[];
     }
   | {
-      type: "SET_SERVICE_RECORDS";
-      serviceRecords: ServiceRecord[];
+      type: "SET_LINE_STOPS";
+      lineStops: LineStop[];
     }
   | {
       type: "SET_ALERTS";
@@ -110,7 +110,7 @@ interface AlertsListState {
 
 interface ScreenplayState {
   places: Place[];
-  serviceRecords: ServiceRecord[];
+  lineStops: LineStop[];
   alerts: Alert[];
   allAPIAlertIds: string[];
   screensByAlertMap: ScreensByAlert;
@@ -132,8 +132,8 @@ const reducer = (
   switch (action.type) {
     case "SET_PLACES":
       return { ...state, places: action.places };
-    case "SET_SERVICE_RECORDS":
-      return { ...state, serviceRecords: action.serviceRecords };
+    case "SET_LINE_STOPS":
+      return { ...state, lineStops: action.lineStops };
     case "SET_ALERTS":
       return {
         ...state,
@@ -258,7 +258,7 @@ const configValidationReducer = (
 
 const initialState: ScreenplayState = {
   places: [] as Place[],
-  serviceRecords: [],
+  lineStops: [],
   alerts: [] as Alert[],
   allAPIAlertIds: [] as string[],
   screensByAlertMap: {} as ScreensByAlert,

--- a/assets/js/models/line_stop.ts
+++ b/assets/js/models/line_stop.ts
@@ -1,0 +1,6 @@
+export interface LineStop {
+  line: string;
+  stop_id: string;
+  direction_id: 0 | 1;
+  type: "start" | "end" | "mid";
+}

--- a/assets/js/models/service_record.ts
+++ b/assets/js/models/service_record.ts
@@ -1,0 +1,6 @@
+export interface ServiceRecord {
+  route: string;
+  place_id: string;
+  direction_id: 0 | 1;
+  type: "start" | "end" | "mid";
+}

--- a/assets/js/models/service_record.ts
+++ b/assets/js/models/service_record.ts
@@ -1,6 +1,0 @@
-export interface ServiceRecord {
-  route: string;
-  place_id: string;
-  direction_id: 0 | 1;
-  type: "start" | "end" | "mid";
-}

--- a/assets/js/utils/api.ts
+++ b/assets/js/utils/api.ts
@@ -11,6 +11,12 @@ export const fetchPlaces = async (): Promise<Place[]> => {
   return await response.json();
 };
 
+export const fetchServiceRecords = async () => {
+  const response = await fetch("/api/service_records");
+  const { data } = await response.json();
+  return data;
+};
+
 interface AlertsResponse {
   all_alert_ids: string[];
   alerts: Alert[];

--- a/assets/js/utils/api.ts
+++ b/assets/js/utils/api.ts
@@ -11,8 +11,8 @@ export const fetchPlaces = async (): Promise<Place[]> => {
   return await response.json();
 };
 
-export const fetchServiceRecords = async () => {
-  const response = await fetch("/api/service_records");
+export const fetchLineStops = async () => {
+  const response = await fetch("/api/line_stops");
   const { data } = await response.json();
   return data;
 };

--- a/assets/tests/setup.ts
+++ b/assets/tests/setup.ts
@@ -46,6 +46,9 @@ beforeEach(() => {
       Promise.resolve({
         json: () => Promise.resolve(places),
       }),
+    )
+    .mockReturnValueOnce(
+      Promise.resolve({ json: () => Promise.resolve({ data: [] }) }),
     );
 });
 

--- a/lib/screenplay/application.ex
+++ b/lib/screenplay/application.ex
@@ -22,7 +22,7 @@ defmodule Screenplay.Application do
         Screenplay.ScreensConfig
       ] ++
         if Application.get_env(:screenplay, :start_cache_processes) do
-          [Screenplay.Alerts.Cache, Screenplay.Places]
+          [Screenplay.Alerts.Cache, Screenplay.Places, Screenplay.PredictionSuppression]
         else
           []
         end

--- a/lib/screenplay/prediction_suppression.ex
+++ b/lib/screenplay/prediction_suppression.ex
@@ -1,4 +1,7 @@
 defmodule Screenplay.PredictionSuppression do
+  @moduledoc """
+  Generates data structures for driving the prediction suppression UI
+  """
   use GenServer
 
   @spec service_records() :: [

--- a/lib/screenplay/prediction_suppression.ex
+++ b/lib/screenplay/prediction_suppression.ex
@@ -1,0 +1,83 @@
+defmodule Screenplay.PredictionSuppression do
+  use GenServer
+
+  @spec service_records() :: [
+          %{
+            place_id: String.t(),
+            route: String.t(),
+            direction_id: 0 | 1,
+            type: :start | :end | :mid
+          }
+        ]
+  def service_records() do
+    case :ets.lookup(:service_records, :value) do
+      [{:value, data}] -> data
+      _ -> []
+    end
+  end
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  end
+
+  @impl GenServer
+  def init(_) do
+    :ets.new(:service_records, [:protected, :named_table, read_concurrency: true])
+    send(self(), :update)
+    {:ok, %{}}
+  end
+
+  @impl GenServer
+  def handle_info(:update, state) do
+    Process.send_after(self(), :update, 60_000)
+
+    case Screenplay.V3Api.get_json("/route_patterns", %{
+           "filter[route]" => "Red,Orange,Blue,Green-B,Green-C,Green-D,Green-E,741,742,743,746",
+           "include" => "representative_trip.stops"
+         }) do
+      {:ok, %{"data" => data, "included" => included}} ->
+        trip_lookup =
+          for %{"type" => "trip"} = trip <- included, into: %{} do
+            {trip["id"], trip}
+          end
+
+        stop_lookup =
+          for %{"type" => "stop"} = stop <- included, into: %{} do
+            {stop["id"], stop}
+          end
+
+        new_service_records =
+          for %{"attributes" => %{"typicality" => 1}} = route_pattern <- data,
+              trip_id = route_pattern["relationships"]["representative_trip"]["data"]["id"],
+              trip = trip_lookup[trip_id],
+              stop_references = trip["relationships"]["stops"]["data"],
+              %{"id" => stop_id} <- stop_references,
+              uniq: true do
+            stop = stop_lookup[stop_id]
+
+            %{
+              place_id: stop["relationships"]["parent_station"]["data"]["id"],
+              route: trip["relationships"]["route"]["data"]["id"] |> route(),
+              direction_id: trip["attributes"]["direction_id"],
+              type:
+                cond do
+                  List.first(stop_references)["id"] == stop_id -> :start
+                  List.last(stop_references)["id"] == stop_id -> :end
+                  true -> :mid
+                end
+            }
+          end
+
+        :ets.insert(:service_records, {:value, new_service_records})
+
+      _ ->
+        nil
+    end
+
+    {:noreply, state}
+  end
+
+  defp route("Green-" <> _), do: "Green"
+  defp route(route_id) when route_id in ["741", "742", "743", "746"], do: "Silver"
+  defp route(route_id), do: route_id
+end

--- a/lib/screenplay/prediction_suppression.ex
+++ b/lib/screenplay/prediction_suppression.ex
@@ -4,7 +4,7 @@ defmodule Screenplay.PredictionSuppression do
   """
   use GenServer
 
-  defguardp is_silver(route_id) when route_id in ["741", "742", "743", "746"]
+  defguardp is_sl_waterfront(route_id) when route_id in ["741", "742", "743", "746"]
 
   @spec line_stops() :: [
           %{
@@ -59,7 +59,7 @@ defmodule Screenplay.PredictionSuppression do
                   "representative_trip" => %{"data" => %{"id" => trip_id}}
                 }
               }
-              when canonical or (is_silver(route_id) and typicality == 1) <- data,
+              when canonical or (is_sl_waterfront(route_id) and typicality == 1) <- data,
               trip = trip_lookup[trip_id],
               stop_references = trip["relationships"]["stops"]["data"],
               first_stop_id = List.first(stop_references)["id"],
@@ -91,6 +91,6 @@ defmodule Screenplay.PredictionSuppression do
   end
 
   defp line("Green-" <> _), do: "Green"
-  defp line(route_id) when is_silver(route_id), do: "Silver"
+  defp line(route_id) when is_sl_waterfront(route_id), do: "Silver"
   defp line(route_id), do: route_id
 end

--- a/lib/screenplay/prediction_suppression.ex
+++ b/lib/screenplay/prediction_suppression.ex
@@ -12,7 +12,7 @@ defmodule Screenplay.PredictionSuppression do
             type: :start | :end | :mid
           }
         ]
-  def service_records() do
+  def service_records do
     case :ets.lookup(:service_records, :value) do
       [{:value, data}] -> data
       _ -> []

--- a/lib/screenplay_web/controllers/dashboard_api_controller.ex
+++ b/lib/screenplay_web/controllers/dashboard_api_controller.ex
@@ -19,6 +19,10 @@ defmodule ScreenplayWeb.DashboardApiController do
     json(conn, updated_config)
   end
 
+  def service_records(conn, _params) do
+    json(conn, %{data: Screenplay.PredictionSuppression.service_records()})
+  end
+
   defp update_config_with_locations(config, locations) do
     Enum.map(config, fn %Place{screens: screens} = place ->
       new_screens =

--- a/lib/screenplay_web/controllers/dashboard_api_controller.ex
+++ b/lib/screenplay_web/controllers/dashboard_api_controller.ex
@@ -19,8 +19,8 @@ defmodule ScreenplayWeb.DashboardApiController do
     json(conn, updated_config)
   end
 
-  def service_records(conn, _params) do
-    json(conn, %{data: Screenplay.PredictionSuppression.service_records()})
+  def line_stops(conn, _params) do
+    json(conn, %{data: Screenplay.PredictionSuppression.line_stops()})
   end
 
   defp update_config_with_locations(config, locations) do

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -69,7 +69,7 @@ defmodule ScreenplayWeb.Router do
     pipe_through([:api, :authenticate])
 
     get("/dashboard", DashboardApiController, :index)
-    get("/service_records", DashboardApiController, :service_records)
+    get("/line_stops", DashboardApiController, :line_stops)
     get("/alerts", AlertsApiController, :index)
     get("/alerts/non_access_alerts", AlertsApiController, :non_access_alerts)
   end

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -69,6 +69,7 @@ defmodule ScreenplayWeb.Router do
     pipe_through([:api, :authenticate])
 
     get("/dashboard", DashboardApiController, :index)
+    get("/service_records", DashboardApiController, :service_records)
     get("/alerts", AlertsApiController, :index)
     get("/alerts/non_access_alerts", AlertsApiController, :non_access_alerts)
   end


### PR DESCRIPTION
**Asana task**: [Prediction suppression: Stops data structure to drive UI](https://app.asana.com/0/1185117109217413/1209637020443919/f)

Description

This adds a new "service record" data structure, which is computed from the API and provides a basis for looking up a particular station/route/direction to determine whether it's the start, end, or middle of its trip. This info will be used to drive the UI for the prediction suppression page.