### PR TITLE
fix crontab format

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -69,7 +69,7 @@ if config_env() != :test do
          crontab: [
            {"0 2 * * *", Screenplay.Jobs.TakeoverToolTestingJob},
            {"* * * * *", Screenplay.Jobs.Reminders},
-           {"0 3 * * * ", Screenplay.Jobs.ClearSuppressedPredictions}
+           {"0 3 * * *", Screenplay.Jobs.ClearSuppressedPredictions}
          ],
          timezone: "America/New_York"},
         Oban.Plugins.Pruner,


### PR DESCRIPTION
This fixes a formatting error in the crontab that was causing crashes in prod. I tested this locally by commenting out the `env` check and verified that it fixes the crash.