### PR TITLE
Added endpoint for Transit Data

### DIFF
--- a/docs/tech_specs/suppressed_predictions_api.md
+++ b/docs/tech_specs/suppressed_predictions_api.md
@@ -1,0 +1,116 @@
+# List Suppressed suppression_type
+
+Lists all Suppressed suppression_type defined by the stop_id, route_id and direction_id
+
+_Note_: JFK/UMass (place-jfk) will use the child stop_ids.
+
+**URL** : `/api/suppressed_suppression_type/suppression_data`
+
+**Method** : `GET`
+
+**Parameters**: None
+
+**API key required** : YES
+
+## Success Responses
+
+**Code** : `200 OK`
+
+**Response**:
+
+```json
+[
+  {
+    "stop_id": "place-aqucl",
+    "route_id": "Blue",
+    "direction_id": 1,
+    "suppression_type": "none"
+  },
+  {
+    "stop_id": "place-aqucl",
+    "route_id": "Blue",
+    "direction_id": 0,
+    "suppression_type": "none"
+  },
+  {
+    "stop_id": "place-ogmnl",
+    "route_id": "Orange",
+    "direction_id": 0,
+    "suppression_type": "terminal"
+  },
+  {
+    "stop_id": "place-hymnl",
+    "route_id": "Green-B",
+    "direction_id": 1,
+    "suppression_type": "stop"
+  },
+  {
+    "stop_id": "place-hymnl",
+    "route_id": "Green-C",
+    "direction_id": 1,
+    "suppression_type": "stop"
+  },
+  {
+    "stop_id": "place-hymnl",
+    "route_id": "Green-D",
+    "direction_id": 1,
+    "suppression_type": "stop"
+  },
+  {
+    "stop_id": "place-crtst",
+    "route_id": "741",
+    "direction_id": 0,
+    "suppression_type": "stop"
+  },
+  {
+    "stop_id": "place-crtst",
+    "route_id": "742",
+    "direction_id": 0,
+    "suppression_type": "stop"
+  },
+  {
+    "stop_id": "place-crtst",
+    "route_id": "743",
+    "direction_id": 0,
+    "suppression_type": "stop"
+  },
+  {
+    "stop_id": "place-crtst",
+    "route_id": "746",
+    "direction_id": 0,
+    "suppression_type": "stop"
+  },
+  {
+    "stop_id": "70085",
+    "route_id": "Red",
+    "direction_id": 0,
+    "suppression_type": "stop"
+  },
+  {
+    "stop_id": "70086",
+    "route_id": "Red",
+    "direction_id": 1,
+    "suppression_type": "none"
+  },
+  {
+    "stop_id": "70095",
+    "route_id": "Red",
+    "direction_id": 0,
+    "suppression_type": "stop"
+  },
+  {
+    "stop_id": "70096",
+    "route_id": "Red",
+    "direction_id": 1,
+    "suppression_type": "none"
+  }
+]
+```
+
+## Failure Responses
+
+**Code** : `403 Forbidden`
+
+**Response**:
+
+`Invalid API key`

--- a/lib/screenplay/prediction_suppression.ex
+++ b/lib/screenplay/prediction_suppression.ex
@@ -3,8 +3,7 @@ defmodule Screenplay.PredictionSuppression do
   Generates data structures for driving the prediction suppression UI
   """
   use GenServer
-
-  defguardp is_sl_waterfront(route_id) when route_id in ["741", "742", "743", "746"]
+  import Screenplay.PredictionSuppressionUtils, only: [is_sl_waterfront: 1]
 
   @spec line_stops() :: [
           %{

--- a/lib/screenplay/suppressed_predictions.ex
+++ b/lib/screenplay/suppressed_predictions.ex
@@ -2,6 +2,10 @@ defmodule Screenplay.SuppressedPredictions do
   @moduledoc """
   Module for functions dealing with `SuppressedPredictions` and the `suppressed_predictions` database 
   """
+
+  alias Screenplay.Places
+  alias Screenplay.PredictionSuppression
+  alias Screenplay.PredictionSuppressionUtils
   alias Screenplay.Repo
   alias Screenplay.SuppressedPredictions.SuppressedPrediction
 
@@ -35,6 +39,140 @@ defmodule Screenplay.SuppressedPredictions do
   def get_all_suppressed_predictions do
     SuppressedPrediction
     |> Repo.all()
+  end
+
+  @doc """
+  Get all suppressed predictions modified for transit data
+  """
+  @spec get_all_suppressed_predictions_for_data() :: [
+          %{
+            route_id: String.t(),
+            stop_id: String.t(),
+            direction_id: integer(),
+            suppression_type: :terminal | :stop | :none
+          }
+        ]
+  def get_all_suppressed_predictions_for_data do
+    suppressed_predictions_map =
+      MapSet.new(
+        get_all_suppressed_predictions(),
+        &%{location_id: &1.location_id, route_id: &1.route_id, direction_id: &1.direction_id}
+      )
+
+    line_stops_map =
+      PredictionSuppression.line_stops()
+      # End stations don't suppress predictions, filter them out
+      |> Enum.filter(&(&1.type != :end))
+      |> Enum.group_by(& &1.stop_id)
+
+    Places.get()
+    |> Enum.flat_map(fn
+      # JFK has special two child stops ids to take into account, if we find it here
+      # we split it up into the two platforms and handle the special case
+      %Screenplay.Places.Place{id: "place-jfk"} ->
+        Enum.map(
+          PredictionSuppressionUtils.jfk_umass_child_stop_data(),
+          fn %{
+               location_id: location_id,
+               route_id: route_id,
+               stop_id: child_stop_id,
+               direction_id: direction_id
+             } ->
+            %{
+              stop_id: child_stop_id,
+              route_id: route_id,
+              direction_id: direction_id,
+              suppression_type:
+                PredictionSuppressionUtils.suppression_type(
+                  location_id,
+                  route_id,
+                  direction_id,
+                  suppressed_predictions_map,
+                  :mid
+                )
+            }
+          end
+        )
+
+      place ->
+        case Map.get(line_stops_map, place.id) do
+          nil ->
+            []
+
+          line_stops ->
+            line_stops
+            |> Enum.filter(&PredictionSuppressionUtils.valid_route_for_place?(place, &1.line))
+            |> Enum.flat_map(fn
+              %{
+                line: "Silver",
+                direction_id: direction_id,
+                type: suppression_type
+              } ->
+                Enum.flat_map(place.screens, fn
+                  %Screenplay.Places.Place.PaEssScreen{routes: routes} ->
+                    Enum.filter(
+                      routes,
+                      fn route ->
+                        PredictionSuppressionUtils.sl_waterfront?(route.id) and
+                          route.direction_id == direction_id
+                      end
+                    )
+
+                  _ ->
+                    []
+                end)
+                |> Enum.uniq_by(fn %{id: route_id, direction_id: direction_id} ->
+                  {route_id, direction_id}
+                end)
+                |> Enum.map(fn %{id: route_id, direction_id: direction_id} ->
+                  PredictionSuppressionUtils.suppressed_prediction_for_data(
+                    place.id,
+                    route_id,
+                    direction_id,
+                    suppressed_predictions_map,
+                    suppression_type,
+                    "Silver"
+                  )
+                end)
+
+              %{
+                line: "Green",
+                stop_id: stop_id,
+                direction_id: direction_id,
+                type: suppression_type
+              } ->
+                place.routes
+                |> Enum.filter(&String.starts_with?(&1, "Green"))
+                |> Enum.map(
+                  &PredictionSuppressionUtils.suppressed_prediction_for_data(
+                    stop_id,
+                    &1,
+                    direction_id,
+                    suppressed_predictions_map,
+                    suppression_type,
+                    "Green"
+                  )
+                )
+
+              %{
+                line: route_id,
+                stop_id: stop_id,
+                direction_id: direction_id,
+                type: suppression_type
+              } ->
+                [
+                  PredictionSuppressionUtils.suppressed_prediction_for_data(
+                    stop_id,
+                    route_id,
+                    direction_id,
+                    suppressed_predictions_map,
+                    suppression_type,
+                    route_id
+                  )
+                ]
+            end)
+        end
+    end)
   end
 
   @doc """

--- a/lib/screenplay/suppressed_predictions/prediction_suppression_utils.ex
+++ b/lib/screenplay/suppressed_predictions/prediction_suppression_utils.ex
@@ -1,0 +1,122 @@
+defmodule Screenplay.PredictionSuppressionUtils do
+  @moduledoc """
+  Utility functions for validating, checking prediction suppression and getting suppression type
+  """
+  require Logger
+
+  @green_line_routes ["Green-B", "Green-C", "Green-D", "Green-E"]
+  def green_line_routes, do: @green_line_routes
+  defguard is_green_line(route_id) when route_id in @green_line_routes
+
+  @sl_waterfront_routes ["741", "742", "743", "746"]
+  def sl_waterfront_routes, do: @sl_waterfront_routes
+  def sl_waterfront?(route_id), do: route_id in @sl_waterfront_routes
+  defguard is_sl_waterfront(route_id) when route_id in @sl_waterfront_routes
+
+  @jfk_umass_ashmont_location_id "jfk_umass_ashmont_platform"
+  @jfk_umass_braintree_location_id "jfk_umass_braintree_platform"
+  def jfk_umass_child_location_ids,
+    do: [@jfk_umass_ashmont_location_id, @jfk_umass_braintree_location_id]
+
+  def jfk_umass_child_stop_data,
+    do: [
+      %{
+        route_id: "Red",
+        stop_id: "70085",
+        direction_id: 0,
+        location_id: @jfk_umass_ashmont_location_id
+      },
+      %{
+        route_id: "Red",
+        stop_id: "70086",
+        direction_id: 1,
+        location_id: @jfk_umass_ashmont_location_id
+      },
+      %{
+        route_id: "Red",
+        stop_id: "70095",
+        direction_id: 0,
+        location_id: @jfk_umass_braintree_location_id
+      },
+      %{
+        route_id: "Red",
+        stop_id: "70096",
+        direction_id: 1,
+        location_id: @jfk_umass_braintree_location_id
+      }
+    ]
+
+  def valid_route_for_place?(place, route_id) when route_id == "Silver" do
+    # For Silver Line, we make sure that the routes are all valid routes in Screenplay
+    # In this case, 741, 742, 743 and 746 within @valid_silver_line_routes
+    Enum.any?(
+      place.screens,
+      fn
+        %Screenplay.Places.Place.PaEssScreen{routes: routes} ->
+          Enum.any?(
+            routes,
+            fn route -> sl_waterfront?(route.id) end
+          )
+
+        _ ->
+          false
+      end
+    )
+  end
+
+  def valid_route_for_place?(place, route_id) when route_id == "Green" do
+    # For Green Line, double check that a branch exists within the routes
+    Enum.any?(
+      place.routes,
+      &String.starts_with?(&1, "Green")
+    )
+  end
+
+  def valid_route_for_place?(place, route_id) do
+    route_id in place.routes
+  end
+
+  def suppressed_prediction_for_data(
+        stop_id,
+        route_id,
+        direction_id,
+        suppressed_predictions_map,
+        suppression_type,
+        suppression_route_id
+      ) do
+    %{
+      stop_id: stop_id,
+      route_id: route_id,
+      direction_id: direction_id,
+      suppression_type:
+        suppression_type(
+          stop_id,
+          suppression_route_id,
+          direction_id,
+          suppressed_predictions_map,
+          suppression_type
+        )
+    }
+  end
+
+  def suppression_type(
+        stop_id,
+        suppression_route_id,
+        direction_id,
+        suppressed_predictions_map,
+        suppression_type
+      ) do
+    if %{
+         location_id: stop_id,
+         route_id: suppression_route_id,
+         direction_id: direction_id
+       } in suppressed_predictions_map do
+      case suppression_type do
+        :mid -> :stop
+        :start -> :terminal
+      end
+    else
+      :none
+    end
+  end
+end

--- a/lib/screenplay_web/controllers/suppressed_predictions_api_controller.ex
+++ b/lib/screenplay_web/controllers/suppressed_predictions_api_controller.ex
@@ -5,6 +5,10 @@ defmodule ScreenplayWeb.SuppressedPredictionsApiController do
 
   alias Screenplay.SuppressedPredictions
 
+  def data(conn, _params) do
+    json(conn, SuppressedPredictions.get_all_suppressed_predictions_for_data())
+  end
+
   def index(conn, _params) do
     json(conn, SuppressedPredictions.get_all_suppressed_predictions())
   end

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -107,6 +107,12 @@ defmodule ScreenplayWeb.Router do
 
   # Prediction Suppression
   scope "/api/suppressed-predictions", ScreenplayWeb do
+    pipe_through([:api, :ensure_api_auth])
+
+    get("/suppression_data", SuppressedPredictionsApiController, :data)
+  end
+
+  scope "/api/suppressed-predictions", ScreenplayWeb do
     pipe_through([:api, :authenticate])
 
     get("/", SuppressedPredictionsApiController, :index)

--- a/test/fixtures/places_and_screens_for_prediction_tests.json
+++ b/test/fixtures/places_and_screens_for_prediction_tests.json
@@ -1,15 +1,15 @@
 [
   {
-    "id": "place-one",
-    "name": "Place One",
-    "routes": ["place-two-route"],
+    "id": "place-jfk",
+    "name": "Place JFK",
+    "routes": ["Red"],
     "screens": [
       {
-        "id": "place-one-sign",
+        "id": "place-jfk",
         "label": null,
         "type": "pa_ess",
         "zone": "e",
-        "routes": [{ "id": "place-one-route", "direction_id": 0 }],
+        "routes": [{ "id": "Red", "direction_id": 1 }],
         "station_code": "place-one-station-code"
       }
     ]
@@ -17,14 +17,14 @@
   {
     "id": "place-two",
     "name": "Place Two",
-    "routes": ["place-two-route"],
+    "routes": ["Blue"],
     "screens": [
       {
         "id": "place-two-sign",
         "label": null,
         "type": "pa_ess",
         "zone": "e",
-        "routes": [{ "id": "place-two-route", "direction_id": 0 }],
+        "routes": [{ "id": "Blue", "direction_id": 0 }],
         "station_code": "place-two-station-code"
       }
     ]
@@ -32,14 +32,14 @@
   {
     "id": "place-three",
     "name": "Place Three",
-    "routes": ["place-three-route"],
+    "routes": ["Orange"],
     "screens": [
       {
         "id": "place-three-sign",
         "label": null,
         "type": "pa_ess",
         "zone": "e",
-        "routes": [{ "id": "place-three-route", "direction_id": 0 }],
+        "routes": [{ "id": "Orange", "direction_id": 0 }],
         "station_code": "place-three-station-code"
       }
     ]

--- a/test/screenplay/suppressed_predictions_test.exs
+++ b/test/screenplay/suppressed_predictions_test.exs
@@ -1,5 +1,8 @@
 defmodule Screenplay.SuppressedPredictionsTest do
+  use ExUnit.Case
+
   alias Screenplay.PlaceCacheHelpers
+  alias Screenplay.PredictionSuppression
   alias Screenplay.SuppressedPredictions
   use ScreenplayWeb.DataCase
 
@@ -12,7 +15,7 @@ defmodule Screenplay.SuppressedPredictionsTest do
 
   describe "suppressed_predictions" do
     setup do
-      PlaceCacheHelpers.seed_place_cache()
+      PlaceCacheHelpers.seed_place_cache("places_and_screens_for_prediction_tests.json")
       :ok
     end
 
@@ -79,6 +82,145 @@ defmodule Screenplay.SuppressedPredictionsTest do
       assert(4 == length(SuppressedPredictions.get_all_suppressed_predictions()))
       assert({3, nil} = SuppressedPredictions.clear_suppressed_predictions_for_end_of_day())
       assert(1 == length(SuppressedPredictions.get_all_suppressed_predictions()))
+    end
+
+    test "get_all_suppressed_predictions_for_data/0" do
+      insert(:suppressed_predictions, %{
+        location_id: "jfk_umass_ashmont_platform",
+        route_id: "Red",
+        direction_id: 1,
+        clear_at_end_of_day: true,
+        inserted_at: ~U[2024-05-01T01:00:00Z],
+        updated_at: ~U[2024-05-01T01:00:00Z]
+      })
+
+      insert(:suppressed_predictions, %{
+        location_id: "jfk_umass_braintree_platform",
+        route_id: "Red",
+        direction_id: 0,
+        clear_at_end_of_day: true,
+        inserted_at: ~U[2024-05-01T01:00:00Z],
+        updated_at: ~U[2024-05-01T01:00:00Z]
+      })
+
+      insert(:suppressed_predictions, %{
+        location_id: "place-two",
+        route_id: "Blue",
+        direction_id: 0,
+        clear_at_end_of_day: true,
+        inserted_at: ~U[2024-05-01T01:00:00Z],
+        updated_at: ~U[2024-05-01T01:00:00Z]
+      })
+
+      insert(:suppressed_predictions, %{
+        location_id: "place-four",
+        route_id: "Green",
+        direction_id: 0,
+        clear_at_end_of_day: false,
+        inserted_at: ~U[2024-05-01T01:00:00Z],
+        updated_at: ~U[2024-05-01T01:00:00Z]
+      })
+
+      insert(:suppressed_predictions, %{
+        location_id: "place-six",
+        route_id: "Silver",
+        direction_id: 0,
+        clear_at_end_of_day: true,
+        inserted_at: ~U[2024-05-01T01:00:00Z],
+        updated_at: ~U[2024-05-01T01:00:00Z]
+      })
+
+      PredictionSuppression.init([])
+
+      new_line_stops =
+        [
+          %{line: "Silver", type: :start, stop_id: "place-six", direction_id: 0},
+          %{line: "Silver", type: :start, stop_id: "place-six", direction_id: 1},
+          %{line: "Red", type: :mid, stop_id: "place-jfk", direction_id: 0},
+          %{line: "Red", type: :mid, stop_id: "place-jfk", direction_id: 1},
+          %{line: "Blue", type: :mid, stop_id: "place-two", direction_id: 0},
+          %{line: "Orange", type: :end, stop_id: "place-three", direction_id: 0},
+          %{line: "Orange", type: :end, stop_id: "place-three", direction_id: 1},
+          %{line: "Green", type: :start, stop_id: "place-four", direction_id: 0},
+          %{line: "Green", type: :start, stop_id: "place-four", direction_id: 1},
+          %{line: "Silver", type: :start, stop_id: "place-five", direction_id: 0},
+          %{line: "Silver", type: :start, stop_id: "place-five", direction_id: 1}
+        ]
+
+      :ets.insert(:line_stops, {:value, new_line_stops})
+
+      assert [
+               %{
+                 direction_id: 0,
+                 route_id: "741",
+                 stop_id: "place-six",
+                 suppression_type: :terminal
+               },
+               %{
+                 direction_id: 0,
+                 route_id: "742",
+                 stop_id: "place-six",
+                 suppression_type: :terminal
+               },
+               %{
+                 direction_id: 0,
+                 route_id: "743",
+                 stop_id: "place-six",
+                 suppression_type: :terminal
+               },
+               %{
+                 direction_id: 1,
+                 route_id: "741",
+                 stop_id: "place-six",
+                 suppression_type: :none
+               },
+               %{
+                 direction_id: 1,
+                 route_id: "742",
+                 stop_id: "place-six",
+                 suppression_type: :none
+               },
+               %{
+                 direction_id: 1,
+                 route_id: "743",
+                 stop_id: "place-six",
+                 suppression_type: :none
+               },
+               %{
+                 stop_id: "place-two",
+                 route_id: "Blue",
+                 direction_id: 0,
+                 suppression_type: :stop
+               },
+               %{
+                 direction_id: 0,
+                 route_id: "Green-B",
+                 stop_id: "place-four",
+                 suppression_type: :terminal
+               },
+               %{
+                 stop_id: "place-four",
+                 route_id: "Green-C",
+                 direction_id: 0,
+                 suppression_type: :terminal
+               },
+               %{
+                 stop_id: "place-four",
+                 route_id: "Green-B",
+                 direction_id: 1,
+                 suppression_type: :none
+               },
+               %{
+                 stop_id: "place-four",
+                 route_id: "Green-C",
+                 direction_id: 1,
+                 suppression_type: :none
+               },
+               %{stop_id: "70085", route_id: "Red", direction_id: 0, suppression_type: :none},
+               %{stop_id: "70086", route_id: "Red", direction_id: 1, suppression_type: :stop},
+               %{stop_id: "70095", route_id: "Red", direction_id: 0, suppression_type: :stop},
+               %{stop_id: "70096", route_id: "Red", direction_id: 1, suppression_type: :none}
+             ] == SuppressedPredictions.get_all_suppressed_predictions_for_data()
     end
   end
 end

--- a/test/screenplay_web/controllers/suppressed_predictions_api_controller_test.exs
+++ b/test/screenplay_web/controllers/suppressed_predictions_api_controller_test.exs
@@ -60,7 +60,7 @@ defmodule ScreenplayWeb.SuppressedPredictionsApiControllerTest do
     }
 
     @tag :authenticated
-    test "returns error when user is not a suppression admin admin", %{conn: conn} do
+    test "returns error when user is not a suppression admin", %{conn: conn} do
       conn = post(conn, "/api/suppressed-predictions", @valid_params)
       assert response(conn, 401)
     end

--- a/test/support/place_cache_helpers.ex
+++ b/test/support/place_cache_helpers.ex
@@ -7,9 +7,9 @@ defmodule Screenplay.PlaceCacheHelpers do
   alias Screenplay.Places.{Cache, Place}
   alias Screenplay.Places.Place.PaEssScreen
 
-  def seed_place_cache do
+  def seed_place_cache(file_to_seed \\ "places_and_screens_for_routes_to_signs.json") do
     fixture_path =
-      Path.join(~w[#{File.cwd!()} test fixtures places_and_screens_for_routes_to_signs.json])
+      Path.join(~w[#{File.cwd!()} test fixtures #{file_to_seed}])
 
     contents =
       fixture_path


### PR DESCRIPTION
**Asana task**: [Prediction Suppression: Transit Data API](https://app.asana.com/0/1185117109217413/1209646154006769/f)

- /api/suppressed_predictions/all will now return a list of suppressed predictions for transit data use
- Takes our current suppressed_predictions data and transforms them within the endpoint to get the correct format
- Added a few new test signs for verifying Green and Silver line logic

- [ ] For features with a design/UX component, deployed branch to dev-green and let product know it's ready for review.
