### PR TITLE
include hidden signs in Places cache

### DIFF
--- a/lib/screenplay/places.ex
+++ b/lib/screenplay/places.ex
@@ -34,5 +34,8 @@ defmodule Screenplay.Places do
   @spec get() :: list(Place.t())
   def get do
     Cache.all(nil, return: :value)
+    |> update_in([Access.all(), Access.key(:screens)], fn screens ->
+      Enum.reject(screens, &match?(%{hidden?: true}, &1))
+    end)
   end
 end

--- a/lib/screenplay/places/builder.ex
+++ b/lib/screenplay/places/builder.ex
@@ -96,7 +96,13 @@ defmodule Screenplay.Places.Builder do
     |> Enum.group_by(&elem(&1, 0), fn
       {_stop_id,
        {id,
-        %Screen{app_id: app_id, disabled: disabled, app_params: app_params, location: location}}} ->
+        %Screen{
+          app_id: app_id,
+          disabled: disabled,
+          app_params: app_params,
+          location: location,
+          hidden_from_screenplay: hidden_from_screenplay
+        }}} ->
         direction_id =
           case app_params do
             %_app{direction_id: direction_id} -> direction_id
@@ -108,13 +114,13 @@ defmodule Screenplay.Places.Builder do
           type: app_id,
           disabled: disabled,
           direction_id: direction_id,
-          location: location || ""
+          location: location || "",
+          hidden?: hidden_from_screenplay
         }
     end)
   end
 
   defp hidden_screen?({_id, %Screen{app_id: :on_bus_v2}}), do: true
-  defp hidden_screen?({_id, %Screen{hidden_from_screenplay: true}}), do: true
   defp hidden_screen?(_), do: false
 
   defp append_routes_to_places(places) do

--- a/lib/screenplay/places/builder.ex
+++ b/lib/screenplay/places/builder.ex
@@ -91,7 +91,6 @@ defmodule Screenplay.Places.Builder do
 
   defp get_showtime_screens do
     ScreensConfigStore.screens()
-    |> Enum.reject(&hidden_screen?/1)
     |> Enum.flat_map(fn {id, screen} -> screen |> stop_ids() |> Enum.map(&{&1, {id, screen}}) end)
     |> Enum.group_by(&elem(&1, 0), fn
       {_stop_id,
@@ -119,9 +118,6 @@ defmodule Screenplay.Places.Builder do
         }
     end)
   end
-
-  defp hidden_screen?({_id, %Screen{app_id: :on_bus_v2}}), do: true
-  defp hidden_screen?(_), do: false
 
   defp append_routes_to_places(places) do
     places

--- a/lib/screenplay/places/place.ex
+++ b/lib/screenplay/places/place.ex
@@ -45,11 +45,12 @@ defmodule Screenplay.Places.Place do
             type: String.t(),
             disabled: boolean(),
             direction_id: String.t(),
-            location: String.t()
+            location: String.t(),
+            hidden?: boolean()
           }
 
     @enforce_keys [:id, :type, :disabled]
-    defstruct @enforce_keys ++ [:direction_id, location: ""]
+    defstruct @enforce_keys ++ [:direction_id, location: "", hidden?: false]
 
     def new(map) do
       map

--- a/test/screenplay/places/builder_test.exs
+++ b/test/screenplay/places/builder_test.exs
@@ -62,7 +62,7 @@ defmodule Screenplay.Places.BuilderTest do
                  ],
                  description: nil
                }
-             ] = PlacesCache.all(nil, return: :value)
+             ] = Screenplay.Places.get()
     end
 
     test "adds bus stops with screens" do
@@ -94,7 +94,7 @@ defmodule Screenplay.Places.BuilderTest do
                  ],
                  description: nil
                }
-             ] = PlacesCache.all(nil, return: :value)
+             ] = Screenplay.Places.get()
     end
 
     test "splits multi-place screens" do
@@ -165,7 +165,7 @@ defmodule Screenplay.Places.BuilderTest do
                  ],
                  description: nil
                }
-             ] = PlacesCache.all(nil, return: :value)
+             ] = Screenplay.Places.get()
     end
 
     test "omits screens with hidden_from_screenplay: true" do
@@ -189,7 +189,7 @@ defmodule Screenplay.Places.BuilderTest do
                  routes: ["Blue"],
                  screens: []
                }
-             ] = PlacesCache.all(nil, return: :value)
+             ] = Screenplay.Places.get()
     end
 
     test "adds PA/ESS screens" do
@@ -287,7 +287,7 @@ defmodule Screenplay.Places.BuilderTest do
                    }
                  ]
                }
-             ] = PlacesCache.all(nil, return: :value)
+             ] = Screenplay.Places.get()
     end
   end
 


### PR DESCRIPTION
**Asana task**: [Screenplay: track "hidden" screens for use with ETT](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1213370309386745?focus=true)

This adds a `hidden?` field to `ShowtimeScreen` structs, so they can be included in the Places cache, but still filtered out via the default code paths. ETT will be able to see these screens via a separate non-filtering getter.