### PR TITLE
feat: Error handling wrapper to handle and communicate errors to user

### DIFF
--- a/assets/css/error-modal.scss
+++ b/assets/css/error-modal.scss
@@ -6,10 +6,8 @@
 
   .modal-content {
     background-color: $cool-gray-20;
-
+    white-space: pre-wrap;
     .modal-header {
-      border-bottom: none;
-
       .btn-close:hover {
         background-color: transparent;
       }

--- a/assets/js/components/App.tsx
+++ b/assets/js/components/App.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from "react";
 import { Routes, Route, BrowserRouter } from "react-router-dom";
 import { ScreenplayProvider } from "../hooks/useScreenplayContext";
 import GlEinkWorkflow from "Components/PermanentConfiguration/Workflows/GlEink/GlEinkWorkflow";
+import ErrorModal from "./Dashboard/ErrorModal";
 
 const OutfrontTakeoverTool = React.lazy(
   () => import("./OutfrontTakeoverTool/OutfrontTakeoverTool"),
@@ -69,6 +70,7 @@ const App = (): ReactElement<HTMLDivElement> => {
   return (
     <BrowserRouter>
       <AppRoutes />
+      <ErrorModal />
     </BrowserRouter>
   );
 };

--- a/assets/js/components/Dashboard/Dashboard.tsx
+++ b/assets/js/components/Dashboard/Dashboard.tsx
@@ -54,7 +54,7 @@ const Dashboard: ComponentType = () => {
 
   useEffect(() => {
     // If there are any active errors, stop refreshing alerts
-    setIsAlertsIntervalRunning(!errorState?.show);
+    setIsAlertsIntervalRunning(errorState !== null);
   }, [errorState]);
 
   // Fetch alerts every 4 seconds.

--- a/assets/js/components/Dashboard/Dashboard.tsx
+++ b/assets/js/components/Dashboard/Dashboard.tsx
@@ -10,7 +10,7 @@ import AlertBanner from "Components/AlertBanner";
 import LinkCopiedToast from "Components/LinkCopiedToast";
 import ActionOutcomeToast from "Components/ActionOutcomeToast";
 import { useLocation } from "react-router-dom";
-import ErrorModal from "Components/ErrorModal";
+import { ErrorState, subscribeToError } from "Utils/errorHandler";
 
 const Dashboard: ComponentType = () => {
   const {
@@ -26,51 +26,44 @@ const Dashboard: ComponentType = () => {
   } = useScreenplayState();
   const [bannerDone, setBannerDone] = useState(false);
   const [isAlertsIntervalRunning, setIsAlertsIntervalRunning] = useState(true);
-  const [showModal, setShowModal] = useState(false);
+  const [errorState, setErrorState] = useState<ErrorState | null>(null);
+  const subscribe = subscribeToError((error) => {
+    setErrorState(error);
+  });
 
   useEffect(() => {
-    fetchAlerts().then(
-      ({
-        all_alert_ids: allAPIalertIds,
-        alerts: newAlerts,
-        screens_by_alert: screensByAlertMap,
-      }) => {
-        findAndSetBannerAlert(alerts, newAlerts);
-        setAlerts(newAlerts, allAPIalertIds, screensByAlertMap);
-      },
-    );
+    const loadInitialData = async () => {
+      await updateAlertsData();
+      // Load places and line stops with error handling
 
-    fetchPlaces().then(setPlaces);
+      const placesData = await fetchPlaces();
+      if (placesData) {
+        setPlaces(placesData);
+      }
 
-    fetchLineStops().then(setLineStops);
+      const lineStopsData = await fetchLineStops();
+      if (lineStopsData) {
+        setLineStops(lineStopsData);
+      }
+    };
+
+    loadInitialData();
 
     // Tests rely on this effect **not** having any dependencies listed.
     // This code pre-dates the addition of the react-hooks eslint rules.
     // - sloane 2024-08-20
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  useEffect(() => {
+    // If there are any active errors, stop refreshing alerts
+    setIsAlertsIntervalRunning(!errorState?.show);
+  }, [errorState, subscribe]);
+
   // Fetch alerts every 4 seconds.
+  // Unlike line and stop data dispalyed on dashboard, alerts are subject to frequent updates
   useInterval(
-    () => {
-      fetchAlerts()
-        .then(
-          ({
-            all_alert_ids: allAPIalertIds,
-            alerts: newAlerts,
-            screens_by_alert: screensByAlertMap,
-          }) => {
-            findAndSetBannerAlert(alerts, newAlerts);
-            setAlerts(newAlerts, allAPIalertIds, screensByAlertMap);
-          },
-        )
-        .catch((response: Response) => {
-          if (response.status === 403) {
-            setIsAlertsIntervalRunning(false);
-            setShowModal(true);
-          } else {
-            throw response;
-          }
-        });
+    async () => {
+      await updateAlertsData();
     },
     isAlertsIntervalRunning ? 4000 : null,
   );
@@ -112,6 +105,19 @@ const Dashboard: ComponentType = () => {
         new Date(existingStartAtOrNull.getTime() + 40000).getTime()
     ) {
       setBannerDone(true);
+    }
+  };
+
+  const updateAlertsData = async () => {
+    const alertsData = await fetchAlerts();
+    if (alertsData) {
+      const {
+        all_alert_ids: allAPIalertIds,
+        alerts: newAlerts,
+        screens_by_alert: screensByAlertMap,
+      } = alertsData;
+      findAndSetBannerAlert(alerts, newAlerts);
+      setAlerts(newAlerts, allAPIalertIds, screensByAlertMap);
     }
   };
 
@@ -169,14 +175,6 @@ const Dashboard: ComponentType = () => {
         )}
         <Outlet />
       </div>
-      <ErrorModal
-        title="Session expired"
-        showErrorModal={showModal}
-        onHide={() => setShowModal(false)}
-        errorMessage="Your session has expired, please refresh your browser."
-        confirmButtonLabel="Refresh now"
-        onConfirm={() => window.location.reload()}
-      />
     </div>
   );
 };

--- a/assets/js/components/Dashboard/Dashboard.tsx
+++ b/assets/js/components/Dashboard/Dashboard.tsx
@@ -3,6 +3,7 @@ import { Outlet } from "react-router";
 import "../../../css/screenplay.scss";
 import { Alert } from "Models/alert";
 import Sidebar from "Components/Sidebar";
+import { useErrorState } from "Hooks/useErrorState";
 import { useScreenplayState } from "Hooks/useScreenplayContext";
 import { useInterval } from "Hooks/useInterval";
 import { fetchAlerts, fetchPlaces, fetchLineStops } from "Utils/api";
@@ -10,11 +11,6 @@ import AlertBanner from "Components/AlertBanner";
 import LinkCopiedToast from "Components/LinkCopiedToast";
 import ActionOutcomeToast from "Components/ActionOutcomeToast";
 import { useLocation } from "react-router-dom";
-import {
-  ErrorState,
-  subscribeToErrorState,
-  unsubscribeFromErrorState,
-} from "Utils/errorHandler";
 
 const Dashboard: ComponentType = () => {
   const {
@@ -30,20 +26,8 @@ const Dashboard: ComponentType = () => {
   } = useScreenplayState();
   const [bannerDone, setBannerDone] = useState(false);
   const [isAlertsIntervalRunning, setIsAlertsIntervalRunning] = useState(true);
-  const [errorState, setErrorState] = useState<ErrorState | null>(null);
 
-  useEffect(() => {
-    // On render, set Error State to initial null value and subscribe to receive any updates
-    const errorListener = (errorState: ErrorState | null) => {
-      setErrorState(errorState);
-    };
-    subscribeToErrorState(errorListener);
-
-    // Cleanup subscription on unmount
-    return () => {
-      unsubscribeFromErrorState(errorListener);
-    };
-  });
+  const { errorState } = useErrorState();
 
   useEffect(() => {
     const loadInitialData = async () => {

--- a/assets/js/components/Dashboard/Dashboard.tsx
+++ b/assets/js/components/Dashboard/Dashboard.tsx
@@ -10,7 +10,11 @@ import AlertBanner from "Components/AlertBanner";
 import LinkCopiedToast from "Components/LinkCopiedToast";
 import ActionOutcomeToast from "Components/ActionOutcomeToast";
 import { useLocation } from "react-router-dom";
-import { ErrorState, subscribeToError } from "Utils/errorHandler";
+import {
+  ErrorState,
+  subscribeToErrorState,
+  unsubscribeFromErrorState,
+} from "Utils/errorHandler";
 
 const Dashboard: ComponentType = () => {
   const {
@@ -27,8 +31,18 @@ const Dashboard: ComponentType = () => {
   const [bannerDone, setBannerDone] = useState(false);
   const [isAlertsIntervalRunning, setIsAlertsIntervalRunning] = useState(true);
   const [errorState, setErrorState] = useState<ErrorState | null>(null);
-  const subscribe = subscribeToError((error) => {
-    setErrorState(error);
+
+  useEffect(() => {
+    // On render, set Error State to initial null value and subscribe to receive any updates
+    const errorListener = (errorState: ErrorState | null) => {
+      setErrorState(errorState);
+    };
+    subscribeToErrorState(errorListener);
+
+    // Cleanup subscription on unmount
+    return () => {
+      unsubscribeFromErrorState(errorListener);
+    };
   });
 
   useEffect(() => {
@@ -57,7 +71,7 @@ const Dashboard: ComponentType = () => {
   useEffect(() => {
     // If there are any active errors, stop refreshing alerts
     setIsAlertsIntervalRunning(!errorState?.show);
-  }, [errorState, subscribe]);
+  }, [errorState]);
 
   // Fetch alerts every 4 seconds.
   // Unlike line and stop data dispalyed on dashboard, alerts are subject to frequent updates

--- a/assets/js/components/Dashboard/ErrorModal.tsx
+++ b/assets/js/components/Dashboard/ErrorModal.tsx
@@ -1,32 +1,14 @@
 import React, { useEffect, useState } from "react";
 import { Button, Modal } from "react-bootstrap";
-import {
-  clearErrorState,
-  subscribeToErrorState,
-  ErrorState,
-  unsubscribeFromErrorState,
-} from "Utils/errorHandler";
+import { useErrorState } from "Hooks/useErrorState";
+import { clearErrorState } from "Utils/errorHandler";
 
 interface ErrorModalProps {
   className?: string;
 }
 
 const ErrorModal: React.FC<ErrorModalProps> = () => {
-  // Initialize error state as null
-  const [errorState, setErrorState] = useState<ErrorState | null>(null);
-
-  useEffect(() => {
-    // On render, set Error State to initial value of null and subscribe to receive any updates
-    const errorListener = (errorState: ErrorState | null) => {
-      setErrorState(errorState);
-    };
-    subscribeToErrorState(errorListener);
-
-    // Cleanup subscription on unmount
-    return () => {
-      unsubscribeFromErrorState(errorListener);
-    };
-  });
+  const { errorState } = useErrorState();
 
   const handleDismiss = () => {
     if (errorState?.onDismiss) {

--- a/assets/js/components/Dashboard/ErrorModal.tsx
+++ b/assets/js/components/Dashboard/ErrorModal.tsx
@@ -2,9 +2,9 @@ import React, { useEffect, useState } from "react";
 import { Button, Modal } from "react-bootstrap";
 import {
   clearErrorState,
-  getErrorState,
-  subscribeToError,
+  subscribeToErrorState,
   ErrorState,
+  unsubscribeFromErrorState,
 } from "Utils/errorHandler";
 
 interface ErrorModalProps {
@@ -12,16 +12,21 @@ interface ErrorModalProps {
 }
 
 const ErrorModal: React.FC<ErrorModalProps> = () => {
+  // Initialize error state as null
   const [errorState, setErrorState] = useState<ErrorState | null>(null);
-  const subscribe = subscribeToError((error) => {
-    setErrorState(error);
-  });
 
   useEffect(() => {
-    // Set initial state
-    setErrorState(getErrorState());
-    return subscribe;
-  }, [errorState, subscribe]);
+    // On render, set Error State to initial value of null and subscribe to receive any updates
+    const errorListener = (errorState: ErrorState | null) => {
+      setErrorState(errorState);
+    };
+    subscribeToErrorState(errorListener);
+
+    // Cleanup subscription on unmount
+    return () => {
+      unsubscribeFromErrorState(errorListener);
+    };
+  });
 
   const handleDismiss = () => {
     if (errorState?.onDismiss) {

--- a/assets/js/components/Dashboard/ErrorModal.tsx
+++ b/assets/js/components/Dashboard/ErrorModal.tsx
@@ -22,7 +22,10 @@ const ErrorModal: React.FC<ErrorModalProps> = () => {
       </Modal.Header>
       <Modal.Body>{errorState?.messageToDisplay}</Modal.Body>
       <Modal.Footer>
-        <Button onClick={clearErrorState} className="error-modal__cancel-button">
+        <Button
+          onClick={clearErrorState}
+          className="error-modal__cancel-button"
+        >
           Cancel
         </Button>
       </Modal.Footer>

--- a/assets/js/components/Dashboard/ErrorModal.tsx
+++ b/assets/js/components/Dashboard/ErrorModal.tsx
@@ -10,44 +10,21 @@ interface ErrorModalProps {
 const ErrorModal: React.FC<ErrorModalProps> = () => {
   const { errorState } = useErrorState();
 
-  const handleDismiss = () => {
-    if (errorState?.onDismiss) {
-      errorState.onDismiss();
-    }
-    clearErrorState();
-  };
-
-  const handleRetry = () => {
-    if (errorState?.onRetry) {
-      errorState.onRetry();
-    }
-    clearErrorState();
-  };
-
-  if (!errorState?.show) {
-    return null;
-  }
-
   return (
     <Modal
-      show={errorState.show}
+      show={errorState !== null}
       className="error-modal"
       backdrop="static"
-      onHide={handleDismiss}
+      onHide={clearErrorState}
     >
       <Modal.Header closeButton closeVariant="white">
-        {errorState.title && <Modal.Title>{errorState.title}</Modal.Title>}
+        {errorState?.title && <Modal.Title>{errorState?.title}</Modal.Title>}
       </Modal.Header>
-      <Modal.Body>{errorState.messageToDisplay}</Modal.Body>
+      <Modal.Body>{errorState?.messageToDisplay}</Modal.Body>
       <Modal.Footer>
-        <Button onClick={handleDismiss} className="error-modal__cancel-button">
+        <Button onClick={clearErrorState} className="error-modal__cancel-button">
           Cancel
         </Button>
-        {errorState.onRetry && (
-          <Button className="error-modal__refresh-button" onClick={handleRetry}>
-            Refresh
-          </Button>
-        )}
       </Modal.Footer>
     </Modal>
   );

--- a/assets/js/components/Dashboard/ErrorModal.tsx
+++ b/assets/js/components/Dashboard/ErrorModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Button, Modal } from "react-bootstrap";
 import { useErrorState } from "Hooks/useErrorState";
 import { clearErrorState } from "Utils/errorHandler";

--- a/assets/js/components/Dashboard/PaMessageForm/AssociateAlert.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/AssociateAlert.tsx
@@ -29,7 +29,7 @@ const AssociateAlert = ({ onApply, onCancel }: AssociateAlertPageProps) => {
   useEffect(() => {
     fetchActiveAndFutureAlerts().then((data) => {
       if (data) {
-      setAlerts(data.alerts);
+        setAlerts(data.alerts);
       }
     });
   }, []);

--- a/assets/js/components/Dashboard/PaMessageForm/AssociateAlert.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/AssociateAlert.tsx
@@ -27,8 +27,10 @@ const AssociateAlert = ({ onApply, onCancel }: AssociateAlertPageProps) => {
   useHideSidebar();
 
   useEffect(() => {
-    fetchActiveAndFutureAlerts().then(({ alerts: alerts }) => {
-      setAlerts(alerts);
+    fetchActiveAndFutureAlerts().then((data) => {
+      if (data) {
+      setAlerts(data.alerts);
+      }
     });
   }, []);
 

--- a/assets/js/components/Dashboard/PendingScreensPage.tsx
+++ b/assets/js/components/Dashboard/PendingScreensPage.tsx
@@ -113,7 +113,9 @@ const PendingScreensPage: ComponentType = () => {
     ],
   );
 
-  useEffect(() => { fetchData();}, [fetchData]);
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
 
   const screens = Object.entries(existingScreens);
   let layout;

--- a/assets/js/components/Dashboard/PendingScreensPage.tsx
+++ b/assets/js/components/Dashboard/PendingScreensPage.tsx
@@ -35,16 +35,16 @@ const PendingScreensPage: ComponentType = () => {
 
   const navigate = useNavigate();
 
-  const fetchData = useCallback(() => {
-    fetchExistingScreensAtPlacesWithPendingScreens().then(
-      ({ places_and_screens, etag, last_modified_ms }) => {
-        setExistingScreens(places_and_screens);
-        setEtag(etag);
-        if (last_modified_ms !== null) {
-          setLastModified(new Date(last_modified_ms));
-        }
-      },
-    );
+  const fetchData = useCallback(async () => {
+    const data = await fetchExistingScreensAtPlacesWithPendingScreens();
+    if (data) {
+      const { places_and_screens, etag, last_modified_ms } = data;
+      setExistingScreens(places_and_screens);
+      setEtag(etag);
+      if (last_modified_ms !== null) {
+        setLastModified(new Date(last_modified_ms));
+      }
+    }
   }, [setExistingScreens, setEtag, setLastModified]);
 
   const publish = useCallback(

--- a/assets/js/components/Dashboard/PendingScreensPage.tsx
+++ b/assets/js/components/Dashboard/PendingScreensPage.tsx
@@ -113,7 +113,7 @@ const PendingScreensPage: ComponentType = () => {
     ],
   );
 
-  useEffect(fetchData, [fetchData]);
+  useEffect(() => { fetchData();}, [fetchData]);
 
   const screens = Object.entries(existingScreens);
   let layout;

--- a/assets/js/components/Dashboard/PermanentConfiguration/Workflows/GlEink/ConfigureScreensPage.tsx
+++ b/assets/js/components/Dashboard/PermanentConfiguration/Workflows/GlEink/ConfigureScreensPage.tsx
@@ -109,10 +109,13 @@ const ConfigureScreensWorkflowPage: ComponentType<
       fetchExistingScreens(
         "gl_eink_v2",
         selectedPlaces.map((place) => place.id),
-      ).then(({ places_and_screens, version_id }) => {
-        initializeExistingScreenValidationErrors(places_and_screens);
-        setConfigVersion(version_id);
-        setExistingScreens(places_and_screens);
+      ).then((data) => {
+        if (data) {
+          const { places_and_screens, version_id } = data;
+          initializeExistingScreenValidationErrors(places_and_screens);
+          setConfigVersion(version_id);
+          setExistingScreens(places_and_screens);
+        }
       });
     }
   }, [

--- a/assets/js/components/OutfrontTakeoverTool/AlertDashboard/AlertsList.tsx
+++ b/assets/js/components/OutfrontTakeoverTool/AlertDashboard/AlertsList.tsx
@@ -6,7 +6,7 @@ import { NoSymbolIcon } from "@heroicons/react/20/solid";
 import { PastAlertsList } from "./PastAlertsList";
 import ReactTooltip from "react-tooltip";
 import { BASE_URL } from "Constants/constants";
-import { withErrorHandlingDisplayError } from "Utils/errorHandler";
+import { withErrorHandling } from "Utils/errorHandler";
 
 interface AlertsListProps {
   startEditWizard: (data: AlertData, step: number) => void;
@@ -19,21 +19,27 @@ const AlertsList = (props: AlertsListProps): JSX.Element => {
   const [pastAlertsData, setPastAlertsData] = useState([]);
   const [lastChangeTime, setLastChangeTime] = useState(Date.now());
 
-  const fetchActiveAlerts = withErrorHandlingDisplayError(async () => {
-    const response = await fetch(`${BASE_URL}/active_alerts`);
-    if (!response.ok) {
-      throw response;
-    }
-    return response.json();
-  }, "Failed to load active alerts. Please refresh the page.");
+  const fetchActiveAlerts = withErrorHandling(
+    async () => {
+      const response = await fetch(`${BASE_URL}/active_alerts`);
+      if (!response.ok) {
+        throw response;
+      }
+      return response.json();
+    },
+    { customMessage: "Failed to load active alerts. Please refresh the page." },
+  );
 
-  const fetchPastAlerts = withErrorHandlingDisplayError(async () => {
-    const response = await fetch(`${BASE_URL}/past_alerts`);
-    if (!response.ok) {
-      throw response;
-    }
-    return response.json();
-  }, "Failed to load past alerts. Please refresh the page.");
+  const fetchPastAlerts = withErrorHandling(
+    async () => {
+      const response = await fetch(`${BASE_URL}/past_alerts`);
+      if (!response.ok) {
+        throw response;
+      }
+      return response.json();
+    },
+    { customMessage: "Failed to load past alerts. Please refresh the page." },
+  );
 
   useEffect(() => {
     const loadActiveAlerts = async () => {

--- a/assets/js/components/OutfrontTakeoverTool/AlertDashboard/AlertsList.tsx
+++ b/assets/js/components/OutfrontTakeoverTool/AlertDashboard/AlertsList.tsx
@@ -6,6 +6,7 @@ import { NoSymbolIcon } from "@heroicons/react/20/solid";
 import { PastAlertsList } from "./PastAlertsList";
 import ReactTooltip from "react-tooltip";
 import { BASE_URL } from "Constants/constants";
+import { withErrorHandlingDisplayError } from "Utils/errorHandler";
 
 interface AlertsListProps {
   startEditWizard: (data: AlertData, step: number) => void;
@@ -18,17 +19,42 @@ const AlertsList = (props: AlertsListProps): JSX.Element => {
   const [pastAlertsData, setPastAlertsData] = useState([]);
   const [lastChangeTime, setLastChangeTime] = useState(Date.now());
 
-  useEffect(() => {
-    fetch(`${BASE_URL}/active_alerts`)
-      .then((response) => response.json())
-      .then(setAlertsData);
-  }, [lastChangeTime]);
+  const fetchActiveAlerts = withErrorHandlingDisplayError(async () => {
+    const response = await fetch(`${BASE_URL}/active_alerts`);
+    if (!response.ok) {
+      throw response;
+    }
+    return response.json();
+  }, "Failed to load active alerts. Please refresh the page.");
+
+  const fetchPastAlerts = withErrorHandlingDisplayError(async () => {
+    const response = await fetch(`${BASE_URL}/past_alerts`);
+    if (!response.ok) {
+      throw response;
+    }
+    return response.json();
+  }, "Failed to load past alerts. Please refresh the page.");
 
   useEffect(() => {
-    fetch(`${BASE_URL}/past_alerts`)
-      .then((response) => response.json())
-      .then(setPastAlertsData);
-  }, [lastChangeTime]);
+    const loadActiveAlerts = async () => {
+      const data = await fetchActiveAlerts();
+      if (data) {
+        setAlertsData(data);
+      }
+    };
+    loadActiveAlerts();
+  }, [fetchActiveAlerts, lastChangeTime]);
+
+  useEffect(() => {
+    // TODO: I don't love this way of doing it, but have it working and moving on for now
+    const loadPastAlerts = async () => {
+      const data = await fetchPastAlerts();
+      if (data) {
+        setPastAlertsData(data);
+      }
+    };
+    loadPastAlerts();
+  }, [fetchPastAlerts, lastChangeTime]);
 
   useEffect(() => {
     setTimeout(() => setLastChangeTime(Date.now()), 60000);

--- a/assets/js/constants/constants.ts
+++ b/assets/js/constants/constants.ts
@@ -79,3 +79,6 @@ export const BASE_ROUTE_NAME_TO_ROUTE_IDS: { [key: string]: string[] } = {
   Mattapan: ["Mattapan"],
   Silver: SILVER_LINE_ROUTES,
 };
+
+export const REFRESH_PAGE_ERROR_MESSAGE =
+  "Please refresh the page and contact engineering if the issue persists.";

--- a/assets/js/hello.ts
+++ b/assets/js/hello.ts
@@ -1,5 +1,0 @@
-function greet(name: string): string {
-  return "Welcome to " + name + " with Typescript!";
-}
-
-export default greet;

--- a/assets/js/hooks/useErrorState.tsx
+++ b/assets/js/hooks/useErrorState.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+import {
+  ErrorState,
+  subscribeToErrorState,
+  unsubscribeFromErrorState,
+} from "../utils/errorHandler";
+
+export const useErrorState = () => {
+  const [errorState, setErrorState] = useState<ErrorState | null>(null);
+  useEffect(() => {
+    // On render, set Error State to initial null value and subscribe to receive any updates
+    const errorListener = (errorState: ErrorState | null) => {
+      setErrorState(errorState);
+    };
+    subscribeToErrorState(errorListener);
+
+    // Cleanup subscription on unmount
+    return () => {
+      unsubscribeFromErrorState(errorListener);
+    };
+  });
+
+  return { errorState };
+};

--- a/assets/js/utils/api.ts
+++ b/assets/js/utils/api.ts
@@ -8,12 +8,10 @@ import getCsrfToken from "../csrf";
 import { NewPaMessageBody, UpdatePaMessageBody } from "Models/pa_message";
 import { SuppressedPrediction } from "Models/suppressed_prediction";
 import { withErrorHandling } from "./errorHandler";
+import { REFRESH_PAGE_ERROR_MESSAGE } from "Constants/constants";
 
 const API_ENDPOINT_PREDICTION_SUPPRESSION = "/api/suppressed-predictions";
 const API_ENDPOINT_PA_MESSAGES = "/api/pa-messages";
-
-const REFRESH_PAGE_ERROR_MESSAGE =
-  "Please refresh the page and contact engineering if the issue persists.";
 
 /////////////////////
 // Location Fetching

--- a/assets/js/utils/api.ts
+++ b/assets/js/utils/api.ts
@@ -7,38 +7,81 @@ import { PlaceIdsAndNewScreens } from "../components/Dashboard/PermanentConfigur
 import getCsrfToken from "../csrf";
 import { NewPaMessageBody, UpdatePaMessageBody } from "Models/pa_message";
 import { SuppressedPrediction } from "Models/suppressed_prediction";
+import { withErrorHandlingDisplayError } from "./errorHandler";
 
-export const fetchPlaces = async (): Promise<Place[]> => {
+const API_ENDPOINT_PREDICTION_SUPPRESSION = "/api/suppressed-predictions";
+const API_ENDPOINT_PA_MESSAGES = "/api/pa-messages";
+
+const REFRESH_PAGE_ERROR_MESSAGE =
+  "Please refresh the page and contact engineering if the issue persists.";
+
+/////////////////////
+// Location Fetching
+////////////////////
+const _fetchPlaces = async (): Promise<Place[]> => {
   const response = await fetch("/api/dashboard");
-  return await response.json();
+  if (!response.ok) {
+    throw response;
+  }
+  return response.json();
 };
 
-export const fetchLineStops = async () => {
+const _fetchLineStops = async () => {
   const response = await fetch("/api/line_stops");
+  if (response.ok) {
+    throw response;
+  }
   const { data } = await response.json();
   return data;
 };
 
+export const fetchPlaces = withErrorHandlingDisplayError(
+  _fetchPlaces,
+  `Failed to load places data. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+);
+
+export const fetchLineStops = withErrorHandlingDisplayError(
+  _fetchLineStops,
+  `Failed to load line stops data. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+);
+
+///////////
+// Alerts
+///////////
 interface AlertsResponse {
   all_alert_ids: string[];
   alerts: Alert[];
   screens_by_alert: ScreensByAlert;
 }
 
-export const fetchAlerts = async (): Promise<AlertsResponse> => {
+export const _fetchAlerts = async (): Promise<AlertsResponse> => {
   const response = await fetch("/api/alerts");
   if (response.status === 200) {
-    return await response.json();
+    return response.json();
   } else {
     throw response;
   }
 };
 
-export const fetchActiveAndFutureAlerts = async (): Promise<AlertsResponse> => {
-  const response = await fetch("/api/alerts/non_access_alerts");
-  return await response.json();
-};
+export const _fetchActiveAndFutureAlerts =
+  async (): Promise<AlertsResponse> => {
+    const response = await fetch("/api/alerts/non_access_alerts");
+    return response.json();
+  };
 
+export const fetchActiveAndFutureAlerts = withErrorHandlingDisplayError(
+  _fetchActiveAndFutureAlerts,
+  `Failed to load active alerts. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+);
+
+export const fetchAlerts = withErrorHandlingDisplayError(
+  _fetchAlerts,
+  `Failed to load alerts. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+);
+
+///////////
+// Screens
+///////////
 export interface ExistingScreens {
   [place_id: string]: ExistingScreensAtPlace;
 }
@@ -48,7 +91,7 @@ export interface ExistingScreensAtPlace {
   pending_screens: { [screen_id: string]: ScreenConfiguration };
 }
 
-export const fetchExistingScreens = async (
+const _fetchExistingScreens = async (
   appId: string,
   placeIds: string[],
 ): Promise<{ places_and_screens: ExistingScreens; version_id: string }> => {
@@ -56,9 +99,17 @@ export const fetchExistingScreens = async (
     `/config/existing-screens/${appId}?place_ids=${placeIds.join(",")}`,
   );
 
-  return await response.json();
+  if (!response.ok) {
+    throw response;
+  }
+
+  return response.json();
 };
 
+export const fetchExistingScreens = withErrorHandlingDisplayError(
+  _fetchExistingScreens,
+  `Failed to load existing screens. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+);
 export interface PendingAndLiveScreensResponse {
   places_and_screens: PendingAndLiveScreens;
   etag: string;
@@ -76,26 +127,34 @@ export interface PendingAndLiveScreens {
   };
 }
 
-export const fetchExistingScreensAtPlacesWithPendingScreens =
+const _fetchExistingScreensAtPlacesWithPendingScreens =
   async (): Promise<PendingAndLiveScreensResponse> => {
     const response = await fetch(
       "/config/existing-screens-at-places-with-pending-screens",
     );
+    if (!response.ok) {
+      throw response;
+    }
     const etag = response.headers.get("etag") as string;
     const data = (await response.json()) as Omit<
       PendingAndLiveScreensResponse,
       "etag"
     >;
-
     return { ...data, etag };
   };
+
+export const fetchExistingScreensAtPlacesWithPendingScreens =
+  withErrorHandlingDisplayError(
+    _fetchExistingScreensAtPlacesWithPendingScreens,
+    `Failed to load pending screens data. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+  );
 
 export const putPendingScreens = async (
   placesAndScreens: PlaceIdsAndNewScreens,
   screenType: "gl_eink_v2" | null,
   version_id: string,
 ): Promise<Response> => {
-  return await fetch("/config/put", {
+  return fetch("/config/put", {
     ...getPostBodyAndHeaders({
       places_and_screens: placesAndScreens,
       screen_type: screenType,
@@ -136,7 +195,7 @@ export const publishScreensForPlace = async (
 export const createNewPaMessage = async (
   message: NewPaMessageBody,
 ): Promise<{ status: number; errors: any }> => {
-  const response = await fetch("/api/pa-messages", {
+  const response = await fetch(API_ENDPOINT_PA_MESSAGES, {
     ...getPostBodyAndHeaders(message),
     credentials: "include",
   });
@@ -151,7 +210,7 @@ export const updateExistingPaMessage = async (
   id: string | number,
   updates: UpdatePaMessageBody,
 ): Promise<{ status: number; body: any }> => {
-  const response = await fetch(`/api/pa-messages/${id}`, {
+  const response = await fetch(`${API_ENDPOINT_PA_MESSAGES}${id}`, {
     method: "PUT",
     credentials: "include",
     headers: {
@@ -199,28 +258,42 @@ const fetchOk = async (
   return res.json();
 };
 
-export const getSuppressedPredictions = async () => {
-  const res = await fetch("/api/suppressed-predictions");
+const _getSuppressedPredictions = async () => {
+  const res = await fetch(API_ENDPOINT_PREDICTION_SUPPRESSION);
   if (!res.ok) {
     throw res;
   }
   return res.json();
 };
 
-export const createSuppressedPrediction = (data: SuppressedPrediction) => {
-  return fetchOk("/api/suppressed-predictions", { body: data, method: "POST" });
-};
+export const getSuppressedPredictions = withErrorHandlingDisplayError(
+  _getSuppressedPredictions,
+  `Failed to load suppressed predictions. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+);
 
-export const deleteSuppressedPrediction = (data: SuppressedPrediction) => {
-  return fetchOk("/api/suppressed-predictions", {
-    body: data,
-    method: "DELETE",
-  });
-};
+export const createSuppressedPrediction = withErrorHandlingDisplayError(
+  (data: SuppressedPrediction) =>
+    fetchOk(API_ENDPOINT_PREDICTION_SUPPRESSION, {
+      body: data,
+      method: "POST",
+    }),
+  `Failed to create a prediction supression. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+);
 
-export const updateSuppressedPrediction = (data: SuppressedPrediction) => {
-  return fetchOk("/api/suppressed-predictions", { body: data, method: "PUT" });
-};
+export const deleteSuppressedPrediction = withErrorHandlingDisplayError(
+  (data: SuppressedPrediction) =>
+    fetchOk(API_ENDPOINT_PREDICTION_SUPPRESSION, {
+      body: data,
+      method: "DELETE",
+    }),
+  `Failed to delete the prediction supression. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+);
+
+export const updateSuppressedPrediction = withErrorHandlingDisplayError(
+  (data: SuppressedPrediction) =>
+    fetchOk(API_ENDPOINT_PREDICTION_SUPPRESSION, { body: data, method: "PUT" }),
+  `Failed to update theprediction supression. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+);
 
 const getPostBodyAndHeaders = (
   bodyData: { [key: string]: any },

--- a/assets/js/utils/api.ts
+++ b/assets/js/utils/api.ts
@@ -7,7 +7,7 @@ import { PlaceIdsAndNewScreens } from "../components/Dashboard/PermanentConfigur
 import getCsrfToken from "../csrf";
 import { NewPaMessageBody, UpdatePaMessageBody } from "Models/pa_message";
 import { SuppressedPrediction } from "Models/suppressed_prediction";
-import { withErrorHandlingDisplayError } from "./errorHandler";
+import { withErrorHandling } from "./errorHandler";
 
 const API_ENDPOINT_PREDICTION_SUPPRESSION = "/api/suppressed-predictions";
 const API_ENDPOINT_PA_MESSAGES = "/api/pa-messages";
@@ -28,22 +28,20 @@ const _fetchPlaces = async (): Promise<Place[]> => {
 
 const _fetchLineStops = async () => {
   const response = await fetch("/api/line_stops");
-  if (response.ok) {
+  if (!response.ok) {
     throw response;
   }
   const { data } = await response.json();
   return data;
 };
 
-export const fetchPlaces = withErrorHandlingDisplayError(
-  _fetchPlaces,
-  `Failed to load places data. ${REFRESH_PAGE_ERROR_MESSAGE}`,
-);
+export const fetchPlaces = withErrorHandling(_fetchPlaces, {
+  customMessage: `Failed to load places data. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+});
 
-export const fetchLineStops = withErrorHandlingDisplayError(
-  _fetchLineStops,
-  `Failed to load line stops data. ${REFRESH_PAGE_ERROR_MESSAGE}`,
-);
+export const fetchLineStops = withErrorHandling(_fetchLineStops, {
+  customMessage: `Failed to load line stops data. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+});
 
 ///////////
 // Alerts
@@ -69,15 +67,16 @@ export const _fetchActiveAndFutureAlerts =
     return response.json();
   };
 
-export const fetchActiveAndFutureAlerts = withErrorHandlingDisplayError(
+export const fetchActiveAndFutureAlerts = withErrorHandling(
   _fetchActiveAndFutureAlerts,
-  `Failed to load active alerts. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+  {
+    customMessage: `Failed to load active alerts. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+  },
 );
 
-export const fetchAlerts = withErrorHandlingDisplayError(
-  _fetchAlerts,
-  `Failed to load alerts. ${REFRESH_PAGE_ERROR_MESSAGE}`,
-);
+export const fetchAlerts = withErrorHandling(_fetchAlerts, {
+  customMessage: `Failed to load alerts. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+});
 
 ///////////
 // Screens
@@ -106,10 +105,9 @@ const _fetchExistingScreens = async (
   return response.json();
 };
 
-export const fetchExistingScreens = withErrorHandlingDisplayError(
-  _fetchExistingScreens,
-  `Failed to load existing screens. ${REFRESH_PAGE_ERROR_MESSAGE}`,
-);
+export const fetchExistingScreens = withErrorHandling(_fetchExistingScreens, {
+  customMessage: `Failed to load existing screens. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+});
 export interface PendingAndLiveScreensResponse {
   places_and_screens: PendingAndLiveScreens;
   etag: string;
@@ -143,11 +141,12 @@ const _fetchExistingScreensAtPlacesWithPendingScreens =
     return { ...data, etag };
   };
 
-export const fetchExistingScreensAtPlacesWithPendingScreens =
-  withErrorHandlingDisplayError(
-    _fetchExistingScreensAtPlacesWithPendingScreens,
-    `Failed to load pending screens data. ${REFRESH_PAGE_ERROR_MESSAGE}`,
-  );
+export const fetchExistingScreensAtPlacesWithPendingScreens = withErrorHandling(
+  _fetchExistingScreensAtPlacesWithPendingScreens,
+  {
+    customMessage: `Failed to load pending screens data. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+  },
+);
 
 export const putPendingScreens = async (
   placesAndScreens: PlaceIdsAndNewScreens,
@@ -266,33 +265,41 @@ const _getSuppressedPredictions = async () => {
   return res.json();
 };
 
-export const getSuppressedPredictions = withErrorHandlingDisplayError(
+export const getSuppressedPredictions = withErrorHandling(
   _getSuppressedPredictions,
-  `Failed to load suppressed predictions. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+  {
+    customMessage: `Failed to load suppressed predictions. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+  },
 );
 
-export const createSuppressedPrediction = withErrorHandlingDisplayError(
+export const createSuppressedPrediction = withErrorHandling(
   (data: SuppressedPrediction) =>
     fetchOk(API_ENDPOINT_PREDICTION_SUPPRESSION, {
       body: data,
       method: "POST",
     }),
-  `Failed to create a prediction supression. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+  {
+    customMessage: `Failed to create a prediction supression. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+  },
 );
 
-export const deleteSuppressedPrediction = withErrorHandlingDisplayError(
+export const deleteSuppressedPrediction = withErrorHandling(
   (data: SuppressedPrediction) =>
     fetchOk(API_ENDPOINT_PREDICTION_SUPPRESSION, {
       body: data,
       method: "DELETE",
     }),
-  `Failed to delete the prediction supression. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+  {
+    customMessage: `Failed to delete the prediction supression. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+  },
 );
 
-export const updateSuppressedPrediction = withErrorHandlingDisplayError(
+export const updateSuppressedPrediction = withErrorHandling(
   (data: SuppressedPrediction) =>
     fetchOk(API_ENDPOINT_PREDICTION_SUPPRESSION, { body: data, method: "PUT" }),
-  `Failed to update theprediction supression. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+  {
+    customMessage: `Failed to update theprediction supression. ${REFRESH_PAGE_ERROR_MESSAGE}`,
+  },
 );
 
 const getPostBodyAndHeaders = (

--- a/assets/js/utils/errorHandler.tsx
+++ b/assets/js/utils/errorHandler.tsx
@@ -1,23 +1,16 @@
 export interface ErrorHandlingOptions {
-  /** Whether to show an error modal for this error */
-  showErrorModal?: boolean;
   /** Custom error message to display */
   customMessage?: string;
   /** Cutstom error title to display */
   customTitle?: string;
-  /** Whether to log the error to console */
-  logError?: boolean;
   /** Custom error handler function */
   onError?: (error: Error | Response) => void;
 }
 
 export interface ErrorState {
-  show: boolean;
   messageToDisplay: string;
   errorMessages?: string[];
   title: string;
-  onRetry?: () => void;
-  onDismiss: () => void;
 }
 
 // Error state management: getting, setting, clearing.
@@ -58,8 +51,7 @@ export const unsubscribeFromErrorState = (
 };
 
 /**
- * Wrapper for operations to handle errors and either fail silently or display an error modal.
- * Defaults to displaying the error modal on first failure
+ * Wrapper for operations to handle errors and display an error modal in case of failure.
  * @param asyncFunction - the function that should be tried
  * @param options - ErrorHandlingOptions
  */
@@ -68,15 +60,13 @@ export const withErrorHandling = <T extends any[], R>(
   options: ErrorHandlingOptions = {},
 ) => {
   return async (...args: T): Promise<R | null> => {
-    const { showErrorModal = true, logError = true, onError } = options;
+    const { onError } = options;
 
     try {
       const result = await asyncFunction(...args);
       return result;
     } catch (error) {
-      if (logError) {
-        console.error(`Error in ${asyncFunction.name}:`, error);
-      }
+      console.error(`Error in ${asyncFunction.name}:`, error);
 
       // If there's no handling specified and it's a session expiration error,
       // then we want to refresh the page after displaying the error
@@ -86,9 +76,8 @@ export const withErrorHandling = <T extends any[], R>(
         };
       }
 
-      if (showErrorModal) {
-        displayErrorModal(error as Error | Response, options);
-      }
+      displayErrorModal(error as Error | Response, options);
+
       return null;
     }
   };
@@ -101,6 +90,7 @@ export const displayErrorModal = (
   error: Error | Response,
   options: ErrorHandlingOptions = {},
 ) => {
+  console.log('test')
   const { customMessage, customTitle, onError } = options;
 
   const message = customMessage ?? getErrorMessage(error);
@@ -115,11 +105,9 @@ export const displayErrorModal = (
   }
 
   setErrorState({
-    show: true,
     errorMessages: errorMessages,
     messageToDisplay: isMultiple ? `${errorMessages.join("\n")}` : message,
     title,
-    onDismiss: clearErrorState,
   });
 };
 

--- a/assets/js/utils/errorHandler.tsx
+++ b/assets/js/utils/errorHandler.tsx
@@ -1,3 +1,5 @@
+import { REFRESH_PAGE_ERROR_MESSAGE } from "Constants/constants";
+
 export interface ErrorHandlingOptions {
   /** Custom error message to display */
   customMessage?: string;
@@ -117,11 +119,11 @@ export const displayErrorModal = (
 const getErrorMessage = (error: Error | Response): string => {
   if (error instanceof Response) {
     if (error.status >= 500) {
-      return "Server error. Please try again or contact engineering if the problem persists.";
+      return `Server error. ${REFRESH_PAGE_ERROR_MESSAGE}`;
     } else if (error.status === 403) {
       return "Your session has expired, please refresh your browser.";
     } else if (error.status === 404) {
-      return "The requested resource was not found. Please try again or contact engineering if the problem persists.";
+      return `The requested resource was not found. ${REFRESH_PAGE_ERROR_MESSAGE}`;
     }
   }
 
@@ -130,11 +132,11 @@ const getErrorMessage = (error: Error | Response): string => {
       return "Network error. Please check your connection and try again.";
     }
     if (error.message.includes("timeout")) {
-      return "Request timed out. Please try again and contact engineering if the issue persists.";
+      return `Request timed out. ${REFRESH_PAGE_ERROR_MESSAGE}`;
     }
   }
 
-  return "Something went wrong. Please try again and contact engineering if the issue persists.";
+  return `Something went wrong. ${REFRESH_PAGE_ERROR_MESSAGE}`;
 };
 
 /**
@@ -145,7 +147,7 @@ const getErrorTitle = (
   isMultiple: string[],
 ): string => {
   if (isMultiple.length > 1) {
-    return `${isMultiple.length} errors occurred`;
+    return `${isMultiple.length} Errors Occurred`;
   }
 
   if (error instanceof Response) {

--- a/assets/js/utils/errorHandler.tsx
+++ b/assets/js/utils/errorHandler.tsx
@@ -103,7 +103,9 @@ export const displayErrorModal = (
 
   setErrorState({
     errorMessages: errorMessages,
-    messageToDisplay: areMultipleErrors ? `${errorMessages.join("\n")}` : message,
+    messageToDisplay: areMultipleErrors
+      ? `${errorMessages.join("\n")}`
+      : message,
     title,
   });
 };

--- a/assets/js/utils/errorHandler.tsx
+++ b/assets/js/utils/errorHandler.tsx
@@ -77,7 +77,7 @@ const isMultipleFailure = (): boolean => {
  * Generates a user friendly error message based on the error type.
  * @returns the error message to display
  */
-const getErrorMessage = (  error: Error | Response): string => {
+const getErrorMessage = (error: Error | Response): string => {
   if (error instanceof Response) {
     if (error.status >= 500) {
       return "Server error. Please try again or contact engineering if the problem persists.";
@@ -124,9 +124,9 @@ const getErrorTitle = (
   return "Error";
 };
 
-/** 
- * Surfaces the error to the user through the error modal. 
-*/
+/**
+ * Surfaces the error to the user through the error modal.
+ */
 export const displayErrorModal = (
   error: Error | Response,
   options: ErrorHandlingOptions = {},
@@ -268,7 +268,7 @@ export const withErrorHandlingRetry = <T extends any[], R>(
 };
 
 /**
- * Checks if an error is a session expiration error. 403 errors must be session expiration, 
+ * Checks if an error is a session expiration error. 403 errors must be session expiration,
  * b/c a user must be logged in with proper permissions to access Screenplay initially.
  */
 export const isSessionExpirationError = (error: any): boolean => {

--- a/assets/js/utils/errorHandler.tsx
+++ b/assets/js/utils/errorHandler.tsx
@@ -1,0 +1,276 @@
+export interface ErrorHandlingOptions {
+  /** Whether to show an error modal for this error */
+  showErrorModal?: boolean;
+  /** Custom error message to display */
+  customMessage?: string;
+  /** Cutstom error title to display */
+  customTitle?: string;
+  /** Whether to log the error to console */
+  logError?: boolean;
+  /** Custom error handler function */
+  onError?: (error: Error | Response) => void;
+  /** Whether to retry the operation on failure */
+  retry?: boolean;
+  /** Number of retry attempts */
+  retryAttempts?: number;
+  /** Delay between retries in milliseconds */
+  retryDelay?: number;
+}
+
+export interface ErrorState {
+  show: boolean;
+  messageToDisplay: string;
+  errorMessages?: string[];
+  title: string;
+  onRetry?: () => void;
+  onDismiss: () => void;
+}
+
+let errorState: ErrorState | null = null;
+let errorListeners: ((error: ErrorState | null) => void)[] = [];
+let errorCount = 0;
+let lastErrorTime = 0;
+const ERROR_COOLDOWN_MS = 5000; // Don't show multiple errors within 5 seconds
+const RETRY_DELAY_DEFAULT_MS = 1000;
+const RETRY_ATTEMPTS_DEFAULT = 3;
+
+// Error state management: getting, setting, clearing.
+export const getErrorState = (): ErrorState | null => errorState;
+
+const setErrorState = (error: ErrorState | null) => {
+  errorState = error;
+  errorListeners.forEach((listener) => listener(error));
+};
+
+export const clearErrorState = () => {
+  setErrorState(null);
+};
+
+/**
+ * Subscribes to changes in the error state. Used by components that rely on these errors.
+ * @param listener - Function to call when error state changes
+ * @returns unsubscribe function to remove the listener
+ */
+export const subscribeToError = (
+  listener: (error: ErrorState | null) => void,
+) => {
+  errorListeners.push(listener);
+  return () => {
+    errorListeners = errorListeners.filter((l) => l !== listener);
+  };
+};
+
+/** Determines if multiple errors have happened during the cooldown window. */
+const isMultipleFailure = (): boolean => {
+  const now = Date.now();
+  if (now - lastErrorTime < ERROR_COOLDOWN_MS) {
+    errorCount++;
+    return errorCount > 1;
+  } else {
+    errorCount = 1;
+    lastErrorTime = now;
+    return false;
+  }
+};
+
+/**
+ * Generates a user friendly error message based on the error type.
+ * @returns the error message to display
+ */
+const getErrorMessage = (  error: Error | Response): string => {
+  if (error instanceof Response) {
+    if (error.status >= 500) {
+      return "Server error. Please try again or contact engineering if the problem persists.";
+    } else if (error.status === 403) {
+      return "Your session has expired, please refresh your browser.";
+    } else if (error.status === 404) {
+      return "The requested resource was not found. Please try again or contact engineering if the problem persists.";
+    }
+  }
+
+  if (error instanceof Error) {
+    if (error.message.includes("fetch")) {
+      return "Network error. Please check your connection and try again.";
+    }
+    if (error.message.includes("timeout")) {
+      return "Request timed out. Please try again and contact engineering if the issue persists.";
+    }
+  }
+
+  return "Something went wrong. Please try again and contact engineering if the issue persists.";
+};
+
+/**
+ * Generates a title for the error modal based on the error type and if there are multiple.
+ */
+const getErrorTitle = (
+  error: Error | Response,
+  isMultiple: string[],
+): string => {
+  if (isMultiple.length > 1) {
+    return `${isMultiple.length} errors occurred`;
+  }
+
+  if (error instanceof Response) {
+    if (error.status >= 500) {
+      return "Server Error";
+    } else if (error.status === 403) {
+      return "Access Denied";
+    } else if (error.status === 404) {
+      return "Not Found";
+    }
+  }
+
+  return "Error";
+};
+
+/** 
+ * Surfaces the error to the user through the error modal. 
+*/
+export const displayErrorModal = (
+  error: Error | Response,
+  options: ErrorHandlingOptions = {},
+) => {
+  const { customMessage, customTitle, logError = true, onError } = options;
+
+  if (logError) {
+    console.error(error);
+  }
+
+  if (onError) {
+    onError(error);
+  }
+  const message = customMessage ?? getErrorMessage(error);
+  const errorMessages = getErrorState()?.errorMessages || [];
+  errorMessages.push(message);
+  const isMultiple = isMultipleFailure();
+  const title =
+    customTitle ?? getErrorTitle(error, isMultiple ? errorMessages : []);
+
+  setErrorState({
+    show: true,
+    errorMessages: errorMessages,
+    messageToDisplay: isMultiple ? `${errorMessages.join("\n")}` : message,
+    title,
+    onDismiss: clearErrorState,
+  });
+};
+
+/**
+ * Wrapper for operations that should display an error modal on their initial failure.
+ * @param asyncFn - the function that should be tried
+ * @param options - ErrorHandlingOptions
+ */
+export const withErrorHandling = <T extends any[], R>(
+  asyncFn: (...args: T) => Promise<R>,
+  options: ErrorHandlingOptions = {},
+) => {
+  return async (...args: T): Promise<R | null> => {
+    const {
+      showErrorModal = true,
+      logError = true,
+      onError,
+      retry = false,
+      retryAttempts = RETRY_ATTEMPTS_DEFAULT,
+      retryDelay = RETRY_DELAY_DEFAULT_MS,
+    } = options;
+
+    let attempts = 0;
+
+    while (attempts <= (retry ? retryAttempts : 0)) {
+      try {
+        const result = await asyncFn(...args);
+        return result;
+      } catch (error) {
+        attempts++;
+
+        if (logError) {
+          console.error(
+            `Error in ${asyncFn.name} (attempt ${attempts}):`,
+            error,
+          );
+        }
+
+        // If there's no handling specified and it's a session expiration error,
+        // then we want to refresh the page after displaying the error
+        if (!onError && isSessionExpirationError(error)) {
+          options.onError = () => {
+            setTimeout(() => window.location.reload(), 2000);
+          };
+        }
+
+        // If this is the last attempt or we're not retrying, handle the error
+        if (attempts > (retry ? retryAttempts : 0)) {
+          if (showErrorModal) {
+            displayErrorModal(error as Error | Response, options);
+          }
+          return null;
+        }
+
+        // Wait before retrying
+        if (retry && attempts <= retryAttempts) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, retryDelay * attempts),
+          );
+        }
+      }
+    }
+
+    return null;
+  };
+};
+
+/**
+ * Wrapper for operations that should display an error modal on their initial failure.
+ */
+export const withErrorHandlingDisplayError = <T extends any[], R>(
+  asyncFn: (...args: T) => Promise<R>,
+  customMessage?: string,
+) => {
+  return withErrorHandling(asyncFn, {
+    showErrorModal: true,
+    logError: true,
+    customMessage,
+  });
+};
+
+/**
+ * Wrapper for operations that should fail silently (no error modal)
+ */
+export const withErrorHandlingSilent = <T extends any[], R>(
+  asyncFn: (...args: T) => Promise<R>,
+  onError?: (error: Error | Response) => void,
+) => {
+  return withErrorHandling(asyncFn, {
+    showErrorModal: false,
+    logError: true,
+    onError,
+  });
+};
+
+/**
+ * Wrapper for operations that should retry on failure
+ */
+export const withErrorHandlingRetry = <T extends any[], R>(
+  asyncFn: (...args: T) => Promise<R>,
+  options: {
+    retryAttempts?: number;
+    retryDelay?: number;
+    customMessage?: string;
+  } = {},
+) => {
+  return withErrorHandling(asyncFn, {
+    showErrorModal: true,
+    logError: true,
+    retry: true,
+    ...options,
+  });
+};
+
+/**
+ * Checks if an error is a session expiration error. 403 errors must be session expiration, 
+ * b/c a user must be logged in with proper permissions to access Screenplay initially.
+ */
+export const isSessionExpirationError = (error: any): boolean => {
+  return error instanceof Response && error.status === 403;
+};

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -58,7 +58,7 @@
         "hard-source-webpack-plugin": "^0.13.1",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^29.7.0",
-        "jest-environment-jsdom": "^29.7.0",
+        "jest-fixed-jsdom": "^0.0.10",
         "mini-css-extract-plugin": "^2.9.2",
         "prettier": "3.2.5",
         "react-test-renderer": "^18.3.1",
@@ -3321,6 +3321,7 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -3467,6 +3468,7 @@
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
       "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@types/tough-cookie": "*",
@@ -3555,7 +3557,8 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/warning": {
       "version": "3.0.3",
@@ -3966,7 +3969,8 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "deprecated": "Use your platform's native atob() and btoa() methods instead",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/acorn": {
       "version": "8.12.1",
@@ -3985,6 +3989,7 @@
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
       "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "acorn": "^8.1.0",
         "acorn-walk": "^8.0.2"
@@ -4013,6 +4018,7 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.3.tgz",
       "integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "acorn": "^8.11.0"
       },
@@ -4025,6 +4031,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -4284,7 +4291,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -4897,6 +4905,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -5510,13 +5519,15 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
       "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/cssstyle": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
       "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "cssom": "~0.3.6"
       },
@@ -5528,7 +5539,8 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -5544,6 +5556,7 @@
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
       "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "abab": "^2.0.6",
         "whatwg-mimetype": "^3.0.0",
@@ -5628,7 +5641,8 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/dedent": {
       "version": "1.5.3",
@@ -5693,6 +5707,7 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -5773,6 +5788,7 @@
       "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
       "deprecated": "Use your platform's native DOMException instead",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "webidl-conversions": "^7.0.0"
       },
@@ -6069,6 +6085,7 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -6799,6 +6816,7 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -7268,6 +7286,7 @@
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
       "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "whatwg-encoding": "^2.0.0"
       },
@@ -7285,6 +7304,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@tootallnate/once": "2",
         "agent-base": "6",
@@ -7299,6 +7319,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -7320,6 +7341,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -7724,7 +7746,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -8663,6 +8686,7 @@
       "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
       "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/fake-timers": "^29.7.0",
@@ -8699,6 +8723,19 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-fixed-jsdom": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/jest-fixed-jsdom/-/jest-fixed-jsdom-0.0.10.tgz",
+      "integrity": "sha512-WaEVX+FripJh+Hn/7dysIgqP66h0KT1NNC22NGmNYANExtCoYNk1q2yjwwcdSboBMkkhn0NtmvKad/cmisnCLg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "jest-environment-jsdom": ">=28.0.0"
       }
     },
     "node_modules/jest-get-type": {
@@ -9808,6 +9845,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
       "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "abab": "^2.0.6",
         "acorn": "^8.8.1",
@@ -10379,7 +10417,8 @@
       "version": "2.2.10",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.10.tgz",
       "integrity": "sha512-QK0sRs7MKv0tKe1+5uZIQk/C8XGza4DAnztJG8iD+TpJIORARrCxczA738awHrZoHeTjSSoHqao2teO0dC/gFQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -10586,6 +10625,7 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
       "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "entities": "^4.4.0"
       },
@@ -11287,7 +11327,8 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -11316,7 +11357,8 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -11681,7 +11723,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -11813,7 +11856,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/sass": {
       "version": "1.75.0",
@@ -11877,6 +11921,7 @@
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
@@ -12374,7 +12419,8 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "1.1.3",
@@ -12568,6 +12614,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
       "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -12583,6 +12630,7 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
       "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "punycode": "^2.1.1"
       },
@@ -13000,6 +13048,7 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -13046,6 +13095,7 @@
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -13089,6 +13139,7 @@
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
       "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "xml-name-validator": "^4.0.0"
       },
@@ -13128,6 +13179,7 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -13310,6 +13362,7 @@
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
       "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "iconv-lite": "0.6.3"
       },
@@ -13322,6 +13375,7 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -13331,6 +13385,7 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
       "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tr46": "^3.0.0",
         "webidl-conversions": "^7.0.0"
@@ -13543,6 +13598,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -13564,6 +13620,7 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
       "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -13572,7 +13629,8 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/assets/package.json
+++ b/assets/package.json
@@ -7,7 +7,7 @@
     "watch": "webpack --mode development --watch",
     "lint": "eslint --fix \"{.,**}/*.{js,ts,tsx}\"",
     "lint:check": "eslint \"{.,**}/*.{js,ts,tsx}\"",
-    "format": "prettier --write \"{.,**}/*.{js,json,ts,tsx,css,scss}\"",
+    "format": "prettier --write \"{.,**}/*.{js,json,ts,tsx,css,scss}\" --list-different",
     "format:check": "prettier --check \"{.,**}/*.{js,json,ts,tsx,css,scss}\"",
     "test": "jest",
     "check": "npm run lint:check && npm run format:check"

--- a/assets/package.json
+++ b/assets/package.json
@@ -65,7 +65,7 @@
     "hard-source-webpack-plugin": "^0.13.1",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
-    "jest-environment-jsdom": "^29.7.0",
+    "jest-fixed-jsdom": "^0.0.10",
     "mini-css-extract-plugin": "^2.9.2",
     "prettier": "3.2.5",
     "react-test-renderer": "^18.3.1",
@@ -108,7 +108,7 @@
     },
     "collectCoverage": true,
     "globalSetup": "./tests/global-setup.js",
-    "testEnvironment": "jsdom",
+    "testEnvironment": "jest-fixed-jsdom",
     "setupFilesAfterEnv": [
       "<rootDir>/tests/setup.ts"
     ]

--- a/assets/tests/setup.ts
+++ b/assets/tests/setup.ts
@@ -25,13 +25,19 @@ beforeAll(() => {
   document.body.appendChild(app);
 });
 
+let originalConsoleError: any;
 let originalFetch: any;
 
 beforeEach(() => {
+  // Suppress console.error during tests to reduce noise
+  originalConsoleError = console.error;
+  console.error = jest.fn();
+
   originalFetch = global.fetch;
   global.fetch = jest.fn(async (url) => {
     if (url === "/api/alerts") {
       return Promise.resolve({
+        ok: true,
         status: 200,
         json: () =>
           Promise.resolve({
@@ -41,11 +47,23 @@ beforeEach(() => {
           }),
       });
     } else if (url === "/api/dashboard") {
-      return Promise.resolve({ json: () => Promise.resolve(places) });
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(places),
+      });
     } else if (url === "/api/line_stops") {
-      return Promise.resolve({ json: () => Promise.resolve({ data: [] }) });
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ data: [] }),
+      });
     } else if (url === "/api/suppressed-predictions") {
-      return Promise.resolve({ json: () => Promise.resolve([]) });
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([]),
+      });
     } else {
       throw "Missing mock";
     }
@@ -54,4 +72,5 @@ beforeEach(() => {
 
 afterEach(() => {
   global.fetch = originalFetch;
+  console.error = originalConsoleError;
 });

--- a/assets/tests/utils/errorHandler.test.tsx
+++ b/assets/tests/utils/errorHandler.test.tsx
@@ -47,13 +47,13 @@ describe("withErrorHandling", () => {
     });
   });
 
-  describe("Error handling without retry", () => {
+  describe("Error handling", () => {
     it("should return null and show error modal on failure", async () => {
       const mockFunction = jest
         .fn()
-        .mockRejectedValue(new Error("Test error without retry"));
+        .mockRejectedValue(new Error("Test error"));
       const wrappedFunction = withErrorHandling(mockFunction, {
-        customMessage: "Test error without retry user facing message",
+        customMessage: "Test error with user facing message",
       });
 
       const result = await wrappedFunction();
@@ -63,7 +63,7 @@ describe("withErrorHandling", () => {
       expect(getErrorState()).not.toBeNull();
       expect(getErrorState()?.show).toBe(true);
       expect(getErrorState()?.messageToDisplay).toBe(
-        "Test error without retry user facing message",
+        "Test error with user facing message",
       );
     });
 
@@ -87,49 +87,6 @@ describe("withErrorHandling", () => {
       await wrappedFunction();
 
       expect(onError).toHaveBeenCalledWith(expect.any(Error));
-    });
-  });
-
-  describe("Error handling with retry", () => {
-    it("should retry the specified number of times before failing", async () => {
-      const mockFunction = jest.fn().mockRejectedValue(new Error("Test error"));
-      const wrappedFunction = withErrorHandling(mockFunction, {
-        retry: true,
-        retryAttempts: 2,
-        retryDelay: 10,
-      });
-
-      const result = await wrappedFunction();
-
-      expect(result).toBeNull();
-      expect(mockFunction).toHaveBeenCalledTimes(3); // 1 initial + 2 retries
-    });
-
-    it("should succeed on retry and return result", async () => {
-      const mockFunction = jest
-        .fn()
-        .mockRejectedValueOnce(new Error("First attempt fails"))
-        .mockResolvedValue("Success on second attempt");
-
-      const wrappedFunction = withErrorHandling(mockFunction, {
-        retry: true,
-        retryAttempts: 2,
-        retryDelay: 10,
-      });
-
-      const result = await wrappedFunction();
-
-      expect(result).toBe("Success on second attempt");
-      expect(mockFunction).toHaveBeenCalledTimes(2);
-    });
-
-    it("should not retry when retry is false", async () => {
-      const mockFunction = jest.fn().mockRejectedValue(new Error("Test error"));
-      const wrappedFunction = withErrorHandling(mockFunction, { retry: false });
-
-      await wrappedFunction();
-
-      expect(mockFunction).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/assets/tests/utils/errorHandler.test.tsx
+++ b/assets/tests/utils/errorHandler.test.tsx
@@ -59,23 +59,11 @@ describe("withErrorHandling", () => {
       expect(result).toBeNull();
       expect(mockFunction).toHaveBeenCalledTimes(1);
       expect(getErrorState()).not.toBeNull();
-      expect(getErrorState()?.show).toBe(true);
       expect(getErrorState()?.messageToDisplay).toBe(
         "Test error with user facing message",
       );
     });
 
-    it("should not show error modal when showErrorModal is false", async () => {
-      const mockFunction = jest.fn().mockRejectedValue(new Error("Test error"));
-      const wrappedFunction = withErrorHandling(mockFunction, {
-        showErrorModal: false,
-      });
-
-      const result = await wrappedFunction();
-
-      expect(result).toBeNull();
-      expect(getErrorState()).toBeNull();
-    });
 
     it("should call custom onError handler", async () => {
       const mockFunction = jest.fn().mockRejectedValue(new Error("Test error"));
@@ -99,7 +87,6 @@ describe("withErrorHandling", () => {
       await wrappedFunction();
 
       expect(getErrorState()).not.toBeNull();
-      expect(getErrorState()?.show).toBe(true);
 
       // Wait for the reload timeout
       await new Promise((resolve) => setTimeout(resolve, 2100));
@@ -182,7 +169,6 @@ describe("withErrorHandling", () => {
 
       expect(subscriber).toHaveBeenCalledWith(
         expect.objectContaining({
-          show: true,
           messageToDisplay: expect.any(String),
           title: expect.any(String),
         }),

--- a/assets/tests/utils/errorHandler.test.tsx
+++ b/assets/tests/utils/errorHandler.test.tsx
@@ -64,7 +64,6 @@ describe("withErrorHandling", () => {
       );
     });
 
-
     it("should call custom onError handler", async () => {
       const mockFunction = jest.fn().mockRejectedValue(new Error("Test error"));
       const onError = jest.fn();

--- a/assets/tests/utils/errorHandler.test.tsx
+++ b/assets/tests/utils/errorHandler.test.tsx
@@ -49,9 +49,7 @@ describe("withErrorHandling", () => {
 
   describe("Error handling", () => {
     it("should return null and show error modal on failure", async () => {
-      const mockFunction = jest
-        .fn()
-        .mockRejectedValue(new Error("Test error"));
+      const mockFunction = jest.fn().mockRejectedValue(new Error("Test error"));
       const wrappedFunction = withErrorHandling(mockFunction, {
         customMessage: "Test error with user facing message",
       });

--- a/assets/tests/utils/errorHandler.test.tsx
+++ b/assets/tests/utils/errorHandler.test.tsx
@@ -1,0 +1,269 @@
+import {
+  withErrorHandling,
+  isSessionExpirationError,
+  getErrorState,
+  clearErrorState,
+  subscribeToErrorState,
+  unsubscribeFromErrorState,
+} from "../../js/utils/errorHandler";
+
+// Mock window.location.reload
+const mockReload = jest.fn();
+Object.defineProperty(window, "location", {
+  value: { reload: mockReload },
+  writable: true,
+});
+
+describe("withErrorHandling", () => {
+  beforeEach(() => {
+    clearErrorState();
+    mockReload.mockClear();
+  });
+
+  describe("Happy path", () => {
+    it("happy path should return function result", async () => {
+      const mockFunction = jest.fn().mockResolvedValue("success");
+      const wrappedFunction = withErrorHandling(mockFunction);
+
+      const result = await wrappedFunction("arg1", "arg2");
+
+      expect(result).toBe("success");
+      expect(mockFunction).toHaveBeenCalledWith("arg1", "arg2");
+      expect(getErrorState()).toBeNull();
+    });
+
+    it("should pass through all arguments correctly", async () => {
+      const mockFunction = jest.fn().mockResolvedValue("success");
+      const wrappedFunction = withErrorHandling(mockFunction);
+
+      await wrappedFunction(1, "test", { key: "value" }, [1, 2, 3]);
+
+      expect(mockFunction).toHaveBeenCalledWith(
+        1,
+        "test",
+        { key: "value" },
+        [1, 2, 3],
+      );
+    });
+  });
+
+  describe("Error handling without retry", () => {
+    it("should return null and show error modal on failure", async () => {
+      const mockFunction = jest
+        .fn()
+        .mockRejectedValue(new Error("Test error without retry"));
+      const wrappedFunction = withErrorHandling(mockFunction, {
+        customMessage: "Test error without retry user facing message",
+      });
+
+      const result = await wrappedFunction();
+
+      expect(result).toBeNull();
+      expect(mockFunction).toHaveBeenCalledTimes(1);
+      expect(getErrorState()).not.toBeNull();
+      expect(getErrorState()?.show).toBe(true);
+      expect(getErrorState()?.messageToDisplay).toBe(
+        "Test error without retry user facing message",
+      );
+    });
+
+    it("should not show error modal when showErrorModal is false", async () => {
+      const mockFunction = jest.fn().mockRejectedValue(new Error("Test error"));
+      const wrappedFunction = withErrorHandling(mockFunction, {
+        showErrorModal: false,
+      });
+
+      const result = await wrappedFunction();
+
+      expect(result).toBeNull();
+      expect(getErrorState()).toBeNull();
+    });
+
+    it("should call custom onError handler", async () => {
+      const mockFunction = jest.fn().mockRejectedValue(new Error("Test error"));
+      const onError = jest.fn();
+      const wrappedFunction = withErrorHandling(mockFunction, { onError });
+
+      await wrappedFunction();
+
+      expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+
+  describe("Error handling with retry", () => {
+    it("should retry the specified number of times before failing", async () => {
+      const mockFunction = jest.fn().mockRejectedValue(new Error("Test error"));
+      const wrappedFunction = withErrorHandling(mockFunction, {
+        retry: true,
+        retryAttempts: 2,
+        retryDelay: 10,
+      });
+
+      const result = await wrappedFunction();
+
+      expect(result).toBeNull();
+      expect(mockFunction).toHaveBeenCalledTimes(3); // 1 initial + 2 retries
+    });
+
+    it("should succeed on retry and return result", async () => {
+      const mockFunction = jest
+        .fn()
+        .mockRejectedValueOnce(new Error("First attempt fails"))
+        .mockResolvedValue("Success on second attempt");
+
+      const wrappedFunction = withErrorHandling(mockFunction, {
+        retry: true,
+        retryAttempts: 2,
+        retryDelay: 10,
+      });
+
+      const result = await wrappedFunction();
+
+      expect(result).toBe("Success on second attempt");
+      expect(mockFunction).toHaveBeenCalledTimes(2);
+    });
+
+    it("should not retry when retry is false", async () => {
+      const mockFunction = jest.fn().mockRejectedValue(new Error("Test error"));
+      const wrappedFunction = withErrorHandling(mockFunction, { retry: false });
+
+      await wrappedFunction();
+
+      expect(mockFunction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Session expiration handling", () => {
+    it("should handle session expiration errors with page reload", async () => {
+      const mockResponse = new Response(null, { status: 403 });
+      const mockFunction = jest.fn().mockRejectedValue(mockResponse);
+      const wrappedFunction = withErrorHandling(mockFunction);
+
+      mockReload.mockClear();
+
+      await wrappedFunction();
+
+      expect(getErrorState()).not.toBeNull();
+      expect(getErrorState()?.show).toBe(true);
+
+      // Wait for the reload timeout
+      await new Promise((resolve) => setTimeout(resolve, 2100));
+      expect(mockReload).toHaveBeenCalled();
+    });
+
+    it("should not auto-reload when custom onError is provided", async () => {
+      const mockResponse = new Response(null, { status: 403 });
+      const mockFunction = jest.fn().mockRejectedValue(mockResponse);
+      const customOnError = jest.fn();
+      const wrappedFunction = withErrorHandling(mockFunction, {
+        onError: customOnError,
+      });
+
+      mockReload.mockClear();
+
+      await wrappedFunction();
+
+      expect(customOnError).toHaveBeenCalledWith(mockResponse);
+      await new Promise((resolve) => setTimeout(resolve, 2100));
+      expect(mockReload).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Error message handling", () => {
+    it("should use custom error message when provided", async () => {
+      const mockFunction = jest.fn().mockRejectedValue(new Error("Test error"));
+      const wrappedFunction = withErrorHandling(mockFunction, {
+        customMessage: "Custom error message",
+      });
+
+      await wrappedFunction();
+
+      const errorState = getErrorState();
+      expect(errorState?.messageToDisplay).toBe("Custom error message");
+    });
+
+    it("should use custom error title when provided", async () => {
+      const mockFunction = jest.fn().mockRejectedValue(new Error("Test error"));
+      const wrappedFunction = withErrorHandling(mockFunction, {
+        customTitle: "Custom Error Title",
+      });
+
+      await wrappedFunction();
+
+      const errorState = getErrorState();
+      expect(errorState?.title).toBe("Custom Error Title");
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should handle null/undefined return values", async () => {
+      const mockFunction = jest.fn().mockResolvedValue(null);
+      const wrappedFunction = withErrorHandling(mockFunction);
+
+      const result = await wrappedFunction();
+
+      expect(result).toBeNull();
+    });
+
+    it("should handle functions that return different types", async () => {
+      const mockFunction = jest.fn().mockResolvedValue({ data: "test" });
+      const wrappedFunction = withErrorHandling(mockFunction);
+
+      const result = await wrappedFunction();
+
+      expect(result).toEqual({ data: "test" });
+    });
+  });
+
+  describe("Error state subscription", () => {
+    it("should notify subscribers when error state changes", async () => {
+      const mockFunction = jest.fn().mockRejectedValue(new Error("Test error"));
+      const wrappedFunction = withErrorHandling(mockFunction);
+      const subscriber = jest.fn();
+
+      subscribeToErrorState(subscriber);
+
+      await wrappedFunction();
+
+      expect(subscriber).toHaveBeenCalledWith(
+        expect.objectContaining({
+          show: true,
+          messageToDisplay: expect.any(String),
+          title: expect.any(String),
+        }),
+      );
+
+      unsubscribeFromErrorState(subscriber);
+    });
+
+    it("should allow unsubscribing from error state changes", async () => {
+      const mockFunction = jest.fn().mockRejectedValue(new Error("Test error"));
+      const wrappedFunction = withErrorHandling(mockFunction);
+      const subscriber = jest.fn();
+
+      subscribeToErrorState(subscriber);
+      unsubscribeFromErrorState(subscriber);
+
+      await wrappedFunction();
+
+      expect(subscriber).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("isSessionExpirationError", () => {
+  it("should return true for 403 Response", () => {
+    const response = new Response(null, { status: 403 });
+    expect(isSessionExpirationError(response)).toBe(true);
+  });
+
+  it("should return false for non-403 Response", () => {
+    const response = new Response(null, { status: 500 });
+    expect(isSessionExpirationError(response)).toBe(false);
+  });
+
+  it("should return false for Error objects", () => {
+    const error = new Error("Test error");
+    expect(isSessionExpirationError(error)).toBe(false);
+  });
+});


### PR DESCRIPTION
**Asana task**: [Communicate errors to user](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1208769995914082?focus=true)


- Adds `errorHandler.tsx` with a wrapper to handle async functions.
- Updates ErrorModal.tsx to display based on a global `ErrorState`. 
- Note that this PR includes some unused functionality within `withErrorHandling`. Silent errors and retries were used in earlier versions of the changes, but I ended up feeling that none of the updated wrapped methods require them. I left these options in for now, and have them unit tested, in case we want to make use of them in the future.

Error being displayed on modal in the center of Screenplay page:
<img width="1421" height="733" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/39a48c45-042a-40bc-8e59-05c656124217" />
Multiple errors:
<img width="339" height="167" alt="2 errors occurred" src="https://github.com/user-attachments/assets/f5b95587-609a-49c3-b914-2b7c46f25450" />
