### PR TITLE
Added Oban Cron for clearing suppressed predictions

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -66,9 +66,11 @@ if config_env() != :test do
       plugins: [
         {Oban.Plugins.Cron,
          crontab: [
-           {"0 7 * * *", Screenplay.Jobs.TakeoverToolTestingJob},
-           {"* * * * *", Screenplay.Jobs.Reminders}
-         ]},
+           {"0 2 * * *", Screenplay.Jobs.TakeoverToolTestingJob},
+           {"* * * * *", Screenplay.Jobs.Reminders},
+           {"0 3 * * * ", Screenplay.Jobs.ClearSuppressedPredictions}
+         ],
+         timezone: "America/New_York"},
         Oban.Plugins.Pruner,
         Oban.Plugins.Lifeline,
         Oban.Plugins.Reindexer

--- a/lib/screenplay/jobs/clear_suppressed_predictions.ex
+++ b/lib/screenplay/jobs/clear_suppressed_predictions.ex
@@ -1,0 +1,15 @@
+defmodule Screenplay.Jobs.ClearSuppressedPredictions do
+  @moduledoc """
+  Runs at the end of every service day to remove suppressed predictions that have been flagged to clear
+  """
+  alias Screenplay.SuppressedPredictions
+  use Oban.Worker, unique: true
+
+  require Logger
+
+  @impl Oban.Worker
+  def perform(_) do
+    SuppressedPredictions.clear_suppressed_predictions_for_end_of_day()
+    :ok
+  end
+end

--- a/lib/screenplay/suppressed_predictions.ex
+++ b/lib/screenplay/suppressed_predictions.ex
@@ -2,7 +2,6 @@ defmodule Screenplay.SuppressedPredictions do
   @moduledoc """
   Module for functions dealing with `SuppressedPredictions` and the `suppressed_predictions` database 
   """
-
   alias Screenplay.Repo
   alias Screenplay.SuppressedPredictions.SuppressedPrediction
 
@@ -70,5 +69,16 @@ defmodule Screenplay.SuppressedPredictions do
           {:ok, SuppressedPrediction.t()} | {:error, Ecto.Changeset.t()}
   def delete_suppressed_prediction(suppressed_prediction) do
     Repo.delete(suppressed_prediction)
+  end
+
+  @doc """
+  Clears all suppressed predicitons with the "clear_at_end_of_day" flag set to true
+  """
+  @spec clear_suppressed_predictions_for_end_of_day() :: {non_neg_integer(), nil}
+  def clear_suppressed_predictions_for_end_of_day do
+    import Ecto.Query, only: [from: 2]
+
+    from(sp in SuppressedPrediction, where: sp.clear_at_end_of_day == true)
+    |> Repo.delete_all()
   end
 end

--- a/test/screenplay/suppressed_predictions_test.exs
+++ b/test/screenplay/suppressed_predictions_test.exs
@@ -38,5 +38,47 @@ defmodule Screenplay.SuppressedPredictionsTest do
       assert {:error, :not_found} ==
                SuppressedPredictions.get_suppressed_prediction("place_typo", "place-one-route", 1)
     end
+
+    test "clear_suppressed_predictions_for_end_of_day/0" do
+      insert(:suppressed_predictions, %{
+        location_id: "place-one",
+        route_id: "place-one-route",
+        direction_id: 1,
+        clear_at_end_of_day: true,
+        inserted_at: ~U[2024-05-01T01:00:00Z],
+        updated_at: ~U[2024-05-01T01:00:00Z]
+      })
+
+      insert(:suppressed_predictions, %{
+        location_id: "place-two",
+        route_id: "place-two-route",
+        direction_id: 0,
+        clear_at_end_of_day: true,
+        inserted_at: ~U[2024-05-01T01:00:00Z],
+        updated_at: ~U[2024-05-01T01:00:00Z]
+      })
+
+      insert(:suppressed_predictions, %{
+        location_id: "place-four",
+        route_id: "Green",
+        direction_id: 0,
+        clear_at_end_of_day: false,
+        inserted_at: ~U[2024-05-01T01:00:00Z],
+        updated_at: ~U[2024-05-01T01:00:00Z]
+      })
+
+      insert(:suppressed_predictions, %{
+        location_id: "place-six",
+        route_id: "Silver",
+        direction_id: 0,
+        clear_at_end_of_day: true,
+        inserted_at: ~U[2024-05-01T01:00:00Z],
+        updated_at: ~U[2024-05-01T01:00:00Z]
+      })
+
+      assert(4 == length(SuppressedPredictions.get_all_suppressed_predictions()))
+      assert({3, nil} = SuppressedPredictions.clear_suppressed_predictions_for_end_of_day())
+      assert(1 == length(SuppressedPredictions.get_all_suppressed_predictions()))
+    end
   end
 end


### PR DESCRIPTION
**Asana task**: [Prediction suppression: Expire at end of service day](https://app.asana.com/0/1185117109217413/1209637020443934/f)

- Oban Cron Job running at 3am everyday to clear suppressed predictions that have the "clear_at_end_of_day" flag
- Added test to handle new clearing functionality

- [ ] For features with a design/UX component, deployed branch to dev-green and let product know it's ready for review.
