### PR TITLE
fix: always hide on-bus screens from place builder

### DIFF
--- a/lib/screenplay/places/builder.ex
+++ b/lib/screenplay/places/builder.ex
@@ -96,7 +96,7 @@ defmodule Screenplay.Places.Builder do
 
   defp get_showtime_screens do
     ScreensConfigStore.screens()
-    |> Enum.filter(fn {_, config} -> not config.hidden_from_screenplay end)
+    |> Enum.reject(&hidden_screen?/1)
     |> Enum.flat_map(&split_multi_place_screens/1)
     |> Enum.group_by(&get_stop_id/1, fn
       {id,
@@ -116,6 +116,10 @@ defmodule Screenplay.Places.Builder do
         %ShowtimeScreen{id: id, type: app_id, disabled: disabled}
     end)
   end
+
+  defp hidden_screen?({_id, %Screen{app_id: :on_bus_v2}}), do: true
+  defp hidden_screen?({_id, %Screen{hidden_from_screenplay: true}}), do: true
+  defp hidden_screen?(_), do: false
 
   defp append_routes_to_places(places) do
     places

--- a/lib/screenplay/screens_config.ex
+++ b/lib/screenplay/screens_config.ex
@@ -24,7 +24,7 @@ defmodule Screenplay.ScreensConfig do
     Supervisor.init(children, strategy: :one_for_one)
   end
 
-  @spec screens() :: list(Screen.t())
+  @spec screens() :: list({String.t(), Screen.t()})
   def screens do
     Cache.all(nil, return: {:key, :value})
   end

--- a/test/fixtures/builder/screens_config.json
+++ b/test/fixtures/builder/screens_config.json
@@ -560,6 +560,19 @@
       "hidden_from_screenplay": false,
       "vendor": "mimo",
       "device_id": ""
+    },
+    "BUS-101": {
+      "disabled": false,
+      "name": "",
+      "tags": [],
+      "app_id": "on_bus_v2",
+      "app_params": {
+        "evergreen_content": []
+      },
+      "refresh_if_loaded_before": null,
+      "hidden_from_screenplay": false,
+      "vendor": "hanover",
+      "device_id": ""
     }
   }
 }


### PR DESCRIPTION
On-Bus screens do not have a fixed location, so currently there is no sensible way of exposing them in Screenplay.