### PR TITLE
fix bus parent station lookup

### DIFF
--- a/lib/screenplay/places/builder.ex
+++ b/lib/screenplay/places/builder.ex
@@ -313,13 +313,7 @@ defmodule Screenplay.Places.Builder do
     stops_to_parent_station_ids =
       parent_stops
       |> Enum.map(fn %{"id" => id} = stop ->
-        {id,
-         get_in(stop, [
-           "relationships",
-           "parent_station",
-           "data",
-           "id"
-         ])}
+        {id, stop["relationships"]["parent_station"]["data"]["id"] || id}
       end)
       |> Enum.into(%{})
 


### PR DESCRIPTION
This fixes a UI crash on the PA message stations page, and restores the missing PA/ESS bus signs in the places list.

We recently changed `signs.json` to list the parent stop id for bus signs, which caused this lookup to return `nil`, effectively filtering out the signs and causing the observed issues. The fix is to default to the original id if this stop is already the parent.