### PR TITLE
implement prediction suppression badges

### DIFF
--- a/assets/css/prediction-suppression.module.scss
+++ b/assets/css/prediction-suppression.module.scss
@@ -31,3 +31,13 @@
   width: 0;
   opacity: 0;
 }
+
+.badge {
+  color: $text-invert;
+  background-color: $button-primary;
+  border-radius: var(--bs-border-radius);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  line-height: 20px;
+  padding: 0 0.5rem;
+}

--- a/assets/css/sidebar.module.scss
+++ b/assets/css/sidebar.module.scss
@@ -34,6 +34,7 @@
 .linkHighlight {
   padding: 8px;
   border-radius: 8px;
+  position: relative;
   .link.active &,
   .link:hover & {
     background-color: #384e5c;

--- a/assets/js/components/Dashboard/PredictionSuppressionPage.tsx
+++ b/assets/js/components/Dashboard/PredictionSuppressionPage.tsx
@@ -18,6 +18,7 @@ import {
 import { SuppressedPrediction } from "Models/suppressed_prediction";
 import { useUniqueId } from "Hooks/useUniqueId";
 import { useSearchParams } from "react-router-dom";
+import cx from "classnames";
 
 const lookupKey = fp.join(":");
 
@@ -89,6 +90,11 @@ const PredictionSuppressionPage = () => {
     ]),
     fp.fromPairs,
   ])(suppressedPredictions);
+
+  const suppressedPredictionCounts = fp.countBy(
+    "route_id",
+    suppressedPredictions,
+  );
 
   const noPredictions = (place: Place) => {
     const serviceType = lineStopLookup[lookupKey([place.id, 0])];
@@ -208,6 +214,17 @@ const PredictionSuppressionPage = () => {
     return renderInput(place.id, place.id, directionId);
   };
 
+  const filterContent = (line: string) => {
+    return (
+      <>
+        <span>{line} Line</span>
+        <span className={cx(styles.badge, "ms-auto")}>
+          {suppressedPredictionCounts[line]}
+        </span>
+      </>
+    );
+  };
+
   return (
     <div className="ms-5 mt-4">
       <h1 className="mb-5">Suppress Predictions</h1>
@@ -221,7 +238,7 @@ const PredictionSuppressionPage = () => {
               {
                 value: "Green",
                 checkedClass: "bg-mbta-green",
-                content: "Green Line",
+                content: filterContent("Green"),
               },
               {
                 value: "Green-B",
@@ -262,22 +279,22 @@ const PredictionSuppressionPage = () => {
               {
                 value: "Red",
                 checkedClass: "bg-mbta-red",
-                content: "Red Line",
+                content: filterContent("Red"),
               },
               {
                 value: "Blue",
                 checkedClass: "bg-mbta-blue",
-                content: "Blue Line",
+                content: filterContent("Blue"),
               },
               {
                 value: "Orange",
                 checkedClass: "bg-mbta-orange",
-                content: "Orange Line",
+                content: filterContent("Orange"),
               },
               {
                 value: "Silver",
                 checkedClass: "bg-mbta-silver",
-                content: "Silver Line",
+                content: filterContent("Silver"),
               },
             ]}
           />

--- a/assets/js/components/Dashboard/Sidebar.tsx
+++ b/assets/js/components/Dashboard/Sidebar.tsx
@@ -18,8 +18,10 @@ import TLogo from "../../../static/images/t-logo.svg";
 import TLogoBlack from "../../../static/images/t-logo-black.svg";
 import cx from "classnames";
 import * as sidebarStyles from "Styles/sidebar.module.scss";
+import * as predictionSuppressionStyles from "Styles/prediction-suppression.module.scss";
 
 import { isEmergencyAdmin, isScreensAdmin } from "Utils/auth";
+import { usePredictionSuppressionState } from "Hooks/useScreenplayContext";
 
 const SidebarLink = ({
   to,
@@ -27,12 +29,14 @@ const SidebarLink = ({
   activeIcon,
   reloadDocument,
   children,
+  extraContent,
 }: {
   to: string;
   icon: Icon;
   activeIcon: Icon;
   reloadDocument?: boolean;
   children: ReactNode;
+  extraContent?: ReactNode;
 }) => {
   return (
     <NavLink
@@ -48,6 +52,7 @@ const SidebarLink = ({
           <>
             <span className={sidebarStyles.linkHighlight}>
               <IconComponent size={36} />
+              {extraContent}
             </span>
             <span>{children}</span>
           </>
@@ -58,6 +63,8 @@ const SidebarLink = ({
 };
 
 const Sidebar = () => {
+  const { suppressedPredictions } = usePredictionSuppressionState();
+
   const environment =
     document
       .querySelector("meta[name=environment-name]")
@@ -90,6 +97,16 @@ const Sidebar = () => {
           to="/prediction-suppression"
           icon={ArrowDownShort}
           activeIcon={ArrowDownShort}
+          extraContent={
+            !!suppressedPredictions?.length && (
+              <span
+                style={{ position: "absolute", bottom: -4, right: -14 }}
+                className={predictionSuppressionStyles.badge}
+              >
+                {suppressedPredictions?.length}
+              </span>
+            )
+          }
         >
           Suppress Predictions
         </SidebarLink>


### PR DESCRIPTION
**Asana task**: [Prediction suppression: Wire up UI state](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1209637020443931?focus=true)

Description

This adds the numerical badges to the prediction suppression page and the global sidebar.