### PR TITLE
separate indoor and outdoor content in emergency takeover messages

### DIFF
--- a/assets/css/alert-wizard.scss
+++ b/assets/css/alert-wizard.scss
@@ -125,7 +125,8 @@
     letter-spacing: 0.05em;
     margin-bottom: 24px;
   }
-  .svg-previews {
+  .svg-previews,
+  .portrait-png {
     margin-bottom: 24px;
   }
   .stacked-station-cards {

--- a/assets/js/components/EmergencyTakeoverTool/AlertDashboard/AlertDetails.tsx
+++ b/assets/js/components/EmergencyTakeoverTool/AlertDashboard/AlertDetails.tsx
@@ -16,7 +16,7 @@ import SVGPreviews from "../AlertWizard/SVGPreviews";
 import AlertReminder from "./AlertReminder";
 
 interface AlertDetailsProps {
-  data: any;
+  data: AlertData;
   startEditWizard: (data: AlertData, step: number) => void;
   clearAlert: (id: string) => void;
   triggerConfirmation: (modalDetails: ModalDetails) => void;
@@ -29,7 +29,14 @@ const AlertDetails = (props: AlertDetailsProps): JSX.Element => {
     triggerConfirmation,
     clearAlert: clearAlertFromProps,
   } = props;
-  const { created_by, id, message, schedule, stations } = data;
+  const {
+    created_by,
+    id,
+    indoor_message,
+    outdoor_message,
+    schedule,
+    stations,
+  } = data;
 
   const stationScreenOrientationList = useContext(
     StationScreenOrientationContext,
@@ -49,8 +56,6 @@ const AlertDetails = (props: AlertDetailsProps): JSX.Element => {
     const endDate = new Date(schedule.end);
     endDateString = formatDate(endDate) + " @ " + formatTime(endDate);
   }
-
-  const messageString = getMessageString(message);
 
   const editAlert = useCallback(
     (step: number) => startEditWizard(data, step),
@@ -77,12 +82,12 @@ const AlertDetails = (props: AlertDetailsProps): JSX.Element => {
   return (
     <div className="alert-card">
       <div className="alert-preview">
-        {message.id === undefined ? (
-          <SVGPreviews showText={true} message={messageString} />
+        {indoor_message.type === "custom" ? (
+          <SVGPreviews showText message={indoor_message.text} prefix="indoor" />
         ) : (
           <img
             className="portrait-png"
-            src={`/images/Outfront-Alert-${message.id}-portrait.png`}
+            src={`/images/Outfront-Alert-${indoor_message.id}-portrait.png`}
             alt=""
           />
         )}
@@ -109,10 +114,15 @@ const AlertDetails = (props: AlertDetailsProps): JSX.Element => {
         </div>
         <table className="details-grid">
           <tbody>
-            <tr>
-              <td>Message text</td>
-              <td className="emphasized-cell">{messageString}</td>
-            </tr>
+            {[
+              { message: indoor_message, label: "Indoor" },
+              { message: outdoor_message, label: "Outdoor" },
+            ].map(({ message, label }) => (
+              <tr key={label}>
+                <td>{label} text</td>
+                <td className="emphasized-cell">{getMessageString(message)}</td>
+              </tr>
+            ))}
             <tr className="gray-row">
               <td>Start</td>
               <td className="emphasized-cell">{startDateString}</td>

--- a/assets/js/components/EmergencyTakeoverTool/AlertDashboard/PastAlertDetails.tsx
+++ b/assets/js/components/EmergencyTakeoverTool/AlertDashboard/PastAlertDetails.tsx
@@ -16,8 +16,15 @@ interface PastAlertDetailsProps {
 }
 
 const PastAlertDetails = (props: PastAlertDetailsProps): JSX.Element => {
-  const { cleared_at, cleared_by, created_by, message, schedule, stations } =
-    props.data;
+  const {
+    cleared_at,
+    cleared_by,
+    created_by,
+    indoor_message,
+    outdoor_message,
+    schedule,
+    stations,
+  } = props.data;
   const stationScreenOrientationList = useContext(
     StationScreenOrientationContext,
   );
@@ -32,8 +39,6 @@ const PastAlertDetails = (props: PastAlertDetailsProps): JSX.Element => {
   const clearedDateString =
     formatDate(clearedDate) + " @ " + formatTime(clearedDate);
 
-  const messageString = getMessageString(message);
-
   return (
     <div className="alert-card">
       <div className="alert-details past-alert">
@@ -45,10 +50,15 @@ const PastAlertDetails = (props: PastAlertDetailsProps): JSX.Element => {
         </div>
         <table className="details-grid past-alert">
           <tbody>
-            <tr>
-              <td>Message text</td>
-              <td className="emphasized-cell">{messageString}</td>
-            </tr>
+            {[
+              { message: indoor_message, label: "Indoor" },
+              { message: outdoor_message, label: "Outdoor" },
+            ].map(({ message, label }) => (
+              <tr key={label}>
+                <td>{label} text</td>
+                <td className="emphasized-cell">{getMessageString(message)}</td>
+              </tr>
+            ))}
             <tr className="gray-row">
               <td>Posted</td>
               <td>

--- a/assets/js/components/EmergencyTakeoverTool/AlertWizard/AlertWizard.tsx
+++ b/assets/js/components/EmergencyTakeoverTool/AlertWizard/AlertWizard.tsx
@@ -5,14 +5,17 @@ import PickStations from "./PickStations";
 import SetSchedule from "./SetSchedule";
 import WizardNavFooter from "./WizardNavFooter";
 import WizardStepper from "./WizardStepper";
-import { AlertData, Station, StationsByLine } from "../EmergencyTakeoverTool";
-
-import CANNED_MESSAGES from "Constants/messages";
+import {
+  AlertData,
+  Message,
+  Station,
+  StationsByLine,
+} from "../EmergencyTakeoverTool";
 
 import { NoSymbolIcon, XMarkIcon } from "@heroicons/react/20/solid";
 import WizardSidebar from "./WizardSidebar";
 import { svgLongSide, svgScale, svgShortSide } from "Constants/misc";
-import { matchStation } from "../../../util";
+import { getMessageString, matchStation } from "../../../util";
 
 import { differenceInHours, parseISO } from "date-fns";
 import { ModalDetails } from "../ConfirmationModal";
@@ -29,9 +32,7 @@ interface AlertWizardState {
   step: number;
   cancelModal: boolean;
   selectedStations: Station[];
-  messageOption: string;
-  cannedMessage: string;
-  customMessage: string;
+  message: Message;
   duration: string | number;
   landscapePNG: string | null;
   portraitPNG: string | null;
@@ -53,9 +54,7 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
         cancelModal: false,
         // User input state
         selectedStations: [],
-        messageOption: "1",
-        cannedMessage: "",
-        customMessage: "",
+        message: { type: "canned", id: -1 },
         duration: 1,
         landscapePNG: null,
         portraitPNG: null,
@@ -75,26 +74,11 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
 
     this.checkStation = this.checkStation.bind(this);
     this.checkLine = this.checkLine.bind(this);
-    this.changeMessageOption = this.changeMessageOption.bind(this);
-    this.changeCannedMessage = this.changeCannedMessage.bind(this);
-    this.changeCustomMessage = this.changeCustomMessage.bind(this);
     this.changeDuration = this.changeDuration.bind(this);
   }
 
   initializeState(alertData: AlertData) {
     const { id, message, stations, schedule } = alertData;
-
-    let messageOption, cannedMessage, customMessage;
-
-    if (message.type === "canned") {
-      messageOption = "1";
-      cannedMessage = message.id.toString();
-      customMessage = CANNED_MESSAGES[message.id];
-    } else {
-      messageOption = "2";
-      cannedMessage = "";
-      customMessage = message.text;
-    }
 
     const selectedStations = stations.map((station: string) =>
       matchStation(station, this.props.stationScreenOrientationList),
@@ -119,9 +103,7 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
       cancelModal: false,
       // User input state
       selectedStations: selectedStations,
-      messageOption: messageOption,
-      cannedMessage: cannedMessage,
-      customMessage: customMessage,
+      message,
       duration: duration,
       landscapePNG: null,
       portraitPNG: null,
@@ -162,32 +144,25 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
           <ConfirmationPage
             goToStep={this.goToStep}
             selectedStations={this.state.selectedStations}
-            message={
-              this.state.messageOption === "1"
-                ? CANNED_MESSAGES[parseInt(this.state.cannedMessage)]
-                : this.state.customMessage
-            }
+            message={getMessageString(this.state.message)}
             duration={this.state.duration}
           />
         );
       default:
         return (
           <CreateMessage
-            messageOption={this.state.messageOption}
-            cannedMessage={this.state.cannedMessage}
-            customMessage={this.state.customMessage}
-            changeMessageOption={this.changeMessageOption}
-            changeCannedMessage={this.changeCannedMessage}
-            changeCustomMessage={this.changeCustomMessage}
+            value={this.state.message}
+            onChange={(v) => this.setState({ message: v })}
           />
         );
     }
   }
 
   waitingForInput() {
+    const { message } = this.state;
     switch (this.state.step) {
       case 1:
-        return !this.state.cannedMessage && !this.state.customMessage;
+        return message.type === "canned" ? message.id === -1 : !message.text;
       case 2:
         return this.state.selectedStations.length === 0;
       // Because 1 hour is automatically selected
@@ -249,20 +224,13 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
     ) as HTMLMetaElement;
     const csrfToken = csrfMetaElement.content;
 
-    let message;
-    if (this.state.messageOption === "1") {
-      message = { type: "canned", id: parseInt(this.state.cannedMessage) };
-    } else {
-      message = { type: "custom", text: this.state.customMessage };
-    }
-
     const stations = this.state.selectedStations.map(({ name }) => name);
     const duration = this.state.duration;
     const landscapePNG = this.state.landscapePNG;
     const portraitPNG = this.state.portraitPNG;
 
     const data = {
-      message,
+      message: this.state.message,
       stations,
       duration,
       portrait_png: portraitPNG,
@@ -351,27 +319,6 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
     }
   }
 
-  changeMessageOption(event: any) {
-    this.setState({ messageOption: event.target.value });
-  }
-
-  changeCannedMessage(event: any) {
-    const index = parseInt(event.target.value);
-    this.setState({
-      messageOption: "1",
-      cannedMessage: event.target.value,
-      customMessage: CANNED_MESSAGES[index],
-    });
-  }
-
-  changeCustomMessage(event: any) {
-    this.setState({
-      messageOption: "2",
-      cannedMessage: "",
-      customMessage: event.target.value,
-    });
-  }
-
   changeDuration(event: any) {
     if (event.target.value === "Open ended") {
       this.setState({ duration: event.target.value });
@@ -397,8 +344,8 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
 
     const img = new Image();
 
-    if (this.state.cannedMessage !== "") {
-      img.src = `/images/Outfront-Alert-${this.state.cannedMessage}-${orientation}.png`;
+    if (this.state.message.type === "canned") {
+      img.src = `/images/Outfront-Alert-${this.state.message.id}-${orientation}.png`;
     } else {
       const svg = document.getElementById(orientation + "-svg") as HTMLElement;
       const data = new XMLSerializer().serializeToString(svg);
@@ -461,10 +408,7 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
           <WizardSidebar
             selectedStations={this.state.selectedStations}
             step={this.state.step}
-            customMessage={
-              this.state.messageOption === "1" ? "" : this.state.customMessage
-            }
-            cannedMessageId={this.state.cannedMessage}
+            message={this.state.message}
           />
         </div>
         <WizardNavFooter

--- a/assets/js/components/EmergencyTakeoverTool/AlertWizard/AlertWizard.tsx
+++ b/assets/js/components/EmergencyTakeoverTool/AlertWizard/AlertWizard.tsx
@@ -15,7 +15,7 @@ import {
 import { NoSymbolIcon, XMarkIcon } from "@heroicons/react/20/solid";
 import WizardSidebar from "./WizardSidebar";
 import { svgLongSide, svgScale, svgShortSide } from "Constants/misc";
-import { getMessageString, matchStation } from "../../../util";
+import { matchStation } from "../../../util";
 
 import { differenceInHours, parseISO } from "date-fns";
 import { ModalDetails } from "../ConfirmationModal";
@@ -32,7 +32,8 @@ interface AlertWizardState {
   step: number;
   cancelModal: boolean;
   selectedStations: Station[];
-  message: Message;
+  indoorMessage: Message;
+  outdoorMessage: Message;
   duration: string | number;
   id: string | null;
   activeAlertsList: any[];
@@ -52,7 +53,8 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
         cancelModal: false,
         // User input state
         selectedStations: [],
-        message: { type: "canned", id: -1 },
+        indoorMessage: { type: "canned", id: -1 },
+        outdoorMessage: { type: "canned", id: -1 },
         duration: 1,
         activeAlertsList: [],
         showErrorMessage: false,
@@ -74,7 +76,8 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
   }
 
   initializeState(alertData: AlertData) {
-    const { id, message, stations, schedule } = alertData;
+    const { id, indoor_message, outdoor_message, stations, schedule } =
+      alertData;
 
     const selectedStations = stations.map((station: string) =>
       matchStation(station, this.props.stationScreenOrientationList),
@@ -99,7 +102,8 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
       cancelModal: false,
       // User input state
       selectedStations: selectedStations,
-      message,
+      indoorMessage: indoor_message,
+      outdoorMessage: outdoor_message,
       duration: duration,
       activeAlertsList: [],
       showErrorMessage: false,
@@ -138,25 +142,30 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
           <ConfirmationPage
             goToStep={this.goToStep}
             selectedStations={this.state.selectedStations}
-            message={getMessageString(this.state.message)}
+            indoorMessage={this.state.indoorMessage}
+            outdoorMessage={this.state.outdoorMessage}
             duration={this.state.duration}
           />
         );
       default:
         return (
           <CreateMessage
-            value={this.state.message}
-            onChange={(v) => this.setState({ message: v })}
+            indoorValue={this.state.indoorMessage}
+            onChangeIndoor={(v) => this.setState({ indoorMessage: v })}
+            outdoorValue={this.state.outdoorMessage}
+            onChangeOutdoor={(v) => this.setState({ outdoorMessage: v })}
           />
         );
     }
   }
 
   waitingForInput() {
-    const { message } = this.state;
+    const { indoorMessage, outdoorMessage } = this.state;
+    const invalidMessage = (message: Message) =>
+      message.type === "canned" ? message.id === -1 : !message.text;
     switch (this.state.step) {
       case 1:
-        return message.type === "canned" ? message.id === -1 : !message.text;
+        return invalidMessage(indoorMessage) || invalidMessage(outdoorMessage);
       case 2:
         return this.state.selectedStations.length === 0;
       // Because 1 hour is automatically selected
@@ -216,14 +225,21 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
     const duration = this.state.duration;
     const pngs = Object.fromEntries(
       await Promise.all(
-        ["portrait", "landscape"].map(async (orientation) => {
-          return [orientation, await this.makePNG(orientation)];
-        }),
+        [
+          { message: this.state.indoorMessage, prefix: "indoor" },
+          { message: this.state.outdoorMessage, prefix: "outdoor" },
+        ].flatMap(({ message, prefix }) =>
+          ["portrait", "landscape"].map(async (orientation) => [
+            `${prefix}_${orientation}`,
+            await this.makePNG(message, prefix, orientation),
+          ]),
+        ),
       ),
     );
 
     const data = {
-      message: this.state.message,
+      indoor_message: this.state.indoorMessage,
+      outdoor_message: this.state.outdoorMessage,
       stations,
       duration,
       pngs,
@@ -319,7 +335,7 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
     }
   }
 
-  async makePNG(orientation: string) {
+  async makePNG(message: Message, prefix: string, orientation: string) {
     const [width, height] =
       orientation === "portrait"
         ? [svgShortSide, svgLongSide]
@@ -342,10 +358,10 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
     await new Promise((resolve) => {
       img.onload = resolve;
       img.src =
-        this.state.message.type === "canned"
-          ? `/images/Outfront-Alert-${this.state.message.id}-${orientation}.png`
+        message.type === "canned"
+          ? `/images/Outfront-Alert-${message.id}-${orientation}.png`
           : svg_to_uri(
-              document.getElementById(orientation + "-svg") as HTMLElement,
+              document.getElementById(`${prefix}-${orientation}-svg`)!,
             );
     });
 
@@ -388,7 +404,8 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
           <WizardSidebar
             selectedStations={this.state.selectedStations}
             step={this.state.step}
-            message={this.state.message}
+            indoorMessage={this.state.indoorMessage}
+            outdoorMessage={this.state.outdoorMessage}
           />
         </div>
         <WizardNavFooter

--- a/assets/js/components/EmergencyTakeoverTool/AlertWizard/AlertWizard.tsx
+++ b/assets/js/components/EmergencyTakeoverTool/AlertWizard/AlertWizard.tsx
@@ -34,8 +34,6 @@ interface AlertWizardState {
   selectedStations: Station[];
   message: Message;
   duration: string | number;
-  landscapePNG: string | null;
-  portraitPNG: string | null;
   id: string | null;
   activeAlertsList: any[];
   showErrorMessage: boolean;
@@ -56,8 +54,6 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
         selectedStations: [],
         message: { type: "canned", id: -1 },
         duration: 1,
-        landscapePNG: null,
-        portraitPNG: null,
         activeAlertsList: [],
         showErrorMessage: false,
       };
@@ -105,8 +101,6 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
       selectedStations: selectedStations,
       message,
       duration: duration,
-      landscapePNG: null,
-      portraitPNG: null,
       activeAlertsList: [],
       showErrorMessage: false,
     };
@@ -183,12 +177,6 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
     if (this.state.step === 4) {
       this.handleSubmit();
     } else {
-      // Temporary hack: to avoid race conditions, convert the SVG to a PNG upon station selection,
-      // which must always happen after message selection.
-      if (this.state.step === 2) {
-        this.generatePNGs();
-      }
-
       this.setState((state) => ({
         step: state.step + 1,
       }));
@@ -215,7 +203,7 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
       });
   }
 
-  handleSubmit() {
+  async handleSubmit() {
     const endpoint =
       this.state.id === null ? `${BASE_URL}/create` : `${BASE_URL}/edit`;
 
@@ -226,15 +214,19 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
 
     const stations = this.state.selectedStations.map(({ name }) => name);
     const duration = this.state.duration;
-    const landscapePNG = this.state.landscapePNG;
-    const portraitPNG = this.state.portraitPNG;
+    const pngs = Object.fromEntries(
+      await Promise.all(
+        ["portrait", "landscape"].map(async (orientation) => {
+          return [orientation, await this.makePNG(orientation)];
+        }),
+      ),
+    );
 
     const data = {
       message: this.state.message,
       stations,
       duration,
-      portrait_png: portraitPNG,
-      landscape_png: landscapePNG,
+      pngs,
       id: this.state.id,
     };
 
@@ -327,12 +319,11 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
     }
   }
 
-  makePNG(
-    orientation: string,
-    width: number,
-    height: number,
-    callback: (dataUrl: string) => void,
-  ) {
+  async makePNG(orientation: string) {
+    const [width, height] =
+      orientation === "portrait"
+        ? [svgShortSide, svgLongSide]
+        : [svgLongSide, svgShortSide];
     const canvas = document.createElement("canvas");
     canvas.width = width * svgScale;
     canvas.height = height * svgScale;
@@ -344,36 +335,25 @@ class AlertWizard extends React.Component<AlertWizardProps, AlertWizardState> {
 
     const img = new Image();
 
-    if (this.state.message.type === "canned") {
-      img.src = `/images/Outfront-Alert-${this.state.message.id}-${orientation}.png`;
-    } else {
-      const svg = document.getElementById(orientation + "-svg") as HTMLElement;
-      const data = new XMLSerializer().serializeToString(svg);
+    const svg_to_uri = (svg: HTMLElement) =>
+      "data:image/svg+xml;base64," +
+      btoa(new XMLSerializer().serializeToString(svg));
+
+    await new Promise((resolve) => {
+      img.onload = resolve;
       img.src =
-        "data:image/svg+xml;base64," + btoa(unescape(encodeURIComponent(data)));
-    }
+        this.state.message.type === "canned"
+          ? `/images/Outfront-Alert-${this.state.message.id}-${orientation}.png`
+          : svg_to_uri(
+              document.getElementById(orientation + "-svg") as HTMLElement,
+            );
+    });
 
-    img.onload = () => {
-      ctx.drawImage(img, 0, 0, width, height);
-      const imgURI = canvas.toDataURL("image/png");
-      callback(imgURI);
-    };
-  }
-
-  generatePNGs() {
-    this.makePNG("portrait", svgShortSide, svgLongSide, (url) =>
-      this.setState({ portraitPNG: url }),
-    );
-    this.makePNG("landscape", svgLongSide, svgShortSide, (url) =>
-      this.setState({ landscapePNG: url }),
-    );
+    ctx.drawImage(img, 0, 0, width, height);
+    return canvas.toDataURL("image/png");
   }
 
   render() {
-    const { step, landscapePNG, portraitPNG } = this.state;
-    if (step > 2 && (landscapePNG === null || portraitPNG === null)) {
-      this.generatePNGs();
-    }
     const modalDetails: ModalDetails = {
       icon: <NoSymbolIcon className="icon" />,
       header: "Cancel new Takeover Alert",

--- a/assets/js/components/EmergencyTakeoverTool/AlertWizard/ConfirmationPage.tsx
+++ b/assets/js/components/EmergencyTakeoverTool/AlertWizard/ConfirmationPage.tsx
@@ -1,12 +1,13 @@
 import React from "react";
-import { formatDate, formatTime } from "../../../util";
+import { formatDate, formatTime, getMessageString } from "../../../util";
 import StackedStationCards from "./StackedStationCards";
-import { Station } from "../EmergencyTakeoverTool";
+import { Message, Station } from "../EmergencyTakeoverTool";
 
 interface ConfirmationPageProps {
   goToStep: (step: number) => void;
   selectedStations: Station[];
-  message: string;
+  indoorMessage: Message;
+  outdoorMessage: Message;
   duration: number | string;
 }
 
@@ -34,15 +35,20 @@ const ConfirmationPage = (props: ConfirmationPageProps): JSX.Element => {
       </div>
       <table className="details-grid">
         <tbody>
-          <tr className="gray-row">
-            <td>Message text</td>
-            <td className="emphasized-cell">{props.message}</td>
-            <td>
-              <div className="edit-link" onClick={() => props.goToStep(1)}>
-                Edit
-              </div>
-            </td>
-          </tr>
+          {[
+            { message: props.indoorMessage, label: "Indoor" },
+            { message: props.outdoorMessage, label: "Outdoor" },
+          ].map(({ message, label }) => (
+            <tr key={label} className="gray-row">
+              <td>{label} text</td>
+              <td className="emphasized-cell">{getMessageString(message)}</td>
+              <td>
+                <div className="edit-link" onClick={() => props.goToStep(1)}>
+                  Edit
+                </div>
+              </td>
+            </tr>
+          ))}
           <tr>
             <td>Stations</td>
             <td>

--- a/assets/js/components/EmergencyTakeoverTool/AlertWizard/CreateMessage.tsx
+++ b/assets/js/components/EmergencyTakeoverTool/AlertWizard/CreateMessage.tsx
@@ -55,7 +55,7 @@ const MessageInput = ({
     <div className="step-body">
       <div className="info">
         <div>{label} text</div>
-        <div className="text-14">(144 character max)</div>
+        <div className="text-14">&nbsp;(144 character max)</div>
       </div>
       <div>
         <div

--- a/assets/js/components/EmergencyTakeoverTool/AlertWizard/CreateMessage.tsx
+++ b/assets/js/components/EmergencyTakeoverTool/AlertWizard/CreateMessage.tsx
@@ -1,17 +1,16 @@
 import React from "react";
 import CANNED_MESSAGES from "Constants/messages";
 import { charLimit } from "Constants/misc";
+import { Message } from "../EmergencyTakeoverTool";
+import cx from "classnames";
+import { getMessageString } from "../../../util";
 
 interface CreateMessageProps {
-  messageOption: string;
-  cannedMessage: string;
-  customMessage: string;
-  changeMessageOption: (event: any) => void;
-  changeCannedMessage: (event: any) => void;
-  changeCustomMessage: (event: any) => void;
+  value: Message;
+  onChange: (value: Message) => void;
 }
 
-const CreateMessage = (props: CreateMessageProps) => {
+const CreateMessage = ({ value, onChange }: CreateMessageProps) => {
   return (
     <>
       <div className="step-instructions">
@@ -29,20 +28,22 @@ const CreateMessage = (props: CreateMessageProps) => {
         </div>
         <div>
           <div
-            className={`radio-option option-one ${
-              props.messageOption === "1" ? "selected-option" : ""
-            }`}
+            className={cx("radio-option", "option-one", {
+              "selected-option": value.type === "canned",
+            })}
           >
             <input
               type="radio"
               value="1"
-              checked={props.messageOption === "1"}
-              onChange={props.changeMessageOption}
+              checked={value.type === "canned"}
+              onChange={() => onChange({ type: "canned", id: -1 })}
             />
             <select
               className="message-select text-16"
-              value={props.cannedMessage}
-              onChange={props.changeCannedMessage}
+              value={value.type === "canned" ? value.id : -1}
+              onChange={(e) =>
+                onChange({ type: "canned", id: +e.target.value })
+              }
             >
               <option value={-1} hidden>
                 Select canned message…
@@ -55,22 +56,26 @@ const CreateMessage = (props: CreateMessageProps) => {
             </select>
           </div>
           <div
-            className={`radio-option option-two ${
-              props.messageOption === "2" ? "selected-option" : ""
-            }`}
+            className={cx("radio-option", "option-two", {
+              "selected-option": value.type === "custom",
+            })}
           >
             <input
               type="radio"
               value="2"
-              checked={props.messageOption === "2"}
-              onChange={props.changeMessageOption}
+              checked={value.type === "custom"}
+              onChange={() =>
+                onChange({ type: "custom", text: getMessageString(value) })
+              }
             />
             <textarea
               className="message-textarea text-16"
-              value={props.customMessage}
+              value={getMessageString(value)}
               maxLength={charLimit}
               placeholder="Type, or select a canned message above to edit here..."
-              onChange={props.changeCustomMessage}
+              onChange={(e) =>
+                onChange({ type: "custom", text: e.target.value })
+              }
             ></textarea>
           </div>
         </div>

--- a/assets/js/components/EmergencyTakeoverTool/AlertWizard/CreateMessage.tsx
+++ b/assets/js/components/EmergencyTakeoverTool/AlertWizard/CreateMessage.tsx
@@ -6,11 +6,18 @@ import cx from "classnames";
 import { getMessageString } from "../../../util";
 
 interface CreateMessageProps {
-  value: Message;
-  onChange: (value: Message) => void;
+  indoorValue: Message;
+  onChangeIndoor: (value: Message) => void;
+  outdoorValue: Message;
+  onChangeOutdoor: (value: Message) => void;
 }
 
-const CreateMessage = ({ value, onChange }: CreateMessageProps) => {
+const CreateMessage = ({
+  indoorValue,
+  onChangeIndoor,
+  outdoorValue,
+  onChangeOutdoor,
+}: CreateMessageProps) => {
   return (
     <>
       <div className="step-instructions">
@@ -21,66 +28,85 @@ const CreateMessage = ({ value, onChange }: CreateMessageProps) => {
           action.
         </div>
       </div>
-      <div className="step-body">
-        <div className="info">
-          <div>Message text</div>
-          <div className="text-14">(144 character max)</div>
-        </div>
-        <div>
-          <div
-            className={cx("radio-option", "option-one", {
-              "selected-option": value.type === "canned",
-            })}
+      <MessageInput
+        value={indoorValue}
+        onChange={onChangeIndoor}
+        label="Indoor"
+      />
+      <MessageInput
+        value={outdoorValue}
+        onChange={onChangeOutdoor}
+        label="Outdoor"
+      />
+    </>
+  );
+};
+
+const MessageInput = ({
+  value,
+  onChange,
+  label,
+}: {
+  value: Message;
+  onChange: (value: Message) => void;
+  label: string;
+}) => {
+  return (
+    <div className="step-body">
+      <div className="info">
+        <div>{label} text</div>
+        <div className="text-14">(144 character max)</div>
+      </div>
+      <div>
+        <div
+          className={cx("radio-option", "option-one", {
+            "selected-option": value.type === "canned",
+          })}
+        >
+          <input
+            type="radio"
+            value="1"
+            checked={value.type === "canned"}
+            onChange={() => onChange({ type: "canned", id: -1 })}
+          />
+          <select
+            className="message-select text-16"
+            value={value.type === "canned" ? value.id : -1}
+            onChange={(e) => onChange({ type: "canned", id: +e.target.value })}
           >
-            <input
-              type="radio"
-              value="1"
-              checked={value.type === "canned"}
-              onChange={() => onChange({ type: "canned", id: -1 })}
-            />
-            <select
-              className="message-select text-16"
-              value={value.type === "canned" ? value.id : -1}
-              onChange={(e) =>
-                onChange({ type: "canned", id: +e.target.value })
-              }
-            >
-              <option value={-1} hidden>
-                Select canned message…
+            <option value={-1} hidden>
+              Select canned message…
+            </option>
+            {CANNED_MESSAGES.map((message, index) => (
+              <option key={index} value={index}>
+                {message}
               </option>
-              {CANNED_MESSAGES.map((message, index) => (
-                <option key={index} value={index}>
-                  {message}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div
-            className={cx("radio-option", "option-two", {
-              "selected-option": value.type === "custom",
-            })}
-          >
-            <input
-              type="radio"
-              value="2"
-              checked={value.type === "custom"}
-              onChange={() =>
-                onChange({ type: "custom", text: getMessageString(value) })
-              }
-            />
-            <textarea
-              className="message-textarea text-16"
-              value={getMessageString(value)}
-              maxLength={charLimit}
-              placeholder="Type, or select a canned message above to edit here..."
-              onChange={(e) =>
-                onChange({ type: "custom", text: e.target.value })
-              }
-            ></textarea>
-          </div>
+            ))}
+          </select>
+        </div>
+        <div
+          className={cx("radio-option", "option-two", {
+            "selected-option": value.type === "custom",
+          })}
+        >
+          <input
+            type="radio"
+            value="2"
+            checked={value.type === "custom"}
+            onChange={() =>
+              onChange({ type: "custom", text: getMessageString(value) })
+            }
+          />
+          <textarea
+            className="message-textarea text-16"
+            value={getMessageString(value)}
+            maxLength={charLimit}
+            placeholder="Type, or select a canned message above to edit here..."
+            onChange={(e) => onChange({ type: "custom", text: e.target.value })}
+          ></textarea>
         </div>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/assets/js/components/EmergencyTakeoverTool/AlertWizard/SVGPreviews.tsx
+++ b/assets/js/components/EmergencyTakeoverTool/AlertWizard/SVGPreviews.tsx
@@ -16,6 +16,7 @@ import {
 interface SVGPreviewsProps {
   showText: boolean;
   message: string;
+  prefix: string;
 }
 
 const createSVGText = (message: string, orientation: string) => {
@@ -232,7 +233,7 @@ class SVGPreviews extends React.Component<SVGPreviewsProps> {
         ) : (
           /* Portrait SVG */
           <svg
-            id="portrait-svg"
+            id={`${this.props.prefix}-portrait-svg`}
             className="portrait-svg"
             width={svgShortSide}
             height={svgLongSide}
@@ -341,7 +342,7 @@ class SVGPreviews extends React.Component<SVGPreviewsProps> {
 
         {/* Landscape SVG */}
         <svg
-          id="landscape-svg"
+          id={`${this.props.prefix}-landscape-svg`}
           className="landscape-hidden"
           width={svgLongSide}
           height={svgShortSide}

--- a/assets/js/components/EmergencyTakeoverTool/AlertWizard/WizardSidebar.tsx
+++ b/assets/js/components/EmergencyTakeoverTool/AlertWizard/WizardSidebar.tsx
@@ -2,13 +2,12 @@ import React from "react";
 import StackedStationCards from "./StackedStationCards";
 
 import SVGPreviews from "./SVGPreviews";
-import { Station } from "../EmergencyTakeoverTool";
+import { Message, Station } from "../EmergencyTakeoverTool";
 
 interface WizardSidebarProps {
   selectedStations: Station[];
   step: number;
-  customMessage: string;
-  cannedMessageId: string;
+  message: Message;
 }
 
 class WizardSidebar extends React.Component<WizardSidebarProps> {
@@ -25,17 +24,17 @@ class WizardSidebar extends React.Component<WizardSidebarProps> {
           alt=""
         />
       );
-    } else if (this.props.cannedMessageId !== "") {
+    } else if (this.props.message.type === "canned") {
       return (
         <img
           className="portrait-png"
-          src={`/images/Outfront-Alert-${this.props.cannedMessageId}-portrait.png`}
+          src={`/images/Outfront-Alert-${this.props.message.id}-portrait.png`}
           alt=""
         />
       );
     }
 
-    return <SVGPreviews showText={true} message={this.props.customMessage} />;
+    return <SVGPreviews showText={true} message={this.props.message.text} />;
   }
 
   render() {

--- a/assets/js/components/EmergencyTakeoverTool/AlertWizard/WizardSidebar.tsx
+++ b/assets/js/components/EmergencyTakeoverTool/AlertWizard/WizardSidebar.tsx
@@ -7,7 +7,8 @@ import { Message, Station } from "../EmergencyTakeoverTool";
 interface WizardSidebarProps {
   selectedStations: Station[];
   step: number;
-  message: Message;
+  indoorMessage: Message;
+  outdoorMessage: Message;
 }
 
 class WizardSidebar extends React.Component<WizardSidebarProps> {
@@ -15,7 +16,7 @@ class WizardSidebar extends React.Component<WizardSidebarProps> {
     super(props);
   }
 
-  getPreviewImage() {
+  getPreviewImage(message: Message, prefix: string) {
     if (this.props.step === 1) {
       return (
         <img
@@ -24,24 +25,25 @@ class WizardSidebar extends React.Component<WizardSidebarProps> {
           alt=""
         />
       );
-    } else if (this.props.message.type === "canned") {
+    } else if (message.type === "canned") {
       return (
         <img
           className="portrait-png"
-          src={`/images/Outfront-Alert-${this.props.message.id}-portrait.png`}
+          src={`/images/Outfront-Alert-${message.id}-portrait.png`}
           alt=""
         />
       );
     }
 
-    return <SVGPreviews showText={true} message={this.props.message.text} />;
+    return <SVGPreviews showText prefix={prefix} message={message.text} />;
   }
 
   render() {
     return (
       <div className="wizard-sidebar">
         <span className="preview-title text-16">Preview</span>
-        {this.getPreviewImage()}
+        {this.getPreviewImage(this.props.indoorMessage, "indoor")}
+        {this.getPreviewImage(this.props.outdoorMessage, "outdoor")}
         <StackedStationCards stations={this.props.selectedStations} />
       </div>
     );

--- a/assets/js/components/EmergencyTakeoverTool/EmergencyTakeoverTool.tsx
+++ b/assets/js/components/EmergencyTakeoverTool/EmergencyTakeoverTool.tsx
@@ -45,7 +45,8 @@ interface AlertData {
   cleared_by: string;
   created_by: string;
   edited_by: string;
-  message: Message;
+  indoor_message: Message;
+  outdoor_message: Message;
   schedule: Schedule;
   stations: string[];
   step: number | null;

--- a/assets/js/components/EmergencyTakeoverTool/EmergencyTakeoverTool.tsx
+++ b/assets/js/components/EmergencyTakeoverTool/EmergencyTakeoverTool.tsx
@@ -37,13 +37,15 @@ interface Schedule {
   end: string;
 }
 
+export type Message = CannedMessage | CustomMessage;
+
 interface AlertData {
   id: string;
   cleared_at: string;
   cleared_by: string;
   created_by: string;
   edited_by: string;
-  message: CannedMessage | CustomMessage;
+  message: Message;
   schedule: Schedule;
   stations: string[];
   step: number | null;

--- a/assets/js/util.ts
+++ b/assets/js/util.ts
@@ -1,7 +1,6 @@
 import { BASE_ROUTE_NAME_TO_ROUTE_IDS } from "Constants/constants";
 import {
-  CannedMessage,
-  CustomMessage,
+  Message,
   StationsByLine,
 } from "./components/EmergencyTakeoverTool/EmergencyTakeoverTool";
 import CANNED_MESSAGES from "Constants/messages";
@@ -144,11 +143,11 @@ export const formatTime = (date: Date) => {
   }).format(date);
 };
 
-export const getMessageString = (message: CannedMessage | CustomMessage) => {
-  // @ts-expect-error work around loose typing
-  if (message.id !== undefined) return CANNED_MESSAGES[parseInt(message.id)];
-  // @ts-expect-error work around loose typing
-  else return message.text;
+export const getMessageString = (message: Message) => {
+  if (message.type === "canned") {
+    return message.id === -1 ? "" : CANNED_MESSAGES[message.id];
+  }
+  return message.text;
 };
 
 export const classWithModifier = (baseClass: string, modifier: string) => {

--- a/lib/screenplay/emergency_takeover_tool/alerts/alert.ex
+++ b/lib/screenplay/emergency_takeover_tool/alerts/alert.ex
@@ -8,7 +8,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.Alert do
 
   @enforce_keys [
     :id,
-    :message,
+    :indoor_message,
+    :outdoor_message,
     :stations,
     :schedule,
     :created_by,
@@ -40,14 +41,16 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.Alert do
   @type user :: String.t()
 
   @type update_map :: %{
-          optional(:message) => canned_message() | custom_message(),
+          optional(:indoor_message) => canned_message() | custom_message(),
+          optional(:outdoor_message) => canned_message() | custom_message(),
           optional(:stations) => list(station),
           optional(:schedule) => schedule()
         }
 
   @type t :: %__MODULE__{
           id: id(),
-          message: canned_message() | custom_message(),
+          indoor_message: canned_message() | custom_message(),
+          outdoor_message: canned_message() | custom_message(),
           stations: list(station()),
           schedule: schedule(),
           created_by: user(),
@@ -62,11 +65,18 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.Alert do
     length |> :crypto.strong_rand_bytes() |> Base.url_encode64()
   end
 
-  @spec new(canned_message() | custom_message(), list(station()), schedule(), user()) :: t()
-  def new(message, stations, schedule, user) do
+  @spec new(
+          canned_message() | custom_message(),
+          canned_message() | custom_message(),
+          list(station()),
+          schedule(),
+          user()
+        ) :: t()
+  def new(indoor_message, outdoor_message, stations, schedule, user) do
     %__MODULE__{
       id: State.get_unused_alert_id(),
-      message: message,
+      indoor_message: indoor_message,
+      outdoor_message: outdoor_message,
       stations: stations,
       schedule: schedule,
       created_by: Util.trim_username(user),
@@ -93,7 +103,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.Alert do
   @spec to_json(t()) :: map()
   def to_json(%__MODULE__{
         id: id,
-        message: message,
+        indoor_message: indoor_message,
+        outdoor_message: outdoor_message,
         stations: stations,
         schedule: schedule,
         created_by: created_by,
@@ -103,7 +114,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.Alert do
       }) do
     %{
       "id" => id,
-      "message" => message_to_json(message),
+      "indoor_message" => message_to_json(indoor_message),
+      "outdoor_message" => message_to_json(outdoor_message),
       "stations" => stations_to_json(stations),
       "schedule" => schedule_to_json(schedule),
       "created_by" => Util.trim_username(created_by),
@@ -116,7 +128,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.Alert do
   @spec from_json(map()) :: t()
   def from_json(%{
         "id" => id,
-        "message" => message_json,
+        "indoor_message" => indoor_message_json,
+        "outdoor_message" => outdoor_message_json,
         "stations" => stations_json,
         "schedule" => schedule_json,
         "created_by" => created_by,
@@ -126,7 +139,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.Alert do
       }) do
     %__MODULE__{
       id: id,
-      message: message_from_json(message_json),
+      indoor_message: message_from_json(indoor_message_json),
+      outdoor_message: message_from_json(outdoor_message_json),
       stations: stations_from_json(stations_json),
       schedule: schedule_from_json(schedule_json),
       created_by: Util.trim_username(created_by),
@@ -138,7 +152,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.Alert do
 
   def from_json(%{
         "id" => id,
-        "message" => message_json,
+        "indoor_message" => indoor_message_json,
+        "outdoor_message" => outdoor_message_json,
         "stations" => stations_json,
         "schedule" => schedule_json,
         "created_by" => created_by,
@@ -146,7 +161,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.Alert do
       }) do
     %__MODULE__{
       id: id,
-      message: message_from_json(message_json),
+      indoor_message: message_from_json(indoor_message_json),
+      outdoor_message: message_from_json(outdoor_message_json),
       stations: stations_from_json(stations_json),
       schedule: schedule_from_json(schedule_json),
       created_by: Util.trim_username(created_by),

--- a/lib/screenplay/emergency_takeover_tool/alerts/state.ex
+++ b/lib/screenplay/emergency_takeover_tool/alerts/state.ex
@@ -191,7 +191,12 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.State do
                 stations_to_delete: Enum.concat(acc.stations_to_delete, a.stations)
               }
             else
-              changes = %{message: a.message, stations: stations_no_overlap, schedule: a.schedule}
+              changes = %{
+                indoor_message: a.indoor_message,
+                outdoor_message: a.outdoor_message,
+                stations: stations_no_overlap,
+                schedule: a.schedule
+              }
 
               %{
                 alerts: Map.put(acc.alerts, existing_id, Alert.update(a, changes, user)),

--- a/lib/screenplay_web/controllers/emergency_takeover_tool/alert_controller.ex
+++ b/lib/screenplay_web/controllers/emergency_takeover_tool/alert_controller.ex
@@ -11,8 +11,7 @@ defmodule ScreenplayWeb.EmergencyTakeoverTool.AlertController do
           "message" => message,
           "stations" => stations,
           "duration" => duration_in_hours,
-          "portrait_png" => portrait_png,
-          "landscape_png" => landscape_png
+          "pngs" => pngs
         }
       ) do
     schedule = schedule_from_duration(DateTime.utc_now(), duration_in_hours)
@@ -31,8 +30,8 @@ defmodule ScreenplayWeb.EmergencyTakeoverTool.AlertController do
     _ = UserActionLogger.log(user, :create_alert, params_to_log)
     :ok = State.add_alert(alert)
 
-    portrait_image_data = decode_png(portrait_png)
-    landscape_image_data = decode_png(landscape_png)
+    portrait_image_data = decode_png(pngs["portrait"])
+    landscape_image_data = decode_png(pngs["landscape"])
 
     _ = SFTP.set_takeover_images(stations, portrait_image_data, landscape_image_data)
 
@@ -50,8 +49,7 @@ defmodule ScreenplayWeb.EmergencyTakeoverTool.AlertController do
           "message" => message,
           "stations" => stations,
           "duration" => duration_in_hours,
-          "portrait_png" => portrait_png,
-          "landscape_png" => landscape_png
+          "pngs" => pngs
         }
       ) do
     alert = State.get_alert(id)
@@ -69,8 +67,8 @@ defmodule ScreenplayWeb.EmergencyTakeoverTool.AlertController do
     _ = UserActionLogger.log(user, :update_alert, params_to_log)
     :ok = State.update_alert(id, new_alert)
 
-    portrait_image_data = decode_png(portrait_png)
-    landscape_image_data = decode_png(landscape_png)
+    portrait_image_data = decode_png(pngs["portrait"])
+    landscape_image_data = decode_png(pngs["landscape"])
 
     _ = SFTP.set_takeover_images(stations, portrait_image_data, landscape_image_data)
 

--- a/lib/screenplay_web/controllers/emergency_takeover_tool/alert_controller.ex
+++ b/lib/screenplay_web/controllers/emergency_takeover_tool/alert_controller.ex
@@ -8,7 +8,8 @@ defmodule ScreenplayWeb.EmergencyTakeoverTool.AlertController do
   def create(
         conn,
         params = %{
-          "message" => message,
+          "indoor_message" => indoor_message,
+          "outdoor_message" => outdoor_message,
           "stations" => stations,
           "duration" => duration_in_hours,
           "pngs" => pngs
@@ -19,19 +20,20 @@ defmodule ScreenplayWeb.EmergencyTakeoverTool.AlertController do
 
     remove_overlapping_alerts(params, user)
 
-    message = Alert.message_from_json(message)
-    alert = Alert.new(message, stations, schedule, user)
+    indoor_message = Alert.message_from_json(indoor_message)
+    outdoor_message = Alert.message_from_json(outdoor_message)
+    alert = Alert.new(indoor_message, outdoor_message, stations, schedule, user)
 
     params_to_log =
       params
-      |> Map.take(["message", "stations", "duration"])
+      |> Map.take(["indoor_message", "outdoor_message", "stations", "duration"])
       |> Map.merge(%{"id" => alert.id})
 
     _ = UserActionLogger.log(user, :create_alert, params_to_log)
     :ok = State.add_alert(alert)
 
-    portrait_image_data = decode_png(pngs["portrait"])
-    landscape_image_data = decode_png(pngs["landscape"])
+    portrait_image_data = decode_png(pngs["indoor_portrait"])
+    landscape_image_data = decode_png(pngs["outdoor_landscape"])
 
     _ = SFTP.set_takeover_images(stations, portrait_image_data, landscape_image_data)
 
@@ -46,7 +48,8 @@ defmodule ScreenplayWeb.EmergencyTakeoverTool.AlertController do
         conn,
         params = %{
           "id" => id,
-          "message" => message,
+          "indoor_message" => indoor_message,
+          "outdoor_message" => outdoor_message,
           "stations" => stations,
           "duration" => duration_in_hours,
           "pngs" => pngs
@@ -54,8 +57,15 @@ defmodule ScreenplayWeb.EmergencyTakeoverTool.AlertController do
       ) do
     alert = State.get_alert(id)
     schedule = schedule_from_duration(DateTime.utc_now(), duration_in_hours)
-    message = Alert.message_from_json(message)
-    changes = %{message: message, stations: stations, schedule: schedule}
+    indoor_message = Alert.message_from_json(indoor_message)
+    outdoor_message = Alert.message_from_json(outdoor_message)
+
+    changes = %{
+      indoor_message: indoor_message,
+      outdoor_message: outdoor_message,
+      stations: stations,
+      schedule: schedule
+    }
 
     user = get_session(conn, "username")
 
@@ -63,12 +73,14 @@ defmodule ScreenplayWeb.EmergencyTakeoverTool.AlertController do
 
     new_alert = Alert.update(alert, changes, user)
 
-    params_to_log = Map.take(params, ["message", "stations", "duration", "id"])
+    params_to_log =
+      Map.take(params, ["indoor_message", "outdoor_message", "stations", "duration", "id"])
+
     _ = UserActionLogger.log(user, :update_alert, params_to_log)
     :ok = State.update_alert(id, new_alert)
 
-    portrait_image_data = decode_png(pngs["portrait"])
-    landscape_image_data = decode_png(pngs["landscape"])
+    portrait_image_data = decode_png(pngs["indoor_portrait"])
+    landscape_image_data = decode_png(pngs["outdoor_landscape"])
 
     _ = SFTP.set_takeover_images(stations, portrait_image_data, landscape_image_data)
 

--- a/test/fixtures/alerts.json
+++ b/test/fixtures/alerts.json
@@ -6,8 +6,12 @@
       "created_by": "user",
       "edited_by": "user",
       "id": "a1",
-      "message": {
+      "indoor_message": {
         "id": 1,
+        "type": "canned"
+      },
+      "outdoor_message": {
+        "id": 2,
         "type": "canned"
       },
       "schedule": {
@@ -25,8 +29,12 @@
       "created_by": "user",
       "edited_by": "user",
       "id": "a2",
-      "message": {
+      "indoor_message": {
         "text": "This is an alert",
+        "type": "custom"
+      },
+      "outdoor_message": {
+        "text": "Test",
         "type": "custom"
       },
       "schedule": {

--- a/test/screenplay/emergency_takeover_tool/alerts/alert_test.exs
+++ b/test/screenplay/emergency_takeover_tool/alerts/alert_test.exs
@@ -5,15 +5,17 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.AlertTest do
 
   describe "new/4" do
     test "creates a new alert with the specified values" do
-      message = %{type: :canned, id: 1}
+      indoor_message = %{type: :canned, id: 1}
+      outdoor_message = %{type: :custom, text: "hi"}
       stations = ["Orient Heights", "Airport"]
       schedule = %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]}
       user = "test user"
 
-      alert = Alert.new(message, stations, schedule, user)
+      alert = Alert.new(indoor_message, outdoor_message, stations, schedule, user)
 
       assert %Alert{
-               message: ^message,
+               indoor_message: ^indoor_message,
+               outdoor_message: ^outdoor_message,
                stations: ^stations,
                schedule: ^schedule,
                created_by: ^user,
@@ -28,7 +30,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.AlertTest do
     test "sets cleared_at and cleared_by properties" do
       alert = %Alert{
         id: "alert",
-        message: %{type: :canned, id: 1},
+        indoor_message: %{type: :canned, id: 1},
+        outdoor_message: %{type: :canned, id: 2},
         stations: ["Orient Heights", "Airport"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "test user",
@@ -47,7 +50,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.AlertTest do
     test "replaces the specified values, and not others" do
       alert = %Alert{
         id: "alert",
-        message: %{type: :canned, id: 1},
+        indoor_message: %{type: :canned, id: 1},
+        outdoor_message: %{type: :canned, id: 2},
         stations: ["Orient Heights", "Airport"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "test user",
@@ -56,12 +60,13 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.AlertTest do
         cleared_by: nil
       }
 
-      changes_map = %{message: %{type: :custom, text: "All clear"}}
+      changes_map = %{outdoor_message: %{type: :custom, text: "All clear"}}
       update_user = "test_user2"
 
       expected = %Alert{
         id: "alert",
-        message: %{type: :custom, text: "All clear"},
+        indoor_message: %{type: :canned, id: 1},
+        outdoor_message: %{type: :custom, text: "All clear"},
         stations: ["Orient Heights", "Airport"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "test user",
@@ -76,7 +81,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.AlertTest do
     test "ignores nil values in changes_map" do
       alert = %Alert{
         id: "alert",
-        message: %{type: :canned, id: 1},
+        indoor_message: %{type: :canned, id: 1},
+        outdoor_message: %{type: :canned, id: 1},
         stations: ["Orient Heights", "Airport"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "test user",
@@ -85,12 +91,13 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.AlertTest do
         cleared_by: nil
       }
 
-      changes_map = %{message: nil, stations: ["Government Center"], schedule: nil}
+      changes_map = %{indoor_message: nil, stations: ["Government Center"], schedule: nil}
       update_user = "test_user2"
 
       expected = %Alert{
         id: "alert",
-        message: %{type: :canned, id: 1},
+        indoor_message: %{type: :canned, id: 1},
+        outdoor_message: %{type: :canned, id: 1},
         stations: ["Government Center"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "test user",
@@ -104,10 +111,11 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.AlertTest do
   end
 
   describe "to_json/1" do
-    test "handles canned message" do
+    test "handles both messages" do
       alert = %Alert{
         id: "alert",
-        message: %{type: :canned, id: 4},
+        indoor_message: %{type: :canned, id: 4},
+        outdoor_message: %{type: :custom, text: "hi"},
         stations: ["Wellington", "Malden Center"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "user",
@@ -118,33 +126,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.AlertTest do
 
       expected = %{
         "id" => "alert",
-        "message" => %{"type" => "canned", "id" => 4},
-        "stations" => ["Wellington", "Malden Center"],
-        "schedule" => %{"start" => "2021-08-19T17:09:42Z", "end" => "2021-08-19T17:39:42Z"},
-        "created_by" => "user",
-        "edited_by" => "user",
-        "cleared_at" => nil,
-        "cleared_by" => nil
-      }
-
-      assert expected == Alert.to_json(alert)
-    end
-
-    test "handles custom message" do
-      alert = %Alert{
-        id: "alert",
-        message: %{type: :custom, text: "This is an alert"},
-        stations: ["Wellington", "Malden Center"],
-        schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
-        created_by: "user",
-        edited_by: "user",
-        cleared_at: nil,
-        cleared_by: nil
-      }
-
-      expected = %{
-        "id" => "alert",
-        "message" => %{"type" => "custom", "text" => "This is an alert"},
+        "indoor_message" => %{"type" => "canned", "id" => 4},
+        "outdoor_message" => %{"type" => "custom", "text" => "hi"},
         "stations" => ["Wellington", "Malden Center"],
         "schedule" => %{"start" => "2021-08-19T17:09:42Z", "end" => "2021-08-19T17:39:42Z"},
         "created_by" => "user",
@@ -158,34 +141,11 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.AlertTest do
   end
 
   describe "from_json/1" do
-    test "handles canned message" do
+    test "handles both messages and trims username" do
       json = %{
         "id" => "alert",
-        "message" => %{"type" => "canned", "id" => 4},
-        "stations" => ["Wellington", "Malden Center"],
-        "schedule" => %{"start" => "2021-08-19T17:09:42Z", "end" => "2021-08-19T17:39:42Z"},
-        "created_by" => "user",
-        "edited_by" => "user"
-      }
-
-      expected = %Alert{
-        id: "alert",
-        message: %{type: :canned, id: 4},
-        stations: ["Wellington", "Malden Center"],
-        schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
-        created_by: "user",
-        edited_by: "user",
-        cleared_at: nil,
-        cleared_by: nil
-      }
-
-      assert expected == Alert.from_json(json)
-    end
-
-    test "handles custom message and trims username" do
-      json = %{
-        "id" => "alert",
-        "message" => %{"type" => "custom", "text" => "This is an alert"},
+        "indoor_message" => %{"type" => "custom", "text" => "This is an alert"},
+        "outdoor_message" => %{"type" => "canned", "id" => 4},
         "stations" => ["Wellington", "Malden Center"],
         "schedule" => %{"start" => "2021-08-19T17:09:42Z", "end" => "2021-08-19T17:39:42Z"},
         "created_by" => "ActiveDirectory_MBTA\\user",
@@ -194,7 +154,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.AlertTest do
 
       expected = %Alert{
         id: "alert",
-        message: %{type: :custom, text: "This is an alert"},
+        indoor_message: %{type: :custom, text: "This is an alert"},
+        outdoor_message: %{type: :canned, id: 4},
         stations: ["Wellington", "Malden Center"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "user",

--- a/test/screenplay/emergency_takeover_tool/alerts/state_test.exs
+++ b/test/screenplay/emergency_takeover_tool/alerts/state_test.exs
@@ -9,7 +9,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
 
       alert = %Alert{
         id: "alert",
-        message: %{type: :canned, id: 1},
+        indoor_message: %{type: :canned, id: 1},
+        outdoor_message: %{type: :canned, id: 1},
         stations: ["Back Bay"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "user",
@@ -32,7 +33,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
 
       cleared_alert = %Alert{
         id: "alert",
-        message: %{type: :canned, id: 1},
+        indoor_message: %{type: :canned, id: 1},
+        outdoor_message: %{type: :canned, id: 1},
         stations: ["Back Bay"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "user",
@@ -55,7 +57,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
 
       alert = %Alert{
         id: nil,
-        message: %{type: :canned, id: 1},
+        indoor_message: %{type: :canned, id: 1},
+        outdoor_message: %{type: :canned, id: 1},
         stations: ["South Station"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "user",
@@ -72,7 +75,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
 
       alert = %Alert{
         id: "alert",
-        message: %{type: :canned, id: 1},
+        indoor_message: %{type: :canned, id: 1},
+        outdoor_message: %{type: :canned, id: 1},
         stations: ["South Station"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "user",
@@ -83,21 +87,7 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
 
       assert :ok == State.add_alert(pid, alert)
 
-      expected_state = %State{
-        alerts: %{
-          "alert" => %Alert{
-            id: "alert",
-            message: %{type: :canned, id: 1},
-            stations: ["South Station"],
-            schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
-            created_by: "user",
-            edited_by: "user",
-            cleared_at: nil,
-            cleared_by: nil
-          }
-        },
-        cleared_alerts: %{}
-      }
+      expected_state = %State{alerts: %{"alert" => alert}, cleared_alerts: %{}}
 
       assert expected_state == :sys.get_state(pid)
     end
@@ -109,7 +99,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
 
       a1 = %Alert{
         id: "a1",
-        message: %{type: :canned, id: 1},
+        indoor_message: %{type: :canned, id: 1},
+        outdoor_message: %{type: :canned, id: 1},
         stations: ["Haymarket", "Government Center"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "user",
@@ -120,7 +111,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
 
       a2 = %Alert{
         id: "a2",
-        message: %{type: :custom, text: "This is an alert"},
+        indoor_message: %{type: :custom, text: "This is an alert"},
+        outdoor_message: %{type: :custom, text: "This is an alert"},
         stations: ["Kendall/MIT"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "user",
@@ -136,7 +128,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
 
       new_alert = %Alert{
         id: "a2",
-        message: %{type: :custom, text: "All clear now"},
+        indoor_message: %{type: :custom, text: "All clear now"},
+        outdoor_message: %{type: :custom, text: "All clear now"},
         stations: ["Kendall/MIT"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "user",
@@ -147,33 +140,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
 
       assert :ok == State.update_alert(pid, "a2", new_alert)
 
-      expected_state = %State{
-        alerts: %{
-          "a1" => %Alert{
-            id: "a1",
-            message: %{type: :canned, id: 1},
-            schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
-            stations: ["Haymarket", "Government Center"],
-            created_by: "user",
-            edited_by: "user",
-            cleared_at: nil,
-            cleared_by: nil
-          },
-          "a2" => %Alert{
-            id: "a2",
-            message: %{text: "All clear now", type: :custom},
-            schedule: %{end: ~U[2021-08-19 17:39:42Z], start: ~U[2021-08-19 17:09:42Z]},
-            stations: ["Kendall/MIT"],
-            created_by: "user",
-            edited_by: "user",
-            cleared_at: nil,
-            cleared_by: nil
-          }
-        },
-        cleared_alerts: %{}
-      }
-
-      assert expected_state == :sys.get_state(pid)
+      assert %{alerts: %{"a1" => ^a1, "a2" => ^new_alert}, cleared_alerts: %{}} =
+               :sys.get_state(pid)
     end
   end
 
@@ -183,7 +151,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
 
       a1 = %Alert{
         id: "a1",
-        message: %{type: :canned, id: 1},
+        indoor_message: %{type: :canned, id: 1},
+        outdoor_message: %{type: :canned, id: 1},
         stations: ["Haymarket", "Government Center"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "user",
@@ -194,7 +163,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
 
       a2 = %Alert{
         id: "a2",
-        message: %{type: :custom, text: "This is an alert"},
+        indoor_message: %{type: :custom, text: "This is an alert"},
+        outdoor_message: %{type: :custom, text: "This is an alert"},
         stations: ["Kendall/MIT"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "user",
@@ -211,34 +181,10 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
 
       assert :ok == State.clear_alert(pid, %{a1 | cleared_by: "clear_user", cleared_at: now})
 
-      expected_state = %State{
-        alerts: %{
-          "a2" => %Alert{
-            id: "a2",
-            message: %{text: "This is an alert", type: :custom},
-            schedule: %{end: ~U[2021-08-19 17:39:42Z], start: ~U[2021-08-19 17:09:42Z]},
-            stations: ["Kendall/MIT"],
-            created_by: "user",
-            edited_by: "user",
-            cleared_at: nil,
-            cleared_by: nil
-          }
-        },
-        cleared_alerts: %{
-          "a1" => %Alert{
-            id: "a1",
-            message: %{type: :canned, id: 1},
-            stations: ["Haymarket", "Government Center"],
-            schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
-            created_by: "user",
-            edited_by: "user",
-            cleared_at: now,
-            cleared_by: "clear_user"
-          }
-        }
-      }
-
-      assert expected_state == :sys.get_state(pid)
+      assert %{
+               alerts: %{"a2" => _},
+               cleared_alerts: %{"a1" => %{cleared_at: now, cleared_by: "clear_user"}}
+             } = :sys.get_state(pid)
     end
   end
 
@@ -248,7 +194,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
 
       a1 = %Alert{
         id: "a1",
-        message: %{type: :canned, id: 1},
+        indoor_message: %{type: :canned, id: 1},
+        outdoor_message: %{type: :canned, id: 1},
         stations: ["Haymarket", "Government Center"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "user",
@@ -259,7 +206,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
 
       a2 = %Alert{
         id: "a2",
-        message: %{type: :custom, text: "This is an alert"},
+        indoor_message: %{type: :custom, text: "This is an alert"},
+        outdoor_message: %{type: :custom, text: "This is an alert"},
         stations: ["Kendall/MIT"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "user",
@@ -283,31 +231,9 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
       assert ["Kendall/MIT"] ==
                State.remove_overlapping_alerts(pid, params, user)
 
-      assert %State{
-               alerts: %{
-                 "a1" => %Alert{
-                   id: "a1",
-                   message: %{type: :canned, id: 1},
-                   stations: ["Haymarket", "Government Center"],
-                   schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
-                   created_by: "user",
-                   edited_by: "user",
-                   cleared_at: nil,
-                   cleared_by: nil
-                 }
-               },
-               cleared_alerts: %{
-                 "a2" => %Alert{
-                   id: "a2",
-                   message: %{type: :custom, text: "This is an alert"},
-                   stations: ["Kendall/MIT"],
-                   schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
-                   created_by: "user",
-                   edited_by: "user",
-                   cleared_at: %DateTime{},
-                   cleared_by: ^user
-                 }
-               }
+      assert %{
+               alerts: %{"a1" => _},
+               cleared_alerts: %{"a2" => %{cleared_at: %DateTime{}, cleared_by: ^user}}
              } = :sys.get_state(pid)
     end
 
@@ -316,7 +242,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
 
       a1 = %Alert{
         id: "a1",
-        message: %{type: :canned, id: 1},
+        indoor_message: %{type: :canned, id: 1},
+        outdoor_message: %{type: :canned, id: 1},
         stations: ["Haymarket", "Government Center"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "user",
@@ -327,7 +254,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
 
       a2 = %Alert{
         id: "a2",
-        message: %{type: :custom, text: "This is an alert"},
+        indoor_message: %{type: :custom, text: "This is an alert"},
+        outdoor_message: %{type: :custom, text: "This is an alert"},
         stations: ["South Station", "Kendall/MIT"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "user",
@@ -352,30 +280,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
                State.remove_overlapping_alerts(pid, params, user)
 
       assert %State{
-               alerts: %{
-                 "a1" => %Alert{
-                   id: "a1",
-                   message: %{type: :canned, id: 1},
-                   stations: ["Haymarket", "Government Center"],
-                   schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
-                   created_by: "user",
-                   edited_by: "user",
-                   cleared_at: nil,
-                   cleared_by: nil
-                 }
-               },
-               cleared_alerts: %{
-                 "a2" => %Alert{
-                   id: "a2",
-                   message: %{type: :custom, text: "This is an alert"},
-                   stations: ["South Station", "Kendall/MIT"],
-                   schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
-                   created_by: "user",
-                   edited_by: "user",
-                   cleared_at: %DateTime{},
-                   cleared_by: ^user
-                 }
-               }
+               alerts: %{"a1" => _},
+               cleared_alerts: %{"a2" => %{cleared_at: %DateTime{}, cleared_by: ^user}}
              } = :sys.get_state(pid)
     end
 
@@ -384,7 +290,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
 
       a1 = %Alert{
         id: "a1",
-        message: %{type: :canned, id: 1},
+        indoor_message: %{type: :canned, id: 1},
+        outdoor_message: %{type: :canned, id: 1},
         stations: ["Haymarket", "Government Center"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "user",
@@ -395,7 +302,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
 
       a2 = %Alert{
         id: "a2",
-        message: %{type: :custom, text: "This is an alert"},
+        indoor_message: %{type: :custom, text: "This is an alert"},
+        outdoor_message: %{type: :custom, text: "This is an alert"},
         stations: ["Kendall/MIT"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "user",
@@ -419,33 +327,7 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
       assert [] ==
                State.remove_overlapping_alerts(pid, params, user)
 
-      expected_state = %State{
-        alerts: %{
-          "a1" => %Alert{
-            id: "a1",
-            message: %{type: :canned, id: 1},
-            stations: ["Haymarket", "Government Center"],
-            schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
-            created_by: "user",
-            edited_by: "user",
-            cleared_at: nil,
-            cleared_by: nil
-          },
-          "a2" => %Alert{
-            id: "a2",
-            message: %{type: :custom, text: "This is an alert"},
-            stations: ["Kendall/MIT"],
-            schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
-            created_by: "user",
-            edited_by: "user",
-            cleared_at: nil,
-            cleared_by: nil
-          }
-        },
-        cleared_alerts: %{}
-      }
-
-      assert expected_state == :sys.get_state(pid)
+      assert %{alerts: %{"a1" => _, "a2" => _}, cleared_alerts: %{}} = :sys.get_state(pid)
     end
 
     test "removes stations from existing alert if another station exists" do
@@ -453,7 +335,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
 
       a1 = %Alert{
         id: "a1",
-        message: %{type: :canned, id: 1},
+        indoor_message: %{type: :canned, id: 1},
+        outdoor_message: %{type: :canned, id: 1},
         stations: ["Haymarket", "Government Center"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "user",
@@ -464,7 +347,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
 
       a2 = %Alert{
         id: "a2",
-        message: %{type: :custom, text: "This is an alert"},
+        indoor_message: %{type: :custom, text: "This is an alert"},
+        outdoor_message: %{type: :custom, text: "This is an alert"},
         stations: ["South Station", "Kendall/MIT"],
         schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
         created_by: "user",
@@ -488,40 +372,18 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
       assert ["Kendall/MIT"] ==
                State.remove_overlapping_alerts(pid, params, user)
 
-      expected_state = %State{
-        alerts: %{
-          "a1" => %Alert{
-            id: "a1",
-            message: %{type: :canned, id: 1},
-            stations: ["Haymarket", "Government Center"],
-            schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
-            created_by: "user",
-            edited_by: "user",
-            cleared_at: nil,
-            cleared_by: nil
-          },
-          "a2" => %Alert{
-            id: "a2",
-            message: %{type: :custom, text: "This is an alert"},
-            stations: ["South Station"],
-            schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
-            created_by: "user",
-            edited_by: "bar",
-            cleared_at: nil,
-            cleared_by: nil
-          }
-        },
-        cleared_alerts: %{}
-      }
-
-      assert expected_state == :sys.get_state(pid)
+      assert %{
+               alerts: %{"a1" => _, "a2" => %{stations: ["South Station"], edited_by: ^user}},
+               cleared_alerts: %{}
+             } = :sys.get_state(pid)
     end
   end
 
   describe "to_json/1" do
     a1 = %Alert{
       id: "a1",
-      message: %{type: :canned, id: 1},
+      indoor_message: %{type: :canned, id: 1},
+      outdoor_message: %{type: :canned, id: 1},
       stations: ["Haymarket", "Government Center"],
       schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
       created_by: "user",
@@ -532,7 +394,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
 
     a2 = %Alert{
       id: "a2",
-      message: %{type: :custom, text: "This is an alert"},
+      indoor_message: %{type: :custom, text: "This is an alert"},
+      outdoor_message: %{type: :custom, text: "This is an alert"},
       stations: ["Kendall/MIT"],
       schedule: %{start: ~U[2021-08-19 17:09:42Z], end: ~U[2021-08-19 17:39:42Z]},
       created_by: "user",
@@ -557,7 +420,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
       "alerts" => [
         %{
           "id" => "a1",
-          "message" => %{"id" => 1, "type" => "canned"},
+          "indoor_message" => %{"id" => 1, "type" => "canned"},
+          "outdoor_message" => %{"id" => 1, "type" => "canned"},
           "schedule" => %{"start" => "2021-08-19T17:09:42Z", "end" => "2021-08-19T17:39:42Z"},
           "stations" => ["Haymarket", "Government Center"],
           "created_by" => "user",
@@ -565,7 +429,8 @@ defmodule Screenplay.EmergencyTakeoverTool.Alerts.StateTest do
         },
         %{
           "id" => "a2",
-          "message" => %{"text" => "This is an alert", "type" => "custom"},
+          "indoor_message" => %{"text" => "This is an alert", "type" => "custom"},
+          "outdoor_message" => %{"text" => "This is an alert", "type" => "custom"},
           "schedule" => %{"start" => "2021-08-19T17:09:42Z", "end" => "2021-08-19T17:39:42Z"},
           "stations" => ["Kendall/MIT"],
           "created_by" => "user",


### PR DESCRIPTION
**Asana task**: [ETT: support indoor/outdoor distinction and new content](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1213370222596880?focus=true)

This splits the emergency takeover messages into separate indoor and outdoor content. Notes:
* We're assuming the old messages will be deleted as part of this change, so we're not making any attempt at being backward compatible.
* Tweaked the UI interactions to eliminate a few edge cases.
* The preview during message creation includes the portrait version of both messages, since that was easy. The landscape version won't fit in the current layout without some additional rework. Only the indoor content rendering is shown in the list view, to avoid taking excessive space.

The PR is split into a few separate commits for easier reviewing.