### PR TITLE
replace reducers with regular state

### DIFF
--- a/assets/js/components/Dashboard/AlertBanner.tsx
+++ b/assets/js/components/Dashboard/AlertBanner.tsx
@@ -2,7 +2,7 @@ import React, { ComponentType } from "react";
 import { ArrowRepeat, CheckCircleFill } from "react-bootstrap-icons";
 import { formatEffect, translateRouteID } from "../../util";
 import { useParams } from "react-router-dom";
-import { useScreenplayContext } from "Hooks/useScreenplayContext";
+import { useScreenplayState } from "Hooks/useScreenplayContext";
 import { Alert } from "Models/alert";
 
 interface BannerAlert {
@@ -20,7 +20,7 @@ const AlertBanner: ComponentType<AlertBannerProps> = ({
   isDone,
   queueExpiration,
 }: AlertBannerProps) => {
-  const { bannerAlert } = useScreenplayContext();
+  const { bannerAlert } = useScreenplayState();
   const { alert, type } = bannerAlert as BannerAlert;
   const wasPosted = alert.created_at === alert.updated_at;
   const params = useParams();

--- a/assets/js/components/Dashboard/AlertsPage.tsx
+++ b/assets/js/components/Dashboard/AlertsPage.tsx
@@ -17,15 +17,14 @@ import AlertCard from "Components/AlertCard";
 import { useNavigate } from "react-router-dom";
 import { placesWithSelectedAlert } from "../../util";
 import {
-  useAlertsListContext,
-  useAlertsListDispatchContext,
-  useScreenplayContext,
+  useAlertsListState,
+  useScreenplayState,
 } from "Hooks/useScreenplayContext";
 import { usePrevious } from "Hooks/usePrevious";
 import moment from "moment";
 
 const AlertsPage: ComponentType = () => {
-  const { places, alerts, screensByAlertMap } = useScreenplayContext();
+  const { places, alerts, screensByAlertMap } = useScreenplayState();
 
   const alertsWithPlaces = alerts.filter(
     (alert) => screensByAlertMap[alert.id],
@@ -56,39 +55,35 @@ const AlertsList: ComponentType<AlertsListProps> = ({
   places,
   screensByAlertMap,
 }: AlertsListProps) => {
-  const { modeLineFilterValue, screenTypeFilterValue, statusFilterValue } =
-    useAlertsListContext();
-  const dispatch = useAlertsListDispatchContext();
+  const {
+    modeLineFilterValue,
+    screenTypeFilterValue,
+    statusFilterValue,
+    setModeLineFilterValue,
+    setScreenTypeFilterValue,
+    setStatusFilterValue,
+  } = useAlertsListState();
   const navigate = useNavigate();
   const prevAlertIds = usePrevious(alerts)?.map((alert) => alert.id);
 
   const handleAlertModeOrLineSelect = (value: string) => {
     const selectedFilter = MODES_AND_LINES.find(({ label }) => label === value);
     if (selectedFilter) {
-      dispatch({
-        type: "SET_MODE_LINE_FILTER",
-        filterValue: selectedFilter,
-      });
+      setModeLineFilterValue(selectedFilter);
     }
   };
 
   const handleAlertScreenTypeSelect = (value: string) => {
     const selectedFilter = SCREEN_TYPES.find(({ label }) => label === value);
     if (selectedFilter) {
-      dispatch({
-        type: "SET_SCREEN_TYPE_FILTER",
-        filterValue: selectedFilter,
-      });
+      setScreenTypeFilterValue(selectedFilter);
     }
   };
 
   const handleAlertStatusSelect = (value: string) => {
     const selectedFilter = STATUSES.find(({ label }) => label === value);
     if (selectedFilter) {
-      dispatch({
-        type: "SET_STATUS_FILTER",
-        filterValue: selectedFilter,
-      });
+      setStatusFilterValue(selectedFilter);
     }
   };
 

--- a/assets/js/components/Dashboard/CopyLinkButton.tsx
+++ b/assets/js/components/Dashboard/CopyLinkButton.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button, OverlayTrigger, Tooltip } from "react-bootstrap";
 import { Link45deg } from "react-bootstrap-icons";
-import { useScreenplayDispatchContext } from "Hooks/useScreenplayContext";
+import { useScreenplayState } from "Hooks/useScreenplayContext";
 
 interface CopyLinkButtonProps {
   url: string;
@@ -9,7 +9,7 @@ interface CopyLinkButtonProps {
 }
 
 const CopyLinkButton = (props: CopyLinkButtonProps): JSX.Element => {
-  const dispatch = useScreenplayDispatchContext();
+  const { setShowLinkCopied } = useScreenplayState();
 
   return (
     <OverlayTrigger
@@ -22,7 +22,7 @@ const CopyLinkButton = (props: CopyLinkButtonProps): JSX.Element => {
         className="screen-detail-action-bar-button copy-link-button"
         onClick={() => {
           navigator.clipboard.writeText(props.url);
-          dispatch({ type: "SHOW_LINK_COPIED", showLinkCopied: true });
+          setShowLinkCopied(true);
           props.queueToastExpiration();
         }}
       >

--- a/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectStationsAndZones.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/SelectStationsAndZones/SelectStationsAndZones.tsx
@@ -3,7 +3,7 @@ import SelectStationsPage from "./SelectStationsPage";
 import SelectZonesPage from "./SelectZonesPage";
 import type { Place } from "Models/place";
 import { Page } from "../types";
-import { useScreenplayDispatchContext } from "Hooks/useScreenplayContext";
+import { useScreenplayState } from "Hooks/useScreenplayContext";
 
 interface Props {
   places: Place[];
@@ -26,14 +26,14 @@ const SelectStationsAndZones = ({
   onError,
   isReadOnly = false,
 }: Props) => {
-  const dispatch = useScreenplayDispatchContext();
+  const { setShowSidebar } = useScreenplayState();
   const [signIds, setSignIds] = useState(value);
 
   useEffect(() => {
-    dispatch({ type: "SHOW_SIDEBAR", showSidebar: false });
+    setShowSidebar(false);
 
-    return () => dispatch({ type: "SHOW_SIDEBAR", showSidebar: true });
-  }, [dispatch]);
+    return () => setShowSidebar(true);
+  }, [setShowSidebar]);
 
   return page === Page.STATIONS ? (
     <SelectStationsPage

--- a/assets/js/components/Dashboard/PendingScreenDetail.tsx
+++ b/assets/js/components/Dashboard/PendingScreenDetail.tsx
@@ -8,7 +8,7 @@ import { Col, Container, Form, Row } from "react-bootstrap";
 import { capitalize } from "../../util";
 import OpenInTabButton from "Components/OpenInTabButton";
 import CopyLinkButton from "Components/CopyLinkButton";
-import { useScreenplayDispatchContext } from "Hooks/useScreenplayContext";
+import { useScreenplayState } from "Hooks/useScreenplayContext";
 import { LightningChargeFill, ClockFill } from "react-bootstrap-icons";
 
 interface Props {
@@ -57,20 +57,13 @@ const PendingScreenDetail: ComponentType<Props> = ({
   isHiddenOnPlacesPage,
   onClickHideOnPlacesPage,
 }: Props): JSX.Element => {
-  const dispatch = useScreenplayDispatchContext();
+  const { setShowLinkCopied } = useScreenplayState();
   const screensUrl = document
     .querySelector("meta[name=screens-url]")
     ?.getAttribute("content");
 
   const queueToastExpiration = () => {
-    setTimeout(
-      () =>
-        dispatch({
-          type: "SHOW_LINK_COPIED",
-          showLinkCopied: false,
-        }),
-      5000,
-    );
+    setTimeout(() => setShowLinkCopied(false), 5000);
   };
 
   const locationDescription = getScreenLocationDescription(config);

--- a/assets/js/components/Dashboard/PermanentConfiguration/Workflows/GlEink/ConfigureScreensPage.tsx
+++ b/assets/js/components/Dashboard/PermanentConfiguration/Workflows/GlEink/ConfigureScreensPage.tsx
@@ -37,10 +37,7 @@ import {
   ExistingScreensAtPlace,
   fetchExistingScreens,
 } from "Utils/api";
-import {
-  useConfigValidationContext,
-  useConfigValidationDispatchContext,
-} from "Hooks/useScreenplayContext";
+import { useConfigValidationState } from "Hooks/useScreenplayContext";
 
 interface PlaceIdsAndExistingScreens {
   [place_id: string]: ExistingScreensAtPlace;
@@ -73,9 +70,11 @@ const ConfigureScreensWorkflowPage: ComponentType<
 }: ConfigureScreensWorkflowPageProps) => {
   const [existingScreens, setExistingScreens] = useState<ExistingScreens>({});
 
-  const { newScreenValidationErrors, pendingScreenValidationErrors } =
-    useConfigValidationContext();
-  const dispatch = useConfigValidationDispatchContext();
+  const {
+    newScreenValidationErrors,
+    pendingScreenValidationErrors,
+    setValidationErrors,
+  } = useConfigValidationState();
   const initializeExistingScreenValidationErrors = useCallback(
     (placesAndScreens: PlaceIdsAndExistingScreens) => {
       for (const place_id in placesAndScreens) {
@@ -89,13 +88,16 @@ const ConfigureScreensWorkflowPage: ComponentType<
         });
       }
 
-      dispatch({
-        type: "SET_VALIDATION_ERRORS",
+      setValidationErrors(
         newScreenValidationErrors,
         pendingScreenValidationErrors,
-      });
+      );
     },
-    [dispatch, newScreenValidationErrors, pendingScreenValidationErrors],
+    [
+      setValidationErrors,
+      newScreenValidationErrors,
+      pendingScreenValidationErrors,
+    ],
   );
 
   // This hook will run in two different scenarios:
@@ -165,9 +167,11 @@ const ConfigurePlaceCard: ComponentType<ConfigurePlaceCardProps> = ({
   const existingLiveScreens: {
     [screen_id: string]: ScreenConfiguration;
   } = existingScreens?.live_screens ?? {};
-  const { newScreenValidationErrors, pendingScreenValidationErrors } =
-    useConfigValidationContext();
-  const dispatch = useConfigValidationDispatchContext();
+  const {
+    newScreenValidationErrors,
+    pendingScreenValidationErrors,
+    setValidationErrors,
+  } = useConfigValidationState();
 
   useEffect(() => {
     if (!existingScreens) return;
@@ -278,11 +282,10 @@ const ConfigurePlaceCard: ComponentType<ConfigurePlaceCardProps> = ({
 
   const deleteNewRow = (index: number) => {
     newScreenValidationErrors[place.id].splice(index, 1);
-    dispatch({
-      type: "SET_VALIDATION_ERRORS",
+    setValidationErrors(
       newScreenValidationErrors,
       pendingScreenValidationErrors,
-    });
+    );
     setNewScreens((prevState) => {
       return [...prevState.slice(0, index), ...prevState.slice(index + 1)];
     });
@@ -312,11 +315,10 @@ const ConfigurePlaceCard: ComponentType<ConfigurePlaceCardProps> = ({
       missingFields: [],
       isDuplicateScreenId: false,
     });
-    dispatch({
-      type: "SET_VALIDATION_ERRORS",
+    setValidationErrors(
       newScreenValidationErrors,
       pendingScreenValidationErrors,
-    });
+    );
   };
 
   return (

--- a/assets/js/components/Dashboard/PermanentConfiguration/Workflows/GlEink/GlEinkWorkflow.tsx
+++ b/assets/js/components/Dashboard/PermanentConfiguration/Workflows/GlEink/GlEinkWorkflow.tsx
@@ -13,11 +13,10 @@ import StationSelectPage from "Components/PermanentConfiguration/Workflows/GlEin
 import { Alert } from "react-bootstrap";
 import { ExclamationCircleFill } from "react-bootstrap-icons";
 import {
-  useConfigValidationContext,
-  useConfigValidationDispatchContext,
+  useConfigValidationState,
+  useScreenplayState,
 } from "Hooks/useScreenplayContext";
 import { putPendingScreens } from "Utils/api";
-import { useScreenplayContext } from "Hooks/useScreenplayContext";
 import ErrorModal from "Components/ErrorModal";
 
 interface EditNavigationState {
@@ -25,7 +24,7 @@ interface EditNavigationState {
 }
 
 const GlEinkWorkflow: ComponentType = () => {
-  const { places } = useScreenplayContext();
+  const { places } = useScreenplayState();
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -44,9 +43,11 @@ const GlEinkWorkflow: ComponentType = () => {
   };
 
   const [showValidationAlert, setShowValidationAlert] = useState(true);
-  const { newScreenValidationErrors, pendingScreenValidationErrors } =
-    useConfigValidationContext();
-  const dispatch = useConfigValidationDispatchContext();
+  const {
+    newScreenValidationErrors,
+    pendingScreenValidationErrors,
+    setValidationErrors,
+  } = useConfigValidationState();
   const [validationErrorMessage, setValidationErrorMessage] =
     useState<string>("");
   const [showErrorModal, setShowErrorModal] = useState<boolean>(false);
@@ -60,15 +61,14 @@ const GlEinkWorkflow: ComponentType = () => {
       setIsEditing(true);
       newScreenValidationErrors[place_id] = [];
       pendingScreenValidationErrors[place_id] = [];
-      dispatch({
-        type: "SET_VALIDATION_ERRORS",
+      setValidationErrors(
         newScreenValidationErrors,
         pendingScreenValidationErrors,
-      });
+      );
     }
   }, [
     location,
-    dispatch,
+    setValidationErrors,
     newScreenValidationErrors,
     pendingScreenValidationErrors,
   ]);
@@ -187,11 +187,10 @@ const GlEinkWorkflow: ComponentType = () => {
     fieldsWithErrors.add("screen_id");
     setValidationErrorMessage(generateErrorMessage(fieldsWithErrors));
     setShowValidationAlert(true);
-    dispatch({
-      type: "SET_VALIDATION_ERRORS",
+    setValidationErrors(
       newScreenValidationErrors,
       pendingScreenValidationErrors,
-    });
+    );
   };
 
   const filteredPlaces = useMemo(
@@ -242,11 +241,10 @@ const GlEinkWorkflow: ComponentType = () => {
           pendingScreenValidationErrors[placeId] = [];
         });
 
-        dispatch({
-          type: "SET_VALIDATION_ERRORS",
+        setValidationErrors(
           newScreenValidationErrors,
           pendingScreenValidationErrors,
-        });
+        );
         setShowValidationAlert(false);
         setConfigStep(configStep - 1);
       };
@@ -267,11 +265,10 @@ const GlEinkWorkflow: ComponentType = () => {
           validateDuplicateScreenIds(placesAndScreensToUpdate);
           setValidationErrorMessage(generateErrorMessage(fieldsWithErrors));
           setShowValidationAlert(true);
-          dispatch({
-            type: "SET_VALIDATION_ERRORS",
+          setValidationErrors(
             newScreenValidationErrors,
             pendingScreenValidationErrors,
-          });
+          );
         }
       };
       layout = (

--- a/assets/js/components/Dashboard/PermanentConfiguration/Workflows/GlEink/StationSelectPage.tsx
+++ b/assets/js/components/Dashboard/PermanentConfiguration/Workflows/GlEink/StationSelectPage.tsx
@@ -8,10 +8,7 @@ import { DirectionID } from "Models/direction_id";
 import { Place } from "Models/place";
 import BottomActionBar from "Components/PermanentConfiguration/BottomActionBar";
 import { useNavigate } from "react-router-dom";
-import {
-  useConfigValidationContext,
-  useConfigValidationDispatchContext,
-} from "Hooks/useScreenplayContext";
+import { useConfigValidationState } from "Hooks/useScreenplayContext";
 import { PlaceIdsAndNewScreens } from "./ConfigureScreensPage";
 interface StationSelectPageProps {
   places: Place[];
@@ -35,20 +32,21 @@ const StationSelectPage: ComponentType<StationSelectPageProps> = ({
       setSelectedPlaces((prev) => new Set([placeToAdd.id, ...prev]));
       newScreenValidationErrors[placeToAdd.id] = [];
       pendingScreenValidationErrors[placeToAdd.id] = [];
-      dispatch({
-        type: "SET_VALIDATION_ERRORS",
+      setValidationErrors(
         newScreenValidationErrors,
         pendingScreenValidationErrors,
-      });
+      );
     }
   };
 
   const navigate = useNavigate();
   const [configStep, setConfigStep] = useState<number>(0);
 
-  const { newScreenValidationErrors, pendingScreenValidationErrors } =
-    useConfigValidationContext();
-  const dispatch = useConfigValidationDispatchContext();
+  const {
+    newScreenValidationErrors,
+    pendingScreenValidationErrors,
+    setValidationErrors,
+  } = useConfigValidationState();
 
   let backButtonLabel;
   let forwardButtonLabel;
@@ -98,20 +96,18 @@ const StationSelectPage: ComponentType<StationSelectPageProps> = ({
                 newSet.add(place.id);
                 newScreenValidationErrors[place.id] = [];
                 pendingScreenValidationErrors[place.id] = [];
-                dispatch({
-                  type: "SET_VALIDATION_ERRORS",
+                setValidationErrors(
                   newScreenValidationErrors,
                   pendingScreenValidationErrors,
-                });
+                );
               } else {
                 newSet.delete(place.id);
                 delete newScreenValidationErrors[place.id];
                 delete pendingScreenValidationErrors[place.id];
-                dispatch({
-                  type: "SET_VALIDATION_ERRORS",
+                setValidationErrors(
                   newScreenValidationErrors,
                   pendingScreenValidationErrors,
-                });
+                );
               }
               setPlacesAndScreensToUpdate((placesAndScreens) => {
                 const { [place.id]: _discarded, ...newPlacesAndScreens } =

--- a/assets/js/components/Dashboard/PlaceRowAccordion.tsx
+++ b/assets/js/components/Dashboard/PlaceRowAccordion.tsx
@@ -2,10 +2,7 @@ import React, { ComponentType, useContext } from "react";
 import PlaceRow from "Components/PlaceRow";
 import { Place } from "Models/place";
 import { Screen } from "Models/screen";
-import {
-  DirectionID,
-  PlacesListReducerAction,
-} from "Hooks/useScreenplayContext";
+import { DirectionID, usePlacesListState } from "Hooks/useScreenplayContext";
 import {
   Accordion,
   AccordionContext,
@@ -77,7 +74,6 @@ const groupPaEssScreensbyRoute = (screens: Screen[]): Map<string, Screen[]> => {
 interface PlaceRowAccordionProps {
   place: Place;
   canShowAnimation?: boolean;
-  dispatch: React.Dispatch<PlacesListReducerAction>;
   activeEventKeys: string[];
   sortDirection: DirectionID;
   filteredLine?: string | null;
@@ -87,23 +83,17 @@ interface PlaceRowAccordionProps {
 const PlaceRowAccordion: ComponentType<PlaceRowAccordionProps> = ({
   place,
   canShowAnimation,
-  dispatch,
   filteredLine,
   sortDirection,
   activeEventKeys,
   className = "",
 }: PlaceRowAccordionProps) => {
+  const { setActiveEventKeys } = usePlacesListState();
   const handleClickAccordion = (eventKey: string) => {
     if (activeEventKeys?.includes(eventKey)) {
-      dispatch({
-        type: "SET_ACTIVE_EVENT_KEYS",
-        eventKeys: activeEventKeys.filter((e: string) => e !== eventKey),
-      });
+      setActiveEventKeys(activeEventKeys.filter((e: string) => e !== eventKey));
     } else {
-      dispatch({
-        type: "SET_ACTIVE_EVENT_KEYS",
-        eventKeys: [...activeEventKeys, eventKey],
-      });
+      setActiveEventKeys([...activeEventKeys, eventKey]);
     }
   };
 

--- a/assets/js/components/Dashboard/PredictionSuppressionPage.tsx
+++ b/assets/js/components/Dashboard/PredictionSuppressionPage.tsx
@@ -1,6 +1,6 @@
 import {
   usePredictionSuppressionState,
-  useScreenplayContext,
+  useScreenplayState,
 } from "Hooks/useScreenplayContext";
 import { RadioList } from "Components/RadioList";
 import React, { ReactNode, useEffect, useState } from "react";
@@ -36,7 +36,7 @@ const directionNames = (line: string) => {
 const PredictionSuppressionPage = () => {
   const [params, setParams] = useSearchParams();
   const [line, setLine] = useState<string>(params.get("line") || "Green");
-  const { places, lineStops } = useScreenplayContext();
+  const { places, lineStops } = useScreenplayState();
   const { suppressedPredictions, mutateSuppressedPredictions } =
     usePredictionSuppressionState();
 

--- a/assets/js/components/Dashboard/ScreenDetailActionBar.tsx
+++ b/assets/js/components/Dashboard/ScreenDetailActionBar.tsx
@@ -4,7 +4,7 @@ import CopyLinkButton from "Components/CopyLinkButton";
 import OpenInWindowButton from "Components/OpenInTabButton";
 import { Dropdown } from "react-bootstrap";
 import { Link45deg, FlagFill, BoxArrowUpRight } from "react-bootstrap-icons";
-import { useScreenplayDispatchContext } from "Hooks/useScreenplayContext";
+import { useScreenplayState } from "Hooks/useScreenplayContext";
 import KebabMenu from "Components/KebabMenu";
 import { isEmergencyAdmin } from "Utils/auth";
 
@@ -16,17 +16,10 @@ interface ScreenDetailActionBarProps {
 const ScreenDetailActionBar = (
   props: ScreenDetailActionBarProps,
 ): JSX.Element => {
-  const dispatch = useScreenplayDispatchContext();
+  const { setShowLinkCopied } = useScreenplayState();
 
   const queueToastExpiration = () => {
-    setTimeout(
-      () =>
-        dispatch({
-          type: "SHOW_LINK_COPIED",
-          showLinkCopied: false,
-        }),
-      5000,
-    );
+    setTimeout(() => setShowLinkCopied(false), 5000);
   };
 
   const reportAProblemURL = isEmergencyAdmin()
@@ -51,7 +44,7 @@ const ScreenDetailActionBar = (
           className="kebab-menu-dropdown__item"
           onClick={() => {
             navigator.clipboard.writeText(props.screenUrl);
-            dispatch({ type: "SHOW_LINK_COPIED", showLinkCopied: true });
+            setShowLinkCopied(true);
             queueToastExpiration();
           }}
         >

--- a/assets/js/hooks/usePlacesWithPaEss.ts
+++ b/assets/js/hooks/usePlacesWithPaEss.ts
@@ -1,9 +1,9 @@
 import { useMemo } from "react";
 import { Place } from "Models/place";
-import { useScreenplayContext } from "Hooks/useScreenplayContext";
+import { useScreenplayState } from "Hooks/useScreenplayContext";
 
 export const usePlacesWithPaEss = () => {
-  const { places } = useScreenplayContext();
+  const { places } = useScreenplayState();
   return useMemo(
     () =>
       places

--- a/assets/tests/components/placeRowAccordion.test.tsx
+++ b/assets/tests/components/placeRowAccordion.test.tsx
@@ -25,14 +25,11 @@ describe("PlaceRowAccordion", () => {
       ],
     };
 
-    const dispatch = jest.fn();
-
     const { getByTestId } = render(
       <ScreenplayProvider>
         <Accordion>
           <PlaceRowAccordion
             place={place}
-            dispatch={dispatch}
             activeEventKeys={[]}
             sortDirection={0}
           />


### PR DESCRIPTION
This refactors the top-level application state to use regular state instead of reducers. Reducers tend to be more verbose, and they only provide extra value in a few narrow use cases (e.g. reducer composition and time-travel debugging), none of which we're using.

The revised code extends the passed Context values with setter callbacks to update the managed state. The result is much more compact and the names/types are more straightforward.

Also reworks the `AlertDetails` page to simplify the code by taking advantage of the new state container.