### PR TITLE
fix: URL in suppressed-predictions API documention

### DIFF
--- a/docs/tech_specs/suppressed_predictions_api.md
+++ b/docs/tech_specs/suppressed_predictions_api.md
@@ -4,7 +4,7 @@ Lists all Suppressed suppression_type defined by the stop_id, route_id and direc
 
 _Note_: JFK/UMass (place-jfk) will use the child stop_ids.
 
-**URL** : `/api/suppressed_suppression_type/suppression_data`
+**URL** : `/api/suppressed-predictions/suppression_data`
 
 **Method** : `GET`
 


### PR DESCRIPTION
**Asana task**: ad-hoc

Hi friends! Working on consuming this new API endpoint and noticed a typo in the URL. Thought it might be easier to open a PR instead of DMing one of you on Slack about it.

- [ ] For features with a design/UX component, deployed branch to dev-green and let product know it's ready for review.
