### PR TITLE
chore: log deleted prediction suppressions

### DIFF
--- a/lib/screenplay_web/controllers/suppressed_predictions_api_controller.ex
+++ b/lib/screenplay_web/controllers/suppressed_predictions_api_controller.ex
@@ -55,9 +55,15 @@ defmodule ScreenplayWeb.SuppressedPredictionsApiController do
       ) do
     with {:ok, suppressed_prediction} <-
            SuppressedPredictions.get_suppressed_prediction(location_id, route_id, direction_id),
-         {:ok, delete_suppressed_prediction} <-
+         {:ok, deleted_suppressed_prediction} <-
            SuppressedPredictions.delete_suppressed_prediction(suppressed_prediction) do
-      json(conn, delete_suppressed_prediction)
+      log_suppressed_prediction(
+        "suppressed_prediction_deleted",
+        deleted_suppressed_prediction,
+        conn
+      )
+
+      json(conn, deleted_suppressed_prediction)
     end
   end
 


### PR DESCRIPTION
We were already logging when a prediction suppression is created or updated, but not when one was deleted. This completes the picture.

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210707261785843