### PR TITLE
don't show alert banner on prediction suppression page

### DIFF
--- a/assets/js/components/Dashboard/Dashboard.tsx
+++ b/assets/js/components/Dashboard/Dashboard.tsx
@@ -152,6 +152,7 @@ const Dashboard: ComponentType = () => {
   const showAlertBanner =
     !pathname.includes("configure-screens") &&
     !pathname.includes("pa-messages") &&
+    !pathname.includes("prediction-suppression") &&
     bannerAlert?.alert;
 
   return (


### PR DESCRIPTION
**Asana task**: [Screenplay: blank alert update message on Prediction Suppression](https://app.asana.com/1/15492006741476/project/1185117109217422/task/1210601350130555?focus=true)

Description

This excludes the alert banner from showing up on the prediction suppression page, since it's not relevant there.