### PR TITLE
Fix redirecting to API endpoint rather than previous page

### DIFF
--- a/lib/screenplay_web/auth_manager/error_handler.ex
+++ b/lib/screenplay_web/auth_manager/error_handler.ex
@@ -9,11 +9,16 @@ defmodule ScreenplayWeb.AuthManager.ErrorHandler do
 
   @impl Guardian.Plug.ErrorHandler
   def auth_error(conn, error, _opts) do
-    if conn.request_path =~ "api" or Plug.Conn.get_session(conn, :previous_path) =~ "api" do
+    request_path = conn.request_path
+
+    if request_path =~ "api" or Plug.Conn.get_session(conn, :previous_path) =~ "api" do
       Plug.Conn.send_resp(conn, 403, "Session expired")
     else
       auth_params = auth_params_for_error(error)
-      Phoenix.Controller.redirect(conn, to: ~p"/auth/keycloak?#{auth_params}")
+
+      conn
+      |> Plug.Conn.put_session(:previous_path_from_auth, request_path)
+      |> Phoenix.Controller.redirect(to: ~p"/auth/keycloak?#{auth_params}")
     end
   end
 

--- a/lib/screenplay_web/controllers/auth_controller.ex
+++ b/lib/screenplay_web/controllers/auth_controller.ex
@@ -20,8 +20,8 @@ defmodule ScreenplayWeb.AuthController do
     roles =
       get_in(auth.extra.raw_info.userinfo, ["resource_access", keycloak_client_id, "roles"]) || []
 
-    previous_path = Plug.Conn.get_session(conn, :previous_path)
-    Plug.Conn.delete_session(conn, :previous_path)
+    previous_path = Plug.Conn.get_session(conn, :previous_path_from_auth)
+    Plug.Conn.delete_session(conn, :previous_path_from_auth)
 
     conn
     |> configure_session(drop: true)

--- a/test/screenplay_web/controllers/auth_controller_test.exs
+++ b/test/screenplay_web/controllers/auth_controller_test.exs
@@ -30,7 +30,7 @@ defmodule ScreenplayWeb.Controllers.AuthControllerTest do
         conn
         |> init_test_session(%{})
         |> assign(:ueberauth_auth, auth)
-        |> Plug.Conn.put_session(:previous_path, "/test")
+        |> Plug.Conn.put_session(:previous_path_from_auth, "/test")
         |> get(~p"/auth/keycloak/callback")
 
       assert redirected_to(conn) == "/test"


### PR DESCRIPTION
**Asana task**: [[bug] Screenplay login redirect to wrong URL](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210789861187901?focus=true)

Description
The idea here is that when we do hit an auth error, we will save the previous path from the previous request if it isn't an API request. We save it in the session and use that as the redirect after authorization. This keeps the old previous path as that is how we were forcing session reloads and continues to reassign previous path every time we go through the `:browser` pipeline. `previous_path_for_auth` though will be consumed as the redirect and removed. 

- [ ] For features with a design/UX component, deployed branch to dev-green and let product know it's ready for review.
