### PR TITLE
feat: Add Park St, Kendall, and Arlington to Outfront takeover tool

### DIFF
--- a/config/outfront_takeover_tool_screens.exs
+++ b/config/outfront_takeover_tool_screens.exs
@@ -38,7 +38,7 @@ config :screenplay,
       %{
         name: "Kendall/MIT",
         portrait: true,
-        landscape: false,
+        landscape: true,
         sftp_dir_name: "013_RED_KENDALL"
       },
       %{
@@ -50,7 +50,7 @@ config :screenplay,
       %{
         name: "Park Street",
         portrait: true,
-        landscape: false,
+        landscape: true,
         sftp_dir_name: "001_XFER_RED_GREEN_PARK"
       },
       %{
@@ -364,7 +364,7 @@ config :screenplay,
       %{
         name: "Park Street",
         portrait: true,
-        landscape: false,
+        landscape: true,
         sftp_dir_name: "001_XFER_RED_GREEN_PARK"
       },
       %{
@@ -376,7 +376,7 @@ config :screenplay,
       %{
         name: "Arlington",
         portrait: true,
-        landscape: false,
+        landscape: true,
         sftp_dir_name: "063_GREEN_ARLINGTON"
       },
       %{


### PR DESCRIPTION
**Asana task**: [Update DUPs available in Outfront Emergency Takeover tool](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210653390960039?focus=true)

Updates the config for the Outfront takeover tool to add the DUPs that have been added at Park St, Kendall, and Arlington. 

Confirmed that all other DUPs are already available on the tool, so with these three added, we will be up to date.

Note: The folders are not yet created on the SFTP server, so this PR will be in the draft state until that is completed.