### PR TITLE
chore: update Node.js version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,10 +79,10 @@ jobs:
         run: mix sobelow --config
 
       # NPM Build + Test
-      - name: Use Node.js 18.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: "npm"
           cache-dependency-path: "./assets"
       - run: npm --prefix assets ci

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 erlang 27.3.4
 elixir 1.17.3-otp-27
-nodejs 18.20.1
+nodejs 22.18.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG ALPINE_VERSION=3.21.3
 ARG ELIXIR_VERSION=1.17.3
 ARG ERLANG_VERSION=27.3.4
-ARG NODE_VERSION=18.20.2
+ARG NODE_VERSION=22.18.0
 
 # first, get the Elixir dependencies within an Elixir + Alpine Linux container
 FROM hexpm/elixir:${ELIXIR_VERSION}-erlang-${ERLANG_VERSION}-alpine-${ALPINE_VERSION} as elixir-builder


### PR DESCRIPTION
Node 18 reached End Of Life in April 2025 and no longer receives security updates. Update to Node 22, the current LTS release, which will be supported until mid-2027.

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1211023063494548