### PR TITLE
add Mattapan line to prediction suppression

### DIFF
--- a/assets/js/components/Dashboard/PredictionSuppressionPage.tsx
+++ b/assets/js/components/Dashboard/PredictionSuppressionPage.tsx
@@ -32,6 +32,8 @@ const directionNames = (line: string) => {
       return ["Westbound", "Eastbound"];
     case "Silver":
       return ["Eastbound", "To South Station/Downtown"];
+    case "Mattapan":
+      return ["Outbound", "Inbound"];
     default:
       return ["Southbound", "Northbound"];
   }
@@ -319,6 +321,11 @@ const PredictionSuppressionPage = () => {
                 value: "Silver",
                 checkedClass: "bg-mbta-silver",
                 content: filterContent("Silver"),
+              },
+              {
+                value: "Mattapan",
+                checkedClass: "bg-mbta-red",
+                content: filterContent("Mattapan"),
               },
             ]}
           />

--- a/lib/screenplay/prediction_suppression.ex
+++ b/lib/screenplay/prediction_suppression.ex
@@ -36,7 +36,8 @@ defmodule Screenplay.PredictionSuppression do
     Process.send_after(self(), :update, 60_000)
 
     case Screenplay.V3Api.get_json("/route_patterns", %{
-           "filter[route]" => "Red,Orange,Blue,Green-B,Green-C,Green-D,Green-E,741,742,743,746",
+           "filter[route]" =>
+             "Red,Orange,Blue,Green-B,Green-C,Green-D,Green-E,Mattapan,741,742,743,746",
            "include" => "representative_trip.stops"
          }) do
       {:ok, %{"data" => data, "included" => included}} ->


### PR DESCRIPTION
This adds the Mattapan line to the prediction suppression page, which was inadvertently omitted from the original designs.