### PR TITLE
add prediction suppression test

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -30,6 +30,7 @@ config :screenplay,
   config_fetcher: Screenplay.Places.S3Fetch,
   screens_config_fetcher: Screenplay.ScreensConfig.Fetch.S3,
   pending_screens_config_fetcher: Screenplay.PendingScreensConfig.Fetch.S3,
+  http_client: HTTPoison,
   config_s3_bucket: "mbta-ctd-config",
   record_sentry: false,
   start_cache_processes: config_env() != :test

--- a/config/test.exs
+++ b/config/test.exs
@@ -23,7 +23,8 @@ config :screenplay,
   local_signs_json_path: {:test, "signs.json"},
   stops_mod: Screenplay.Stops.Mock,
   routes_mod: Screenplay.Routes.Mock,
-  facilities_mod: Screenplay.Facilities.Mock
+  facilities_mod: Screenplay.Facilities.Mock,
+  http_client: HTTPoison.Mock
 
 config :ueberauth, Ueberauth,
   providers: [

--- a/lib/screenplay/alerts/screens_by_alert.ex
+++ b/lib/screenplay/alerts/screens_by_alert.ex
@@ -7,8 +7,10 @@ defmodule Screenplay.Alerts.ScreensByAlert do
   def get_screens_by_alert(alert_ids) do
     url = build_url(alert_ids)
 
+    http_client = Application.get_env(:screenplay, :http_client)
+
     with {:http_request, {:ok, response}} <-
-           {:http_request, HTTPoison.get(url)},
+           {:http_request, http_client.get(url)},
          {:response_success, %{status_code: 200, body: body}} <-
            {:response_success, response},
          {:parse, {:ok, parsed}} <- {:parse, Jason.decode(body)} do

--- a/lib/screenplay/github_api/client.ex
+++ b/lib/screenplay/github_api/client.ex
@@ -17,7 +17,9 @@ defmodule Screenplay.GithubApi.Client do
   def get_file_contents_from_repo(name, file_path) do
     url = "https://api.github.com/repos/mbta/#{name}/contents/#{file_path}"
 
-    case HTTPoison.get(url) do
+    http_client = Application.get_env(:screenplay, :http_client)
+
+    case http_client.get(url) do
       {:ok, %{status_code: 200, body: body}} ->
         %{"content" => response_json} = Jason.decode!(body)
 

--- a/lib/screenplay/jobs/reminders.ex
+++ b/lib/screenplay/jobs/reminders.ex
@@ -59,7 +59,9 @@ defmodule Screenplay.Jobs.Reminders do
   defp send_slack_message(message, url) do
     {:ok, json} = Jason.encode(message)
 
-    case HTTPoison.post(url, json) do
+    http_client = Application.get_env(:screenplay, :http_client)
+
+    case http_client.post(url, json) do
       {:ok, response} ->
         Logger.debug(fn ->
           "HTTP RESP:\n#{inspect(response)}"

--- a/lib/screenplay/v3_api.ex
+++ b/lib/screenplay/v3_api.ex
@@ -19,9 +19,11 @@ defmodule Screenplay.V3Api do
 
     url = build_url(route, params)
 
+    http_client = Application.get_env(:screenplay, :http_client)
+
     with {:http_request, {:ok, response}} <-
            {:http_request,
-            HTTPoison.get(
+            http_client.get(
               url,
               headers,
               Keyword.merge(@default_opts, opts)

--- a/lib/screenplay/watts/client.ex
+++ b/lib/screenplay/watts/client.ex
@@ -22,7 +22,9 @@ defmodule Screenplay.Watts.Client do
     watts_api_key = Application.fetch_env!(:screenplay, :watts_api_key)
     request_data = Jason.encode!(%{text: "<speak>#{text}</speak>", voice_id: "Matthew"})
 
-    case HTTPoison.post(
+    http_client = Application.get_env(:screenplay, :http_client)
+
+    case http_client.post(
            "#{watts_url}/tts",
            request_data,
            [

--- a/test/screenplay/prediction_suppression_test.exs
+++ b/test/screenplay/prediction_suppression_test.exs
@@ -1,0 +1,121 @@
+defmodule Screenplay.PredictionSuppressionTest do
+  use ExUnit.Case
+
+  import Mox
+
+  @api_response %{
+    data: [
+      %{
+        "attributes" => %{"canonical" => true, "typicality" => 1},
+        "id" => "Blue-6-0",
+        "relationships" => %{
+          "representative_trip" => %{"data" => %{"id" => "canonical-Blue-C1-0", "type" => "trip"}},
+          "route" => %{"data" => %{"id" => "Blue", "type" => "route"}}
+        },
+        "type" => "route_pattern"
+      },
+      %{
+        "attributes" => %{"canonical" => false, "typicality" => 1},
+        "id" => "746-_-0",
+        "relationships" => %{
+          "representative_trip" => %{"data" => %{"id" => "66858485", "type" => "trip"}},
+          "route" => %{"data" => %{"id" => "746", "type" => "route"}}
+        },
+        "type" => "route_pattern"
+      }
+    ],
+    included: [
+      %{
+        "attributes" => %{"direction_id" => 0},
+        "id" => "canonical-Blue-C1-0",
+        "relationships" => %{
+          "route" => %{"data" => %{"id" => "Blue", "type" => "route"}},
+          "stops" => %{
+            "data" => [
+              %{"id" => "70059", "type" => "stop"},
+              %{"id" => "70057", "type" => "stop"},
+              %{"id" => "70055", "type" => "stop"}
+            ]
+          }
+        },
+        "type" => "trip"
+      },
+      %{
+        "id" => "70059",
+        "relationships" => %{
+          "parent_station" => %{"data" => %{"id" => "place-wondl", "type" => "stop"}}
+        },
+        "type" => "stop"
+      },
+      %{
+        "id" => "70057",
+        "relationships" => %{
+          "parent_station" => %{"data" => %{"id" => "place-rbmnl", "type" => "stop"}}
+        },
+        "type" => "stop"
+      },
+      %{
+        "id" => "70055",
+        "relationships" => %{
+          "parent_station" => %{"data" => %{"id" => "place-bmmnl", "type" => "stop"}}
+        },
+        "type" => "stop"
+      },
+      %{
+        "attributes" => %{"direction_id" => 0},
+        "id" => "66858485",
+        "relationships" => %{
+          "route" => %{"data" => %{"id" => "746", "type" => "route"}},
+          "stops" => %{
+            "data" => [
+              %{"id" => "74611", "type" => "stop"},
+              %{"id" => "74612", "type" => "stop"},
+              %{"id" => "74613", "type" => "stop"}
+            ]
+          }
+        },
+        "type" => "trip"
+      },
+      %{
+        "id" => "74611",
+        "relationships" => %{
+          "parent_station" => %{"data" => %{"id" => "place-sstat", "type" => "stop"}}
+        },
+        "type" => "stop"
+      },
+      %{
+        "id" => "74612",
+        "relationships" => %{
+          "parent_station" => %{"data" => %{"id" => "place-crtst", "type" => "stop"}}
+        },
+        "type" => "stop"
+      },
+      %{
+        "id" => "74613",
+        "relationships" => %{
+          "parent_station" => %{"data" => %{"id" => "place-wtcst", "type" => "stop"}}
+        },
+        "type" => "stop"
+      }
+    ]
+  }
+
+  test "update" do
+    expect(HTTPoison.Mock, :get, fn _, _, _ ->
+      {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(@api_response)}}
+    end)
+
+    Screenplay.PredictionSuppression.init([])
+    Screenplay.PredictionSuppression.handle_info(:update, %{})
+
+    assert Screenplay.PredictionSuppression.line_stops() ==
+             [
+               %{line: "Blue", type: :start, direction_id: 0, stop_id: "place-wondl"},
+               %{line: "Blue", type: :mid, direction_id: 0, stop_id: "place-rbmnl"},
+               %{line: "Blue", type: :end, direction_id: 0, stop_id: "place-bmmnl"},
+               %{line: "Silver", type: :start, direction_id: 0, stop_id: "place-sstat"},
+               %{line: "Silver", type: :mid, direction_id: 0, stop_id: "place-crtst"},
+               %{line: "Silver", type: :end, direction_id: 0, stop_id: "place-wtcst"}
+             ]
+  end
+end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -2,3 +2,4 @@ Mox.defmock(Screenplay.RoutePatterns.Mock, for: Screenplay.RoutePatterns.Behavio
 Mox.defmock(Screenplay.Stops.Mock, for: Screenplay.Stops.Stop)
 Mox.defmock(Screenplay.Routes.Mock, for: Screenplay.Routes.Route)
 Mox.defmock(Screenplay.Facilities.Mock, for: Screenplay.Facilities.Facility)
+Mox.defmock(HTTPoison.Mock, for: HTTPoison.Base)


### PR DESCRIPTION
This sets up some infrastructure for mocking HTTP calls, and then adds a test for the new prediction suppression code.