### PR TITLE
fix: Only fetch alerts in ETT on load and after 60s timer

### DIFF
--- a/assets/js/components/EmergencyTakeoverTool/AlertDashboard/AlertDetails.tsx
+++ b/assets/js/components/EmergencyTakeoverTool/AlertDashboard/AlertDetails.tsx
@@ -17,16 +17,14 @@ import AlertReminder from "./AlertReminder";
 
 interface AlertDetailsProps {
   data: any;
-  setLastChangeTime: (time: number) => void;
   startEditWizard: (data: AlertData, step: number) => void;
-  clearAlert: (id: string, setLastChangeTime: (time: number) => void) => void;
+  clearAlert: (id: string) => void;
   triggerConfirmation: (modalDetails: ModalDetails) => void;
 }
 
 const AlertDetails = (props: AlertDetailsProps): JSX.Element => {
   const {
     data,
-    setLastChangeTime,
     startEditWizard,
     triggerConfirmation,
     clearAlert: clearAlertFromProps,
@@ -71,10 +69,10 @@ const AlertDetails = (props: AlertDetailsProps): JSX.Element => {
           Clear Alert
         </>
       ),
-      onSubmit: () => clearAlertFromProps(id, setLastChangeTime),
+      onSubmit: () => clearAlertFromProps(id),
     };
     triggerConfirmation(modalDetails);
-  }, [triggerConfirmation, id, clearAlertFromProps, setLastChangeTime]);
+  }, [triggerConfirmation, id, clearAlertFromProps]);
 
   return (
     <div className="alert-card">

--- a/assets/js/components/EmergencyTakeoverTool/AlertDashboard/AlertsList.tsx
+++ b/assets/js/components/EmergencyTakeoverTool/AlertDashboard/AlertsList.tsx
@@ -17,58 +17,51 @@ interface AlertsListProps {
 const AlertsList = (props: AlertsListProps): JSX.Element => {
   const [alertsData, setAlertsData] = useState([]);
   const [pastAlertsData, setPastAlertsData] = useState([]);
-  const [lastChangeTime, setLastChangeTime] = useState(Date.now());
 
-  const fetchActiveAlerts = withErrorHandling(
-    async () => {
-      const response = await fetch(`${BASE_URL}/active_alerts`);
-      if (!response.ok) {
-        throw response;
-      }
-      return response.json();
-    },
-    { customMessage: "Failed to load active alerts. Please refresh the page." },
-  );
+  const refreshAlerts = async () => {
+    // Refresh active and past alerts on page load, alert clear, and at a regular interval.
+    const fetchActiveAlerts = withErrorHandling(
+      async () => {
+        const response = await fetch(`${BASE_URL}/active_alerts`);
+        if (!response.ok) {
+          throw response;
+        }
+        return response.json();
+      },
+      {
+        customMessage: "Failed to load active alerts. Please refresh the page.",
+      },
+    );
 
-  const fetchPastAlerts = withErrorHandling(
-    async () => {
-      const response = await fetch(`${BASE_URL}/past_alerts`);
-      if (!response.ok) {
-        throw response;
-      }
-      return response.json();
-    },
-    { customMessage: "Failed to load past alerts. Please refresh the page." },
-  );
+    const fetchPastAlerts = withErrorHandling(
+      async () => {
+        const response = await fetch(`${BASE_URL}/past_alerts`);
+        if (!response.ok) {
+          throw response;
+        }
+        return response.json();
+      },
+      { customMessage: "Failed to load past alerts. Please refresh the page." },
+    );
 
-  useEffect(() => {
-    const loadActiveAlerts = async () => {
-      const data = await fetchActiveAlerts();
-      if (data) {
-        setAlertsData(data);
-      }
-    };
-    loadActiveAlerts();
-  }, [lastChangeTime]);
+    const activeData = await fetchActiveAlerts();
+    if (activeData) {
+      setAlertsData(activeData);
+    }
 
-  useEffect(() => {
-    const loadPastAlerts = async () => {
-      const data = await fetchPastAlerts();
-      if (data) {
-        setPastAlertsData(data);
-      }
-    };
-    loadPastAlerts();
-  }, [lastChangeTime]);
+    const pastData = await fetchPastAlerts();
+    if (pastData) {
+      setPastAlertsData(pastData);
+    }
+  };
 
   useEffect(() => {
-    setTimeout(() => setLastChangeTime(Date.now()), 60000);
-  }, [lastChangeTime]);
+    refreshAlerts();
+    const interval = setInterval(refreshAlerts, 60000);
+    return () => clearInterval(interval);
+  }, []);
 
-  const clearAlert = (
-    id: string,
-    setLastChangeTime: (time: number) => void,
-  ) => {
+  const clearAlert = (id: string) => {
     const csrfMetaElement = document.head.querySelector(
       "[name~=csrf-token][content]",
     ) as HTMLMetaElement;
@@ -93,7 +86,7 @@ const AlertsList = (props: AlertsListProps): JSX.Element => {
       })
       .then(({ success }) => {
         if (success) {
-          setLastChangeTime(Date.now());
+          refreshAlerts();
         } else {
           // Should this be a toast or other user-visible message?
           console.log("Error when clearing with id: ", id);
@@ -130,7 +123,7 @@ const AlertsList = (props: AlertsListProps): JSX.Element => {
       })
       .then(({ success }) => {
         if (success) {
-          setLastChangeTime(Date.now());
+          refreshAlerts();
         } else {
           // Should this be a toast or other user-visible message?
           console.log("Error when clearing all alerts");
@@ -182,7 +175,6 @@ const AlertsList = (props: AlertsListProps): JSX.Element => {
             return (
               <AlertDetails
                 data={data}
-                setLastChangeTime={setLastChangeTime}
                 startEditWizard={props.startEditWizard}
                 clearAlert={clearAlert}
                 triggerConfirmation={props.triggerConfirmation}

--- a/assets/js/components/EmergencyTakeoverTool/AlertDashboard/AlertsList.tsx
+++ b/assets/js/components/EmergencyTakeoverTool/AlertDashboard/AlertsList.tsx
@@ -49,10 +49,9 @@ const AlertsList = (props: AlertsListProps): JSX.Element => {
       }
     };
     loadActiveAlerts();
-  }, [fetchActiveAlerts, lastChangeTime]);
+  }, [lastChangeTime]);
 
   useEffect(() => {
-    // TODO: I don't love this way of doing it, but have it working and moving on for now
     const loadPastAlerts = async () => {
       const data = await fetchPastAlerts();
       if (data) {
@@ -60,7 +59,7 @@ const AlertsList = (props: AlertsListProps): JSX.Element => {
       }
     };
     loadPastAlerts();
-  }, [fetchPastAlerts, lastChangeTime]);
+  }, [lastChangeTime]);
 
   useEffect(() => {
     setTimeout(() => setLastChangeTime(Date.now()), 60000);

--- a/assets/js/components/EmergencyTakeoverTool/AlertDashboard/AlertsList.tsx
+++ b/assets/js/components/EmergencyTakeoverTool/AlertDashboard/AlertsList.tsx
@@ -14,36 +14,36 @@ interface AlertsListProps {
   closeModal: () => void;
 }
 
+const fetchActiveAlerts = withErrorHandling(
+  async () => {
+    const response = await fetch(`${BASE_URL}/active_alerts`);
+    if (!response.ok) {
+      throw response;
+    }
+    return response.json();
+  },
+  {
+    customMessage: "Failed to load active alerts. Please refresh the page.",
+  },
+);
+
+const fetchPastAlerts = withErrorHandling(
+  async () => {
+    const response = await fetch(`${BASE_URL}/past_alerts`);
+    if (!response.ok) {
+      throw response;
+    }
+    return response.json();
+  },
+  { customMessage: "Failed to load past alerts. Please refresh the page." },
+);
+
 const AlertsList = (props: AlertsListProps): JSX.Element => {
   const [alertsData, setAlertsData] = useState([]);
   const [pastAlertsData, setPastAlertsData] = useState([]);
 
   const refreshAlerts = async () => {
     // Refresh active and past alerts on page load, alert clear, and at a regular interval.
-    const fetchActiveAlerts = withErrorHandling(
-      async () => {
-        const response = await fetch(`${BASE_URL}/active_alerts`);
-        if (!response.ok) {
-          throw response;
-        }
-        return response.json();
-      },
-      {
-        customMessage: "Failed to load active alerts. Please refresh the page.",
-      },
-    );
-
-    const fetchPastAlerts = withErrorHandling(
-      async () => {
-        const response = await fetch(`${BASE_URL}/past_alerts`);
-        if (!response.ok) {
-          throw response;
-        }
-        return response.json();
-      },
-      { customMessage: "Failed to load past alerts. Please refresh the page." },
-    );
-
     const activeData = await fetchActiveAlerts();
     if (activeData) {
       setAlertsData(activeData);


### PR DESCRIPTION
Noticed a bug when working on ETT work that would cause `active_alerts` and `past_alerts` APIs to both be repeatedly called. Both of their `useEffect` hooks depended on `fetchActiveAlerts` and `fetchPastAlerts`, which are recreated on every render. This caused the effects to run continuously. 

Removing these dependencies corrects this behavior, so the APIs are only called on initial load, when the 60 second timer expires, and alerts are cleared.