### PR TITLE
wire up prediction suppression UI

### DIFF
--- a/assets/js/components/Dashboard/PaMessagesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessagesPage.tsx
@@ -81,15 +81,12 @@ const PaMessagesPage: ComponentType = () => {
   const showMoreActions = stateFilter == "current";
 
   useEffect(() => {
-    setParams(() => {
-      const newParams = new URLSearchParams();
-      if (stateFilter) newParams.set("state", stateFilter);
-      for (const serviceType of serviceTypes) {
-        newParams.append("serviceTypes[]", serviceType);
-      }
-
-      return newParams;
-    });
+    const newParams = new URLSearchParams();
+    if (stateFilter) newParams.set("state", stateFilter);
+    for (const serviceType of serviceTypes) {
+      newParams.append("serviceTypes[]", serviceType);
+    }
+    setParams(newParams, { replace: true });
   }, [setParams, stateFilter, serviceTypes]);
 
   const { data, isLoading } = usePaMessages({

--- a/assets/js/components/Dashboard/PredictionSuppressionPage.tsx
+++ b/assets/js/components/Dashboard/PredictionSuppressionPage.tsx
@@ -43,7 +43,7 @@ const PredictionSuppressionPage = () => {
   useEffect(() => {
     const newParams = new URLSearchParams();
     newParams.set("line", line);
-    setParams(newParams);
+    setParams(newParams, { replace: true });
   }, [setParams, line]);
 
   const filteredPlaces = sortByStationOrder(

--- a/assets/js/models/suppressed_prediction.ts
+++ b/assets/js/models/suppressed_prediction.ts
@@ -1,0 +1,6 @@
+export interface SuppressedPrediction {
+  location_id: string;
+  route_id: string;
+  direction_id: number;
+  clear_at_end_of_day: boolean;
+}

--- a/assets/js/utils/api.ts
+++ b/assets/js/utils/api.ts
@@ -1,3 +1,4 @@
+import fp from "lodash/fp";
 import { Alert } from "../models/alert";
 import { Place } from "../models/place";
 import { ScreenConfiguration } from "../models/screen_configuration";
@@ -5,6 +6,7 @@ import { ScreensByAlert } from "../models/screensByAlert";
 import { PlaceIdsAndNewScreens } from "../components/Dashboard/PermanentConfiguration/Workflows/GlEink/ConfigureScreensPage";
 import getCsrfToken from "../csrf";
 import { NewPaMessageBody, UpdatePaMessageBody } from "Models/pa_message";
+import { SuppressedPrediction } from "Models/suppressed_prediction";
 
 export const fetchPlaces = async (): Promise<Place[]> => {
   const response = await fetch("/api/dashboard");
@@ -174,6 +176,50 @@ export const updateExistingPaMessage = async (
     status: response.status,
     body: await response.json(),
   };
+};
+
+const fetchOk = async (
+  url: string,
+  options: Omit<RequestInit, "body"> & { body: any },
+) => {
+  const res = await fetch(
+    url,
+    fp.merge(options, {
+      body: JSON.stringify(options.body),
+      credentials: "include" as RequestCredentials,
+      headers: {
+        "content-type": "application/json",
+        "x-csrf-token": getCsrfToken(),
+      },
+    }),
+  );
+  if (!res.ok) {
+    throw res;
+  }
+  return res.json();
+};
+
+export const getSuppressedPredictions = async () => {
+  const res = await fetch("/api/suppressed-predictions");
+  if (!res.ok) {
+    throw res;
+  }
+  return res.json();
+};
+
+export const createSuppressedPrediction = (data: SuppressedPrediction) => {
+  return fetchOk("/api/suppressed-predictions", { body: data, method: "POST" });
+};
+
+export const deleteSuppressedPrediction = (data: SuppressedPrediction) => {
+  return fetchOk("/api/suppressed-predictions", {
+    body: data,
+    method: "DELETE",
+  });
+};
+
+export const updateSuppressedPrediction = (data: SuppressedPrediction) => {
+  return fetchOk("/api/suppressed-predictions", { body: data, method: "PUT" });
 };
 
 const getPostBodyAndHeaders = (

--- a/assets/tests/setup.ts
+++ b/assets/tests/setup.ts
@@ -29,10 +29,9 @@ let originalFetch: any;
 
 beforeEach(() => {
   originalFetch = global.fetch;
-  global.fetch = jest
-    .fn()
-    .mockReturnValueOnce(
-      Promise.resolve({
+  global.fetch = jest.fn(async (url) => {
+    if (url === "/api/alerts") {
+      return Promise.resolve({
         status: 200,
         json: () =>
           Promise.resolve({
@@ -40,16 +39,17 @@ beforeEach(() => {
             alerts,
             screens_by_alert: alertsOnScreens,
           }),
-      }),
-    )
-    .mockReturnValueOnce(
-      Promise.resolve({
-        json: () => Promise.resolve(places),
-      }),
-    )
-    .mockReturnValueOnce(
-      Promise.resolve({ json: () => Promise.resolve({ data: [] }) }),
-    );
+      });
+    } else if (url === "/api/dashboard") {
+      return Promise.resolve({ json: () => Promise.resolve(places) });
+    } else if (url === "/api/line_stops") {
+      return Promise.resolve({ json: () => Promise.resolve({ data: [] }) });
+    } else if (url === "/api/suppressed-predictions") {
+      return Promise.resolve({ json: () => Promise.resolve([]) });
+    } else {
+      throw "Missing mock";
+    }
+  }) as jest.Mock;
 });
 
 afterEach(() => {

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -93,7 +93,14 @@ config :ueberauth, Ueberauth,
   providers: [
     keycloak:
       {Screenplay.Ueberauth.Strategy.Fake,
-       [roles: ["screenplay-emergency-admin", "screens-admin", "pa-message-admin"]]}
+       [
+         roles: [
+           "screenplay-emergency-admin",
+           "screens-admin",
+           "pa-message-admin",
+           "suppression-admin"
+         ]
+       ]}
   ]
 
 config :ueberauth_oidcc,


### PR DESCRIPTION
**Asana task**: [Prediction suppression: Wire up UI state](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1209637020443931?focus=true)

This implements the stateful interactions on the prediction suppression page. Uses the SWR library to do "optimistic updates" for snappy interactions. The state lives in a top-level container because it will be needed on every page to drive the badge number on the left nav (coming in a followup PR)