### PR TITLE
implement prediction suppression page

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -200,6 +200,12 @@ footer {
 .bg-mbta-bus {
   background-color: $mbta-bus !important;
 }
+.bg-dark {
+  background-color: $dark-bg !important;
+}
 .text-invert {
   color: $text-invert !important;
+}
+.text-secondary {
+  color: $text-secondary !important;
 }

--- a/assets/css/prediction-suppression.module.scss
+++ b/assets/css/prediction-suppression.module.scss
@@ -1,0 +1,35 @@
+@import "./variables.scss";
+
+.tableRow {
+  tbody > & {
+    border-bottom: 1px solid #6c757d;
+    border-top: 1px solid #6c757d;
+    &:nth-child(odd) {
+      background-color: $bg-elevation-3;
+    }
+    &:nth-child(even) {
+      background-color: #171f26;
+    }
+  }
+}
+
+.suppressionLabel {
+  cursor: pointer;
+  border-radius: var(--bs-border-radius);
+  padding: 0.375rem 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  color: $text-link-primary;
+  &:has(:checked) {
+    color: $text-invert;
+    background-color: $button-primary;
+  }
+  &:has(:focus-visible) {
+    box-shadow: 0 0 0 0.25rem rgba(86, 100, 111, 0.5);
+  }
+}
+
+.suppressionCheckbox {
+  width: 0;
+  opacity: 0;
+}

--- a/assets/js/components/App.tsx
+++ b/assets/js/components/App.tsx
@@ -22,6 +22,9 @@ const SelectScreenTypeComponent = React.lazy(
 const PaMessagesPage = React.lazy(() => import("Components/PaMessagesPage"));
 const NewPaMessage = React.lazy(() => import("Components/NewPaMessage"));
 const EditPaMessage = React.lazy(() => import("Components/EditPaMessage"));
+const PredictionSuppressionPage = React.lazy(
+  () => import("Components/PredictionSuppressionPage"),
+);
 
 class AppRoutes extends React.Component {
   render() {
@@ -51,6 +54,10 @@ class AppRoutes extends React.Component {
             <Route path="pa-messages" element={<PaMessagesPage />} />
             <Route path="pa-messages/new" element={<NewPaMessage />} />
             <Route path="pa-messages/:id/edit" element={<EditPaMessage />} />
+            <Route
+              path="prediction-suppression"
+              element={<PredictionSuppressionPage />}
+            />
           </Route>
         </Routes>
       </React.Suspense>

--- a/assets/js/components/Dashboard/PredictionSuppressionPage.tsx
+++ b/assets/js/components/Dashboard/PredictionSuppressionPage.tsx
@@ -1,0 +1,238 @@
+import { useScreenplayContext } from "Hooks/useScreenplayContext";
+import { RadioList } from "Components/RadioList";
+import React, { useState } from "react";
+import fp from "lodash/fp";
+import * as styles from "Styles/prediction-suppression.module.scss";
+import { Dot, XCircleFill } from "react-bootstrap-icons";
+import { Form } from "react-bootstrap";
+import { sortByStationOrder } from "../../util";
+import { Place } from "Models/place";
+
+const lookupKey = (placeId: string, directionId: number) =>
+  `${placeId}:${directionId}`;
+
+const directionNames = (line: string) => {
+  switch (line.split("-")[0]) {
+    case "Green":
+    case "Blue":
+      return ["Westbound", "Eastbound"];
+    case "Silver":
+      return ["Eastbound", "To South Station/Downtown"];
+    default:
+      return ["Southbound", "Northbound"];
+  }
+};
+
+const PredictionSuppressionPage = () => {
+  const [line, setLine] = useState<string>("Green");
+  const { places, lineStops } = useScreenplayContext();
+  const filteredPlaces = sortByStationOrder(
+    fp.filter(({ routes, screens }) => {
+      switch (line) {
+        case "Green":
+          return fp.any(fp.startsWith("Green"), routes);
+        case "Silver":
+          return (
+            fp.includes(line, routes) &&
+            fp.any(
+              (screen) =>
+                screen.type === "pa_ess" &&
+                fp.any(
+                  ({ id }) => fp.includes(id, ["741", "742", "743", "746"]),
+                  screen.routes,
+                ),
+              screens,
+            )
+          );
+        default:
+          return fp.includes(line, routes);
+      }
+    }, places),
+    line,
+  );
+  const lineStopLookup = fp.flow([
+    fp.filter({ line: line.split("-")[0] }),
+    fp.map(({ stop_id, direction_id, type }) => [
+      lookupKey(stop_id, direction_id),
+      type,
+    ]),
+    fp.fromPairs,
+  ])(lineStops);
+
+  const noPredictions = (place: Place) => {
+    const serviceType = lineStopLookup[lookupKey(place.id, 0)];
+    return (
+      line.startsWith("Green") && fp.includes(serviceType, ["start", "end"])
+    );
+  };
+
+  const renderInput = (place: Place, directionId: number) => {
+    const serviceType = lineStopLookup[lookupKey(place.id, directionId)];
+    const suppressed = false;
+    const expire = false;
+    if (serviceType === "start" || serviceType === "mid") {
+      const predictionsText =
+        serviceType == "start" ? "terminal predictions" : "predictions";
+      return (
+        <>
+          <label className={styles.suppressionLabel}>
+            <input
+              type="checkbox"
+              checked={suppressed}
+              onChange={() => {}}
+              className={styles.suppressionCheckbox}
+            />
+            {suppressed && <XCircleFill className="me-2" />}
+            {fp.capitalize(
+              suppressed
+                ? `${predictionsText} suppressed`
+                : `suppress ${predictionsText}`,
+            )}
+          </label>
+          {suppressed && (
+            <Form.Check
+              className="mt-2 mb-0"
+              label="Clear at end of service day"
+              checked={expire}
+            />
+          )}
+        </>
+      );
+    }
+  };
+
+  const renderCell = (place: Place, directionId: number) => {
+    if (place.id == "place-jfk") {
+      return (
+        <>
+          <div>Ashmont platform</div>
+          {renderInput(place, directionId)}
+          <div>Braintree platform</div>
+          {renderInput(place, directionId)}
+        </>
+      );
+    }
+    return renderInput(place, directionId);
+  };
+
+  return (
+    <div className="ms-5 mt-4">
+      <h1 className="mb-5">Suppress Predictions</h1>
+      <div className="d-flex gap-5">
+        <div style={{ flex: "0 0 200px" }}>
+          <div className="mb-2">Filter by service line</div>
+          <RadioList
+            value={line}
+            onChange={setLine}
+            items={[
+              {
+                value: "Green",
+                checkedClass: "bg-mbta-green",
+                content: "Green Line",
+              },
+              {
+                value: "Green-B",
+                checkedClass: "bg-mbta-green",
+                content: (
+                  <>
+                    <Dot /> B Branch
+                  </>
+                ),
+              },
+              {
+                value: "Green-C",
+                checkedClass: "bg-mbta-green",
+                content: (
+                  <>
+                    <Dot /> C Branch
+                  </>
+                ),
+              },
+              {
+                value: "Green-D",
+                checkedClass: "bg-mbta-green",
+                content: (
+                  <>
+                    <Dot /> D Branch
+                  </>
+                ),
+              },
+              {
+                value: "Green-E",
+                checkedClass: "bg-mbta-green",
+                content: (
+                  <>
+                    <Dot /> E Branch
+                  </>
+                ),
+              },
+              {
+                value: "Red",
+                checkedClass: "bg-mbta-red",
+                content: "Red Line",
+              },
+              {
+                value: "Blue",
+                checkedClass: "bg-mbta-blue",
+                content: "Blue Line",
+              },
+              {
+                value: "Orange",
+                checkedClass: "bg-mbta-orange",
+                content: "Orange Line",
+              },
+              {
+                value: "Silver",
+                checkedClass: "bg-mbta-silver",
+                content: "Silver Line",
+              },
+            ]}
+          />
+        </div>
+        <table style={{ flex: "1" }}>
+          <colgroup>
+            <col style={{ width: 250 }} />
+            <col style={{ width: 300 }} />
+            <col style={{ width: 300 }} />
+          </colgroup>
+          <thead className="sticky-top bg-dark">
+            <tr>
+              <th className="px-3 pb-3 fs-3">{line} Line</th>
+              {directionNames(line).map((name) => (
+                <th
+                  key={name}
+                  className="px-3 pb-3 align-bottom text-secondary"
+                >
+                  {name}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {filteredPlaces.map((place) => (
+              <tr key={place.id} className={styles.tableRow}>
+                <td className="p-3">{place.name}</td>
+                {noPredictions(place) ? (
+                  <td colSpan={2} className="p-3">
+                    <em className="text-secondary">
+                      Predictions aren&apos;t generated for this location
+                    </em>
+                  </td>
+                ) : (
+                  [0, 1].map((directionId) => (
+                    <td key={directionId} className="p-3">
+                      {renderCell(place, directionId)}
+                    </td>
+                  ))
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div></div>
+      </div>
+    </div>
+  );
+};
+
+export default PredictionSuppressionPage;

--- a/assets/js/components/Dashboard/Sidebar.tsx
+++ b/assets/js/components/Dashboard/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   LightningFill,
   Signpost,
   SignpostFill,
+  ArrowDownShort,
   Icon,
 } from "react-bootstrap-icons";
 import TLogo from "../../../static/images/t-logo.svg";
@@ -84,6 +85,15 @@ const Sidebar = () => {
       >
         Posted Alerts
       </SidebarLink>
+      {document.querySelector("meta[name=show-prediction-suppression]") && (
+        <SidebarLink
+          to="/prediction-suppression"
+          icon={ArrowDownShort}
+          activeIcon={ArrowDownShort}
+        >
+          Suppress Predictions
+        </SidebarLink>
+      )}
       <SidebarLink to="/pa-messages" icon={VolumeUp} activeIcon={VolumeUpFill}>
         PA/ESS
       </SidebarLink>

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -52,7 +52,8 @@ config :screenplay,
   fullstory_org_id: System.get_env("FULLSTORY_ORG_ID"),
   api_key: System.fetch_env!("SCREENPLAY_API_KEY"),
   watts_url: System.get_env("WATTS_URL"),
-  watts_api_key: System.get_env("WATTS_API_KEY")
+  watts_api_key: System.get_env("WATTS_API_KEY"),
+  show_prediction_suppression: System.get_env("SHOW_PREDICTION_SUPPRESSION")
 
 if sentry_dsn not in [nil, ""] do
   config :sentry,

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -63,6 +63,7 @@ defmodule ScreenplayWeb.Router do
     get("/", DashboardController, :root_redirect)
     get("/dashboard", DashboardController, :index)
     get("/alerts/*id", AlertsController, :index)
+    get("/prediction-suppression", DashboardController, :index)
   end
 
   scope "/api", ScreenplayWeb do

--- a/lib/screenplay_web/templates/layout/app.html.heex
+++ b/lib/screenplay_web/templates/layout/app.html.heex
@@ -32,6 +32,9 @@
     <%= if @fullstory_org_id do %>
         <meta name="fullstory-org-id" content={@fullstory_org_id}>
     <% end %>
+    <%= if Application.get_env(:screenplay, :show_prediction_suppression) do %>
+        <meta name="show-prediction-suppression" content={true}>
+    <% end %>
     <%= csrf_meta_tag() %>
     <title>Screenplay</title>
     <link rel="icon" href={Routes.static_path(@conn, "/favicon.ico")} sizes="32x32">


### PR DESCRIPTION
**Asana task**: [Prediction suppression: Build basic UI](https://app.asana.com/0/1185117109217413/1209637020443925/f)

This partially implements the prediction suppression page. Includes the station list with filtering, UI elements in the right place, and much of the styling. State and interactions are NOT wired up yet.

The sidebar link is hidden by default, and can be enabled in development by setting the `SHOW_PREDICTION_SUPPRESSION` environment variable.