### PR TITLE
enforce strict equality checks

### DIFF
--- a/assets/eslint.config.mjs
+++ b/assets/eslint.config.mjs
@@ -67,6 +67,7 @@ export default [
     rules: {
       "no-console": 0,
       "prefer-rest-params": "off",
+      "eqeqeq": "error",
       "@typescript-eslint/ban-ts-comment": "off",
       "@typescript-eslint/no-explicit-any": "off",
 

--- a/assets/js/components/Dashboard/AlertCard.tsx
+++ b/assets/js/components/Dashboard/AlertCard.tsx
@@ -135,7 +135,7 @@ const AlertCard = (props: AlertCardProps): JSX.Element => {
                 {numberOfPlaces}
               </span>{" "}
               <span className="alert-card__place-details__place-count__text">
-                {numberOfPlaces == 1 ? "place" : "places"}
+                {numberOfPlaces === 1 ? "place" : "places"}
               </span>
             </div>
             <div className="alert-card__place-details__screen-count">
@@ -143,7 +143,7 @@ const AlertCard = (props: AlertCardProps): JSX.Element => {
                 {numberOfScreens}
               </span>{" "}
               <span className="alert-card__place-details__screen-count__text">
-                {numberOfScreens == 1 ? "screen" : "screens"}
+                {numberOfScreens === 1 ? "screen" : "screens"}
               </span>
             </div>
             <ChevronRight

--- a/assets/js/components/Dashboard/AlertsPage.tsx
+++ b/assets/js/components/Dashboard/AlertsPage.tsx
@@ -173,7 +173,7 @@ const AlertsList: ComponentType<AlertsListProps> = ({
         case "Ferry":
           return (ie) => ie.route_type === RouteType.Ferry;
         case "Access":
-          return (ie) => ie.facility != null;
+          return (ie) => ie.facility !== null;
         default:
           return (ie) => ids.includes(ie.route as string);
       }

--- a/assets/js/components/Dashboard/EditPaMessage/EditPaMessage.tsx
+++ b/assets/js/components/Dashboard/EditPaMessage/EditPaMessage.tsx
@@ -9,11 +9,11 @@ import { AudioPreview } from "Components/PaMessageForm/types";
 import { STATIC_TEMPLATES } from "Components/PaMessageForm/StaticTemplatePage";
 import { isPaMessageAdmin } from "Utils/auth";
 
-const useAlert = (id: string | null | undefined) => {
+const useAlert = (id: string | null) => {
   const { data: alerts, isLoading } = useSWR<Array<Alert>>(
     id ? "/api/alerts/non_access_alerts" : null,
     async (url: string | null) => {
-      if (url == null) return [];
+      if (url === null) return [];
 
       const response = await fetch(url);
       const { alerts } = await response.json();
@@ -22,7 +22,7 @@ const useAlert = (id: string | null | undefined) => {
   );
 
   const alert = useMemo(() => {
-    if (id == null) return null;
+    if (id === null) return null;
     return alerts?.find((a) => a.id === id);
   }, [id, alerts]);
 
@@ -60,7 +60,7 @@ const FetchPaMessage = ({ id }: { id: string | number }) => {
     if (error?.status === 404) navigate("/pa-messages");
   }, [error, navigate]);
 
-  if (isLoading || error || paMessage == null) return null;
+  if (isLoading || error || !paMessage) return null;
 
   return <FetchAlert paMessage={paMessage} />;
 };

--- a/assets/js/components/Dashboard/PaMessagesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessagesPage.tsx
@@ -78,7 +78,7 @@ const PaMessagesPage: ComponentType = () => {
   );
   const isReadOnly = !isPaMessageAdmin();
 
-  const showMoreActions = stateFilter == "current";
+  const showMoreActions = stateFilter === "current";
 
   useEffect(() => {
     const newParams = new URLSearchParams();
@@ -98,7 +98,7 @@ const PaMessagesPage: ComponentType = () => {
 
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const [toastProps, setToastProps] = useState<ToastProps | null>();
+  const [toastProps, setToastProps] = useState<ToastProps | null>(null);
 
   return (
     <>
@@ -201,7 +201,7 @@ const PaMessagesPage: ComponentType = () => {
                 }
                 emptyStateText="There are no PA/ESS Messages matching the current filters."
               />
-              {toastProps != null && (
+              {toastProps !== null && (
                 <Toast
                   {...toastProps}
                   onClose={() => {

--- a/assets/js/components/Dashboard/PaessDetailContainer.tsx
+++ b/assets/js/components/Dashboard/PaessDetailContainer.tsx
@@ -18,15 +18,16 @@ const PaessDetailContainer = (
 
   const stationCode = props.screens[0].station_code;
   const leftScreens = props.screens.filter(
-    (screen) => screen.zone != null && zonePositions.left.includes(screen.zone),
+    (screen) =>
+      screen.zone !== undefined && zonePositions.left.includes(screen.zone),
   );
   const centerScreens = props.screens.filter(
     (screen) =>
-      screen.zone != null && zonePositions.center.includes(screen.zone),
+      screen.zone !== undefined && zonePositions.center.includes(screen.zone),
   );
   const rightScreens = props.screens.filter(
     (screen) =>
-      screen.zone != null && zonePositions.right.includes(screen.zone),
+      screen.zone !== undefined && zonePositions.right.includes(screen.zone),
   );
 
   return (
@@ -40,8 +41,8 @@ const PaessDetailContainer = (
           <div>
             {leftScreens.map(
               (screen) =>
-                screen.station_code != null &&
-                screen.zone != null && (
+                screen.station_code !== undefined &&
+                screen.zone !== undefined && (
                   <PaessScreenDetail
                     key={`${screen.station_code}-${screen.zone}`}
                     stationCode={screen.station_code}
@@ -62,8 +63,8 @@ const PaessDetailContainer = (
           <div>
             {centerScreens.map(
               (screen) =>
-                screen.station_code != null &&
-                screen.zone != null && (
+                screen.station_code !== undefined &&
+                screen.zone !== undefined && (
                   <PaessScreenDetail
                     key={`${screen.station_code}-${screen.zone}`}
                     stationCode={screen.station_code}
@@ -84,8 +85,8 @@ const PaessDetailContainer = (
           <div>
             {rightScreens.map(
               (screen) =>
-                screen.station_code != null &&
-                screen.zone != null && (
+                screen.station_code !== undefined &&
+                screen.zone !== undefined && (
                   <PaessScreenDetail
                     key={`${screen.station_code}-${screen.zone}`}
                     stationCode={screen.station_code}

--- a/assets/js/components/Dashboard/PermanentConfiguration/Workflows/GlEink/ConfigureScreensPage.tsx
+++ b/assets/js/components/Dashboard/PermanentConfiguration/Workflows/GlEink/ConfigureScreensPage.tsx
@@ -251,7 +251,7 @@ const ConfigurePlaceCard: ComponentType<ConfigurePlaceCardProps> = ({
     screen: ScreenConfiguration,
     index: number,
   ) => {
-    if (screen.new_id == screenID) {
+    if (screen.new_id === screenID) {
       setUpdatedPendingScreens((prevState) => {
         return [
           ...prevState.slice(0, index),

--- a/assets/js/components/Dashboard/PlacesActionBar.tsx
+++ b/assets/js/components/Dashboard/PlacesActionBar.tsx
@@ -90,14 +90,14 @@ const ActionBarStats: React.ComponentType<StatsProps> = ({
       >
         {placeCount}
       </span>{" "}
-      {placeCount == 1 ? "place" : "places"} ·{" "}
+      {placeCount === 1 ? "place" : "places"} ·{" "}
       <span
         className="places-action-bar__stats__number"
         data-testid="places-action-bar-stats-screen-count"
       >
         {screenCount}
       </span>{" "}
-      {screenCount == 1 ? "screen" : "screens"}
+      {screenCount === 1 ? "screen" : "screens"}
     </span>
   );
 };

--- a/assets/js/components/Dashboard/PredictionSuppressionPage.tsx
+++ b/assets/js/components/Dashboard/PredictionSuppressionPage.tsx
@@ -159,7 +159,7 @@ const PredictionSuppressionPage = () => {
 
     if (serviceType === "start" || serviceType === "mid") {
       const predictionsText =
-        serviceType == "start" ? "terminal predictions" : "predictions";
+        serviceType === "start" ? "terminal predictions" : "predictions";
       return (
         <>
           <label className={styles.suppressionLabel}>
@@ -195,7 +195,7 @@ const PredictionSuppressionPage = () => {
   };
 
   const renderCell = (place: Place, directionId: number) => {
-    if (place.id == "place-jfk") {
+    if (place.id === "place-jfk") {
       return (
         <>
           <div>Ashmont platform</div>

--- a/assets/js/components/Dashboard/PriorityPicker.tsx
+++ b/assets/js/components/Dashboard/PriorityPicker.tsx
@@ -22,7 +22,7 @@ const PriorityPicker = ({
   // Non-PA messages need a priority in between Emergency (1) and Current service Disruption (2)
   // But here we want to just show the labels as is, 1 2 3 4 rather than 1 3 4 5 so adjust here
   const adjustPriorityForLabel = (priority: number): number =>
-    priority == 1 ? priority : priority - 1;
+    priority === 1 ? priority : priority - 1;
 
   return (
     <Form.Group>

--- a/assets/js/components/Dashboard/ScreenDetail.tsx
+++ b/assets/js/components/Dashboard/ScreenDetail.tsx
@@ -92,7 +92,7 @@ const ScreenCard = (props: ScreenDetailProps) => {
                   "screen-detail__screen-type-location screen-detail__screen-type-location--paess",
                   {
                     "screen-detail__screen-type-location--paess-s":
-                      paessRouteLetter == "s",
+                      paessRouteLetter === "s",
                   },
                 )}
               >

--- a/assets/js/components/Dashboard/Toast.tsx
+++ b/assets/js/components/Dashboard/Toast.tsx
@@ -44,7 +44,7 @@ const Toast = ({
   return (
     <ToastContainer position="bottom-center" className="toast-container">
       <BSToast
-        show={message != null}
+        show={message !== null}
         onClose={onClose}
         delay={5000}
         autohide={autoHide}

--- a/assets/js/components/OutfrontTakeoverTool/AlertWizard/AlertWizard.tsx
+++ b/assets/js/components/OutfrontTakeoverTool/AlertWizard/AlertWizard.tsx
@@ -163,7 +163,7 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
             goToStep={this.goToStep}
             selectedStations={this.state.selectedStations}
             message={
-              this.state.messageOption == "1"
+              this.state.messageOption === "1"
                 ? CANNED_MESSAGES[parseInt(this.state.cannedMessage)]
                 : this.state.customMessage
             }
@@ -462,7 +462,7 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
             selectedStations={this.state.selectedStations}
             step={this.state.step}
             customMessage={
-              this.state.messageOption == "1" ? "" : this.state.customMessage
+              this.state.messageOption === "1" ? "" : this.state.customMessage
             }
             cannedMessageId={this.state.cannedMessage}
           />

--- a/assets/js/components/Tables/MessageTable.tsx
+++ b/assets/js/components/Tables/MessageTable.tsx
@@ -46,7 +46,7 @@ const MessageTable = ({
         </thead>
         <tbody>{rows}</tbody>
       </table>
-      {rows.length == 0 && (
+      {rows.length === 0 && (
         <div>
           {isLoading ? (
             <div className={messageTableStyles.loadingContainer}>

--- a/assets/js/hooks/useUpdateAnimation.tsx
+++ b/assets/js/hooks/useUpdateAnimation.tsx
@@ -11,7 +11,7 @@ export const useUpdateAnimation = (
     // Prevents animation when already showing and on page load.
     if (
       timer.current !== undefined ||
-      (!showAnimationOnMount && prevValue == null)
+      (!showAnimationOnMount && (prevValue === null || prevValue === undefined))
     ) {
       return;
     }


### PR DESCRIPTION
This enables the eslint rule to enforce `===` and `!==` usage, and fixes all resulting issues.