### PR TITLE
Update actions/setup-node from v2 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
 
       # NPM Build + Test
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
           cache: "npm"


### PR DESCRIPTION
Our CI was failing on `setup-node` due to failed cache, seems like we needed to update the version in order to fix it
