### PR TITLE
chore: switch to 4:00am service day boundary

### DIFF
--- a/assets/js/components/Dashboard/PaMessageForm/MainForm.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/MainForm.tsx
@@ -153,8 +153,7 @@ const MainForm = ({
 
   const startDateTime = moment(`${startDate} ${startTime}`, "YYYY-MM-DD HH:mm");
   const endDateTime = moment(`${endDate} ${endTime}`, "YYYY-MM-DD HH:mm");
-  const popoverText =
-    "A service day starts at 3:00 AM, and ends at 3:00 AM the following day";
+  const popoverText = "The service day starts and ends at 4:00 AM";
 
   const isEndTimeInvalid = validated && !moment(endTime, "HH:mm").isValid();
 
@@ -233,7 +232,7 @@ const MainForm = ({
                   <Button
                     className={paMessageStyles.serviceTimeButton}
                     variant="link"
-                    onClick={() => setStartTime("03:00")}
+                    onClick={() => setStartTime("04:00")}
                   >
                     Start of service day
                   </Button>
@@ -316,7 +315,7 @@ const MainForm = ({
                       onClick={() => {
                         if (isEndTimeInvalid) return;
 
-                        if (moment(endTime, "HH:mm").hour() >= 3) {
+                        if (moment(endTime, "HH:mm").hour() >= 4) {
                           setEndDate(
                             moment(endDate, "YYYY-MM-DD")
                               .add(1, "d")
@@ -324,7 +323,7 @@ const MainForm = ({
                           );
                         }
 
-                        setEndTime("03:00");
+                        setEndTime("04:00");
                       }}
                     >
                       End of service day

--- a/lib/screenplay/pa_messages/pa_message/queries.ex
+++ b/lib/screenplay/pa_messages/pa_message/queries.ex
@@ -29,10 +29,10 @@ defmodule Screenplay.PaMessages.PaMessage.Queries do
         ) ::
           Ecto.Query.t()
   def active(q \\ PaMessage, alert_ids, now) do
-    current_service_day = Util.get_current_service_day(now)
+    service_day_of_week = now |> Util.service_date() |> Date.day_of_week()
 
     current(q, alert_ids, now)
-    |> where([m], (is_nil(m.paused) or not m.paused) and ^current_service_day in m.days_of_week)
+    |> where([m], (is_nil(m.paused) or not m.paused) and ^service_day_of_week in m.days_of_week)
   end
 
   @doc """

--- a/lib/screenplay/util.ex
+++ b/lib/screenplay/util.ex
@@ -12,14 +12,18 @@ defmodule Screenplay.Util do
     |> String.replace("ActiveDirectory_MBTA\\", "")
   end
 
-  @spec get_current_service_day(DateTime.t()) :: integer()
-  def get_current_service_day(now \\ DateTime.utc_now()) do
-    now
-    # Shift to EST to account for possible Daylight Savings Time
+  @doc """
+  Determines the MBTA service date for a given moment. The "service day" starts/ends at 4:00am.
+  """
+  @spec service_date() :: Date.t()
+  @spec service_date(DateTime.t()) :: Date.t()
+  def service_date(datetime \\ DateTime.utc_now()) do
+    datetime
     |> DateTime.shift_zone!("America/New_York")
-    # Shift time back 3 hours to account for MBTA's 3am-3am service day
-    |> DateTime.add(-180, :minute)
-    |> Date.day_of_week()
+    |> case do
+      %DateTime{hour: hour} = dt when hour < 4 -> Date.add(dt, -1)
+      dt -> DateTime.to_date(dt)
+    end
   end
 
   @spec format_changeset_errors(changeset :: Ecto.Changeset.t()) :: String.t()

--- a/test/screenplay/util_test.exs
+++ b/test/screenplay/util_test.exs
@@ -1,0 +1,15 @@
+defmodule Screenplay.UtilTest do
+  use ExUnit.Case, async: true
+
+  alias Screenplay.Util
+
+  describe "service_date/1" do
+    test "returns the correct service date for a given datetime" do
+      # UTC is 4 hours ahead of Eastern Time in the summer
+      assert Util.service_date(~U[2025-08-08 04:00:00Z]) == ~D[2025-08-07]
+      assert Util.service_date(~U[2025-08-08 07:59:00Z]) == ~D[2025-08-07]
+      assert Util.service_date(~U[2025-08-08 08:00:00Z]) == ~D[2025-08-08]
+      assert Util.service_date(~U[2025-08-08 23:00:00Z]) == ~D[2025-08-08]
+    end
+  end
+end


### PR DESCRIPTION
Due to the addition of limited late-night service, 4:00am should now be considered the start/end of the service day.

This affects:

* when PA messages are considered to be "active" when set to only play on certain days of the week
* the time filled in by the "start/end of service day" controls when a user is creating or editing a PA message

Incidentally reworks a function that determined the current service day to behave better around time zone changes. This used `DateTime.add`, which computes a time difference based on elapsed time, not wall time; on the date of the "fall back" from EDT to EST, shifting time backwards by 3 hours from e.g. 02:30 could land at 00:30 (still on the same day, rather than the previous day as intended).

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1211034769779824