### PR TITLE
refactor: Add Outfront ETT Screens to Places framework

### DIFF
--- a/assets/js/components/EmergencyTakeoverTool/EmergencyTakeoverTool.tsx
+++ b/assets/js/components/EmergencyTakeoverTool/EmergencyTakeoverTool.tsx
@@ -3,6 +3,7 @@ import AlertDashboard from "./AlertDashboard/AlertDashboard";
 import AlertWizard from "./AlertWizard/AlertWizard";
 import ConfirmationModal, { ModalDetails } from "./ConfirmationModal";
 import { BASE_URL } from "Constants/constants";
+import STATION_ORDER_BY_LINE from "Constants/stationOrder";
 
 export interface Station {
   name: string;
@@ -56,7 +57,6 @@ class EmergencyTakeoverTool extends React.Component<
   constructor(props = {}) {
     super(props);
     this.state = {
-      // TODO
       alertWizardOpen: false,
       alertData: null,
       modalOpen: false,
@@ -71,11 +71,20 @@ class EmergencyTakeoverTool extends React.Component<
       stationScreenOrientationList: null,
     };
 
-    fetch(`${BASE_URL}/stations_and_screen_orientations`)
+    fetch(`${BASE_URL}/stations_and_screens`)
       .then((response) => response.json())
-      .then((result) =>
-        this.setState({ stationScreenOrientationList: result }),
-      );
+      .then((stationsMap: { [stationName: string]: Station }) => {
+        // Group stations by line using STATION_ORDER_BY_LINE
+        const stationsByLine: StationsByLine = {};
+
+        Object.keys(STATION_ORDER_BY_LINE).forEach((line) => {
+          stationsByLine[line] = STATION_ORDER_BY_LINE[line]
+            .map((stationInfo) => stationsMap[stationInfo.name])
+            .filter((station) => station !== undefined);
+        });
+
+        this.setState({ stationScreenOrientationList: stationsByLine });
+      });
 
     this.toggleAlertWizard = this.toggleAlertWizard.bind(this);
     this.openModal = this.openModal.bind(this);

--- a/assets/js/components/EmergencyTakeoverTool/EmergencyTakeoverTool.tsx
+++ b/assets/js/components/EmergencyTakeoverTool/EmergencyTakeoverTool.tsx
@@ -74,13 +74,16 @@ class EmergencyTakeoverTool extends React.Component<
     fetch(`${BASE_URL}/stations_and_screens`)
       .then((response) => response.json())
       .then((stationsMap: { [stationName: string]: Station }) => {
-        // Group stations by line using STATION_ORDER_BY_LINE
+        // Group stations by line
         const stationsByLine: StationsByLine = {};
 
         Object.keys(STATION_ORDER_BY_LINE).forEach((line) => {
-          stationsByLine[line] = STATION_ORDER_BY_LINE[line]
-            .map((stationInfo) => stationsMap[stationInfo.name])
-            .filter((station) => station !== undefined);
+          const stationInfo = STATION_ORDER_BY_LINE[line];
+          if (stationInfo) {
+            stationsByLine[line] = stationInfo
+              .map((station) => stationsMap[station.name])
+              .filter((station) => station !== undefined);
+          }
         });
 
         this.setState({ stationScreenOrientationList: stationsByLine });

--- a/assets/js/util.ts
+++ b/assets/js/util.ts
@@ -119,6 +119,12 @@ export const matchStation = (
   station: string,
   stationScreenOrientationList: StationsByLine,
 ) => {
+  console.log(
+    "Matching station",
+    station,
+    "in list",
+    stationScreenOrientationList,
+  );
   const result = Object.values(stationScreenOrientationList)
     .flat()
     .find(({ name }) => name === station);

--- a/assets/js/util.ts
+++ b/assets/js/util.ts
@@ -119,12 +119,6 @@ export const matchStation = (
   station: string,
   stationScreenOrientationList: StationsByLine,
 ) => {
-  console.log(
-    "Matching station",
-    station,
-    "in list",
-    stationScreenOrientationList,
-  );
   const result = Object.values(stationScreenOrientationList)
     .flat()
     .find(({ name }) => name === station);

--- a/config/config.exs
+++ b/config/config.exs
@@ -79,7 +79,7 @@ config :screenplay, Oban,
   queues: [default: 10],
   repo: Screenplay.Repo
 
-import_config "outfront_takeover_tool_screens.exs"
+import_config "outfront_takeover_screens.exs"
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/outfront_ett_screens.exs
+++ b/config/outfront_ett_screens.exs
@@ -1,0 +1,413 @@
+import Config
+
+config :screenplay,
+  landscape_dir: "Landscape",
+  portrait_dir: "Portrait",
+  outfront_ett_screens: %{
+    red: [
+      %{
+        place_id: "place-alfcl",
+        portrait: true,
+        landscape: false,
+        sftp_dir_name: "008_RED_ALEWIFE"
+      },
+      %{
+        place_id: "place-davis",
+        portrait: true,
+        landscape: false,
+        sftp_dir_name: "009_RED_DAVIS"
+      },
+      %{
+        place_id: "place-portr",
+        portrait: true,
+        landscape: false,
+        sftp_dir_name: "010_RED_CR_PORTER"
+      },
+      %{
+        place_id: "place-harsq",
+        portrait: true,
+        landscape: false,
+        sftp_dir_name: "011_RED_HARVARD"
+      },
+      %{
+        place_id: "place-cntsq",
+        portrait: true,
+        landscape: false,
+        sftp_dir_name: "012_RED_CENTRAL"
+      },
+      %{
+        place_id: "place-knncl",
+        portrait: true,
+        landscape: true,
+        sftp_dir_name: "013_RED_KENDALL"
+      },
+      %{
+        place_id: "place-chmnl",
+        portrait: true,
+        landscape: false,
+        sftp_dir_name: "014_RED_CHARLES"
+      },
+      %{
+        place_id: "place-pktrm",
+        portrait: true,
+        landscape: true,
+        sftp_dir_name: "001_XFER_RED_GREEN_PARK"
+      },
+      %{
+        place_id: "place-dwnxg",
+        portrait: true,
+        landscape: false,
+        sftp_dir_name: "002_XFER_RED_ORANGE_SILVER_DOWNTOWNCROSSING"
+      },
+      %{
+        place_id: "place-sstat",
+        portrait: true,
+        landscape: true,
+        sftp_dir_name: "003_XFER_RED_SILVER_CR_SOUTHSTATION"
+      },
+      %{
+        place_id: "place-brdwy",
+        portrait: true,
+        landscape: true,
+        sftp_dir_name: "015_RED_BROADWAY"
+      },
+      %{
+        place_id: "place-andrw",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "016_RED_ANDREW"
+      },
+      %{
+        place_id: "place-jfk",
+        portrait: true,
+        landscape: false,
+        sftp_dir_name: "017_RED_CR_JFKUMASS"
+      },
+      %{
+        place_id: "place-shmnl",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "018_A_RED_SAVINHILL"
+      },
+      %{
+        place_id: "place-fldcr",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "019_A_RED_FIELDSCORNER"
+      },
+      %{
+        place_id: "place-smmnl",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "020_A_RED_SHAWMUT"
+      },
+      %{
+        place_id: "place-asmnl",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "021_A_RED_ASHMONT"
+      },
+      %{
+        place_id: "place-nqncy",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "022_B_RED_NORTHQUINCY"
+      },
+      %{
+        place_id: "place-wlsta",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "023_B_RED_WOLLASTON"
+      },
+      %{
+        place_id: "place-qnctr",
+        portrait: true,
+        landscape: true,
+        sftp_dir_name: "024_B_RED_CR_QUINCYCENTER"
+      },
+      %{
+        place_id: "place-qamnl",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "025_B_RED_QUINCYADAMS"
+      },
+      %{
+        place_id: "place-brntn",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "026_B_RED_CR_BRAINTREE"
+      }
+    ],
+    orange: [
+      %{
+        place_id: "place-ogmnl",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "034_ORANGE_OAKGROVE"
+      },
+      %{
+        place_id: "place-mlmnl",
+        portrait: true,
+        landscape: true,
+        sftp_dir_name: "035_ORANGE_CR_MALDENCENTER"
+      },
+      %{
+        place_id: "place-welln",
+        portrait: true,
+        landscape: false,
+        sftp_dir_name: "036_ORANGE_WELLINGTON"
+      },
+      %{
+        place_id: "place-astao",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "037_ORANGE_ASSEMBLY"
+      },
+      %{
+        place_id: "place-sull",
+        portrait: true,
+        landscape: true,
+        sftp_dir_name: "038_ORANGE_SULLIVAN"
+      },
+      %{
+        place_id: "place-ccmnl",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "039_ORANGE_COMMUNITYCOLLEGE"
+      },
+      %{
+        place_id: "place-north",
+        portrait: true,
+        landscape: false,
+        sftp_dir_name: "004_XFER_ORANGE_GREEN_CR_NORTHSTATION"
+      },
+      %{
+        place_id: "place-haecl",
+        portrait: true,
+        landscape: true,
+        sftp_dir_name: "005_XFER_ORANGE_GREEN_HAYMARKET"
+      },
+      %{
+        place_id: "place-state",
+        portrait: true,
+        landscape: false,
+        sftp_dir_name: "006_XFER_ORANGE_BLUE_STATE"
+      },
+      %{
+        place_id: "place-dwnxg",
+        portrait: true,
+        landscape: false,
+        sftp_dir_name: "002_XFER_RED_ORANGE_SILVER_DOWNTOWNCROSSING"
+      },
+      %{
+        place_id: "place-chncl",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "040_ORANGE_SILVER_CHINATOWN"
+      },
+      %{
+        place_id: "place-tumnl",
+        portrait: true,
+        landscape: true,
+        sftp_dir_name: "041_ORANGE_SILVER_TUFTSMEDICAL"
+      },
+      %{
+        place_id: "place-bbsta",
+        portrait: true,
+        landscape: true,
+        sftp_dir_name: "042_ORANGE_CR_BACKBAY"
+      },
+      %{
+        place_id: "place-masta",
+        portrait: true,
+        landscape: false,
+        sftp_dir_name: "043_ORANGE_MASSAVE"
+      },
+      %{
+        place_id: "place-rugg",
+        portrait: true,
+        landscape: false,
+        sftp_dir_name: "044_ORANGE_CR_RUGGLES"
+      },
+      %{
+        place_id: "place-rcmnl",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "045_ORANGE_ROXBURYCROSSING"
+      },
+      %{
+        place_id: "place-jaksn",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "046_ORANGE_JACKSON"
+      },
+      %{
+        place_id: "place-sbmnl",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "047_ORANGE_STONYBROOK"
+      },
+      %{
+        place_id: "place-grnst",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "048_ORANGE_GREENST"
+      },
+      %{
+        place_id: "place-forhl",
+        portrait: true,
+        landscape: false,
+        sftp_dir_name: "049_ORANGE_CR_FORESTHILLS"
+      }
+    ],
+    blue: [
+      %{
+        place_id: "place-bomnl",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "059_BLUE_BOWDOIN"
+      },
+      %{
+        place_id: "place-gover",
+        portrait: true,
+        landscape: false,
+        sftp_dir_name: "007_XFER_BLUE_GREEN_GOVERNMENTCENTER"
+      },
+      %{
+        place_id: "place-state",
+        portrait: true,
+        landscape: false,
+        sftp_dir_name: "006_XFER_ORANGE_BLUE_STATE"
+      },
+      %{
+        place_id: "place-aqucl",
+        portrait: false,
+        landscape: true,
+        sftp_dir_name: "058_BLUE_AQUARIUM"
+      },
+      %{
+        place_id: "place-mvbcl",
+        portrait: true,
+        landscape: true,
+        sftp_dir_name: "057_BLUE_MAVERICK"
+      },
+      %{
+        place_id: "place-aport",
+        portrait: true,
+        landscape: true,
+        sftp_dir_name: "056_BLUE_SILVER_AIRPORT"
+      },
+      %{
+        place_id: "place-wimnl",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "055_BLUE_WOODISLAND"
+      },
+      %{
+        place_id: "place-orhte",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "054_BLUE_ORIENTHEIGHTS"
+      },
+      %{
+        place_id: "place-sdmnl",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "053_BLUE_SUFFOLKDOWNS"
+      },
+      %{
+        place_id: "place-bmmnl",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "052_BLUE_BEACHMONT"
+      },
+      %{
+        place_id: "place-rbmnl",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "051_BLUE_REVEREBEACH"
+      },
+      %{
+        place_id: "place-wondl",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "050_BLUE_WONDERLAND"
+      }
+    ],
+    silver: [
+      %{
+        place_id: "place-wtcst",
+        portrait: false,
+        landscape: true,
+        sftp_dir_name: "125_1_2_3_SILVER_WORLDTRADE"
+      }
+    ],
+    green: [
+      %{
+        place_id: "place-north",
+        portrait: true,
+        landscape: false,
+        sftp_dir_name: "004_XFER_ORANGE_GREEN_CR_NORTHSTATION"
+      },
+      %{
+        place_id: "place-haecl",
+        portrait: true,
+        landscape: true,
+        sftp_dir_name: "005_XFER_ORANGE_GREEN_HAYMARKET"
+      },
+      %{
+        place_id: "place-gover",
+        portrait: true,
+        landscape: false,
+        sftp_dir_name: "007_XFER_BLUE_GREEN_GOVERNMENTCENTER"
+      },
+      %{
+        place_id: "place-pktrm",
+        portrait: true,
+        landscape: true,
+        sftp_dir_name: "001_XFER_RED_GREEN_PARK"
+      },
+      %{
+        place_id: "place-boyls",
+        portrait: true,
+        landscape: false,
+        sftp_dir_name: "062_GREEN_SILVER_BOYLSTON"
+      },
+      %{
+        place_id: "place-armnl",
+        portrait: true,
+        landscape: true,
+        sftp_dir_name: "063_GREEN_ARLINGTON"
+      },
+      %{
+        place_id: "place-coecl",
+        portrait: true,
+        landscape: false,
+        sftp_dir_name: "064_GREEN_COPLEY"
+      },
+      %{
+        place_id: "place-hymnl",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "065_GREEN_HYNES"
+      },
+      %{
+        place_id: "place-kencl",
+        portrait: true,
+        landscape: true,
+        sftp_dir_name: "066_GREEN_KENMORE"
+      },
+      %{
+        place_id: "place-prmnl",
+        portrait: false,
+        landscape: true,
+        sftp_dir_name: "111_E_GREEN_PRUDENTIAL"
+      },
+      %{
+        place_id: "place-symcl",
+        portrait: false,
+        landscape: false,
+        sftp_dir_name: "112_E_GREEN_SYMPHONY"
+      }
+    ]
+  }

--- a/config/outfront_takeover_screens.exs
+++ b/config/outfront_takeover_screens.exs
@@ -3,136 +3,158 @@ import Config
 config :screenplay,
   landscape_dir: "Landscape",
   portrait_dir: "Portrait",
-  outfront_takeover_tool_screens: %{
+  outfront_takeover_screens: %{
     red: [
       %{
+        place_id: "place-alfcl",
         name: "Alewife",
         portrait: true,
         landscape: false,
         sftp_dir_name: "008_RED_ALEWIFE"
       },
       %{
+        place_id: "place-davis",
         name: "Davis",
         portrait: true,
         landscape: false,
         sftp_dir_name: "009_RED_DAVIS"
       },
       %{
+        place_id: "place-portr",
         name: "Porter",
         portrait: true,
         landscape: false,
         sftp_dir_name: "010_RED_CR_PORTER"
       },
       %{
+        place_id: "place-harsq",
         name: "Harvard",
         portrait: true,
         landscape: false,
         sftp_dir_name: "011_RED_HARVARD"
       },
       %{
+        place_id: "place-cntsq",
         name: "Central",
         portrait: true,
         landscape: false,
         sftp_dir_name: "012_RED_CENTRAL"
       },
       %{
+        place_id: "place-knncl",
         name: "Kendall/MIT",
         portrait: true,
         landscape: true,
         sftp_dir_name: "013_RED_KENDALL"
       },
       %{
+        place_id: "place-chmnl",
         name: "Charles/MGH",
         portrait: true,
         landscape: false,
         sftp_dir_name: "014_RED_CHARLES"
       },
       %{
+        place_id: "place-pktrm",
         name: "Park Street",
         portrait: true,
         landscape: true,
         sftp_dir_name: "001_XFER_RED_GREEN_PARK"
       },
       %{
+        place_id: "place-dwnxg",
         name: "Downtown Crossing",
         portrait: true,
         landscape: false,
         sftp_dir_name: "002_XFER_RED_ORANGE_SILVER_DOWNTOWNCROSSING"
       },
       %{
+        place_id: "place-sstat",
         name: "South Station",
         portrait: true,
         landscape: true,
         sftp_dir_name: "003_XFER_RED_SILVER_CR_SOUTHSTATION"
       },
       %{
+        place_id: "place-brdwy",
         name: "Broadway",
         portrait: true,
         landscape: true,
         sftp_dir_name: "015_RED_BROADWAY"
       },
       %{
+        place_id: "place-andrw",
         name: "Andrew",
         portrait: false,
         landscape: false,
         sftp_dir_name: "016_RED_ANDREW"
       },
       %{
+        place_id: "place-jfk",
         name: "JFK/UMass",
         portrait: true,
         landscape: false,
         sftp_dir_name: "017_RED_CR_JFKUMASS"
       },
       %{
+        place_id: "place-shmnl",
         name: "Savin Hill",
         portrait: false,
         landscape: false,
         sftp_dir_name: "018_A_RED_SAVINHILL"
       },
       %{
+        place_id: "place-fldcr",
         name: "Fields Corner",
         portrait: false,
         landscape: false,
         sftp_dir_name: "019_A_RED_FIELDSCORNER"
       },
       %{
+        place_id: "place-smmnl",
         name: "Shawmut",
         portrait: false,
         landscape: false,
         sftp_dir_name: "020_A_RED_SHAWMUT"
       },
       %{
-        name: "ASHMONT",
+        place_id: "place-asmnl",
+        name: "Ashmont",
         portrait: false,
         landscape: false,
         sftp_dir_name: "021_A_RED_ASHMONT"
       },
       %{
+        place_id: "place-nqncy",
         name: "North Quincy",
         portrait: false,
         landscape: false,
         sftp_dir_name: "022_B_RED_NORTHQUINCY"
       },
       %{
+        place_id: "place-wlsta",
         name: "Wollaston",
         portrait: false,
         landscape: false,
         sftp_dir_name: "023_B_RED_WOLLASTON"
       },
       %{
+        place_id: "place-qnctr",
         name: "Quincy Center",
         portrait: true,
         landscape: true,
         sftp_dir_name: "024_B_RED_CR_QUINCYCENTER"
       },
       %{
+        place_id: "place-qamnl",
         name: "Quincy Adams",
         portrait: false,
         landscape: false,
         sftp_dir_name: "025_B_RED_QUINCYADAMS"
       },
       %{
-        name: "BRAINTREE",
+        place_id: "place-brntn",
+        name: "Braintree",
         portrait: false,
         landscape: false,
         sftp_dir_name: "026_B_RED_CR_BRAINTREE"
@@ -140,120 +162,140 @@ config :screenplay,
     ],
     orange: [
       %{
+        place_id: "place-ogmnl",
         name: "Oak Grove",
         portrait: false,
         landscape: false,
         sftp_dir_name: "034_ORANGE_OAKGROVE"
       },
       %{
+        place_id: "place-mlmnl",
         name: "Malden Center",
         portrait: true,
         landscape: true,
         sftp_dir_name: "035_ORANGE_CR_MALDENCENTER"
       },
       %{
+        place_id: "place-welln",
         name: "Wellington",
         portrait: true,
         landscape: false,
         sftp_dir_name: "036_ORANGE_WELLINGTON"
       },
       %{
+        place_id: "place-astao",
         name: "Assembly",
         portrait: false,
         landscape: false,
         sftp_dir_name: "037_ORANGE_ASSEMBLY"
       },
       %{
+        place_id: "place-sull",
         name: "Sullivan Square",
         portrait: true,
         landscape: true,
         sftp_dir_name: "038_ORANGE_SULLIVAN"
       },
       %{
+        place_id: "place-ccmnl",
         name: "Community College",
         portrait: false,
         landscape: false,
         sftp_dir_name: "039_ORANGE_COMMUNITYCOLLEGE"
       },
       %{
+        place_id: "place-north",
         name: "North Station",
         portrait: true,
         landscape: false,
         sftp_dir_name: "004_XFER_ORANGE_GREEN_CR_NORTHSTATION"
       },
       %{
+        place_id: "place-haecl",
         name: "Haymarket",
         portrait: true,
         landscape: true,
         sftp_dir_name: "005_XFER_ORANGE_GREEN_HAYMARKET"
       },
       %{
+        place_id: "place-state",
         name: "State",
         portrait: true,
         landscape: false,
         sftp_dir_name: "006_XFER_ORANGE_BLUE_STATE"
       },
       %{
+        place_id: "place-dwnxg",
         name: "Downtown Crossing",
         portrait: true,
         landscape: false,
         sftp_dir_name: "002_XFER_RED_ORANGE_SILVER_DOWNTOWNCROSSING"
       },
       %{
+        place_id: "place-chncl",
         name: "Chinatown",
         portrait: false,
         landscape: false,
         sftp_dir_name: "040_ORANGE_SILVER_CHINATOWN"
       },
       %{
+        place_id: "place-tumnl",
         name: "Tufts Medical Center",
         portrait: true,
         landscape: true,
         sftp_dir_name: "041_ORANGE_SILVER_TUFTSMEDICAL"
       },
       %{
+        place_id: "place-bbsta",
         name: "Back Bay",
         portrait: true,
         landscape: true,
         sftp_dir_name: "042_ORANGE_CR_BACKBAY"
       },
       %{
+        place_id: "place-masta",
         name: "Massachusetts Avenue",
         portrait: true,
         landscape: false,
         sftp_dir_name: "043_ORANGE_MASSAVE"
       },
       %{
+        place_id: "place-rugg",
         name: "Ruggles",
         portrait: true,
         landscape: false,
         sftp_dir_name: "044_ORANGE_CR_RUGGLES"
       },
       %{
+        place_id: "place-rcmnl",
         name: "Roxbury Crossing",
         portrait: false,
         landscape: false,
         sftp_dir_name: "045_ORANGE_ROXBURYCROSSING"
       },
       %{
+        place_id: "place-jaksn",
         name: "Jackson Square",
         portrait: false,
         landscape: false,
         sftp_dir_name: "046_ORANGE_JACKSON"
       },
       %{
+        place_id: "place-sbmnl",
         name: "Stony Brook",
         portrait: false,
         landscape: false,
         sftp_dir_name: "047_ORANGE_STONYBROOK"
       },
       %{
+        place_id: "place-grnst",
         name: "Green Street",
         portrait: false,
         landscape: false,
         sftp_dir_name: "048_ORANGE_GREENST"
       },
       %{
+        place_id: "place-forhl",
         name: "Forest Hills",
         portrait: true,
         landscape: false,
@@ -262,72 +304,84 @@ config :screenplay,
     ],
     blue: [
       %{
+        place_id: "place-bowd",
         name: "Bowdoin",
         portrait: false,
         landscape: false,
         sftp_dir_name: "059_BLUE_BOWDOIN"
       },
       %{
+        place_id: "place-gover",
         name: "Government Center",
         portrait: true,
         landscape: false,
         sftp_dir_name: "007_XFER_BLUE_GREEN_GOVERNMENTCENTER"
       },
       %{
+        place_id: "place-state",
         name: "State",
         portrait: true,
         landscape: false,
         sftp_dir_name: "006_XFER_ORANGE_BLUE_STATE"
       },
       %{
+        place_id: "place-aquar",
         name: "Aquarium",
         portrait: false,
         landscape: true,
         sftp_dir_name: "058_BLUE_AQUARIUM"
       },
       %{
+        place_id: "place-mvbcl",
         name: "Maverick",
         portrait: true,
         landscape: true,
         sftp_dir_name: "057_BLUE_MAVERICK"
       },
       %{
+        place_id: "place-aport",
         name: "Airport",
         portrait: true,
         landscape: true,
         sftp_dir_name: "056_BLUE_SILVER_AIRPORT"
       },
       %{
+        place_id: "place-wimnl",
         name: "Wood Island",
         portrait: false,
         landscape: false,
         sftp_dir_name: "055_BLUE_WOODISLAND"
       },
       %{
+        place_id: "place-orhte",
         name: "Orient Heights",
         portrait: false,
         landscape: false,
         sftp_dir_name: "054_BLUE_ORIENTHEIGHTS"
       },
       %{
+        place_id: "place-sdmnl",
         name: "Suffolk Downs",
         portrait: false,
         landscape: false,
         sftp_dir_name: "053_BLUE_SUFFOLKDOWNS"
       },
       %{
+        place_id: "place-bmmnl",
         name: "Beachmont",
         portrait: false,
         landscape: false,
         sftp_dir_name: "052_BLUE_BEACHMONT"
       },
       %{
+        place_id: "place-rbmnl",
         name: "Revere Beach",
         portrait: false,
         landscape: false,
         sftp_dir_name: "051_BLUE_REVEREBEACH"
       },
       %{
+        place_id: "place-wondl",
         name: "Wonderland",
         portrait: false,
         landscape: false,
@@ -336,6 +390,7 @@ config :screenplay,
     ],
     silver: [
       %{
+        place_id: "place-wtcst",
         name: "World Trade Center",
         portrait: false,
         landscape: true,
@@ -344,66 +399,77 @@ config :screenplay,
     ],
     green: [
       %{
+        place_id: "place-north",
         name: "North Station",
         portrait: true,
         landscape: false,
         sftp_dir_name: "004_XFER_ORANGE_GREEN_CR_NORTHSTATION"
       },
       %{
+        place_id: "place-haecl",
         name: "Haymarket",
         portrait: true,
         landscape: true,
         sftp_dir_name: "005_XFER_ORANGE_GREEN_HAYMARKET"
       },
       %{
+        place_id: "place-gover",
         name: "Government Center",
         portrait: true,
         landscape: false,
         sftp_dir_name: "007_XFER_BLUE_GREEN_GOVERNMENTCENTER"
       },
       %{
+        place_id: "place-pktrm",
         name: "Park Street",
         portrait: true,
         landscape: true,
         sftp_dir_name: "001_XFER_RED_GREEN_PARK"
       },
       %{
+        place_id: "place-boyls",
         name: "Boylston",
         portrait: true,
         landscape: false,
         sftp_dir_name: "062_GREEN_SILVER_BOYLSTON"
       },
       %{
+        place_id: "place-armnl",
         name: "Arlington",
         portrait: true,
         landscape: true,
         sftp_dir_name: "063_GREEN_ARLINGTON"
       },
       %{
+        place_id: "place-coecl",
         name: "Copley",
         portrait: true,
         landscape: false,
         sftp_dir_name: "064_GREEN_COPLEY"
       },
       %{
+        place_id: "place-hymnl",
         name: "Hynes Convention Center",
         portrait: false,
         landscape: false,
         sftp_dir_name: "065_GREEN_HYNES"
       },
       %{
+        place_id: "place-kencl",
         name: "Kenmore",
         portrait: true,
         landscape: true,
         sftp_dir_name: "066_GREEN_KENMORE"
       },
       %{
+        place_id: "place-prmnl",
         name: "Prudential",
         portrait: false,
         landscape: true,
         sftp_dir_name: "111_E_GREEN_PRUDENTIAL"
       },
       %{
+        place_id: "place-symcl",
         name: "Symphony",
         portrait: false,
         landscape: false,

--- a/config/outfront_takeover_screens.exs
+++ b/config/outfront_takeover_screens.exs
@@ -304,7 +304,7 @@ config :screenplay,
     ],
     blue: [
       %{
-        place_id: "place-bowd",
+        place_id: "place-bomnl",
         name: "Bowdoin",
         portrait: false,
         landscape: false,

--- a/lib/screenplay/jobs/takeover_tool_testing_job.ex
+++ b/lib/screenplay/jobs/takeover_tool_testing_job.ex
@@ -74,15 +74,15 @@ defmodule Screenplay.Jobs.TakeoverToolTestingJob do
     {:ok, portrait_dirs} = sftp_client_module().list_dir(conn, "./Portrait")
     {:ok, landscape_dirs} = sftp_client_module().list_dir(conn, "./Landscape")
 
-    outfront_takeover_tool_screens =
+    outfront_takeover_screens =
       :screenplay
-      |> Application.get_env(:outfront_takeover_tool_screens)
+      |> Application.get_env(:outfront_takeover_screens)
       |> Map.values()
       |> List.flatten()
       |> Enum.uniq()
 
-    portrait_stations = Enum.filter(outfront_takeover_tool_screens, & &1.portrait)
-    landscape_stations = Enum.filter(outfront_takeover_tool_screens, & &1.landscape)
+    portrait_stations = Enum.filter(outfront_takeover_screens, & &1.portrait)
+    landscape_stations = Enum.filter(outfront_takeover_screens, & &1.landscape)
 
     log_missing_dirs(portrait_dirs, portrait_stations, @portrait_dir)
     log_missing_dirs(landscape_dirs, landscape_stations, @landscape_dir)

--- a/lib/screenplay/outfront/sftp.ex
+++ b/lib/screenplay/outfront/sftp.ex
@@ -45,7 +45,7 @@ defmodule Screenplay.Outfront.SFTP do
   def get_outfront_directory_for_station(station) do
     %{sftp_dir_name: dir_name} =
       :screenplay
-      |> Application.get_env(:outfront_takeover_tool_screens)
+      |> Application.get_env(:outfront_takeover_screens)
       |> Map.values()
       |> List.flatten()
       |> Enum.find(&(&1.name == station))

--- a/lib/screenplay/places.ex
+++ b/lib/screenplay/places.ex
@@ -6,6 +6,7 @@ defmodule Screenplay.Places do
   use Supervisor
 
   alias Screenplay.Places.{Builder, Cache, Place}
+  alias Screenplay.Places.Place.OutfrontTakeoverScreen
 
   @spec start_link(keyword()) :: Supervisor.on_start()
   def start_link(_) do
@@ -33,6 +34,16 @@ defmodule Screenplay.Places do
 
   @spec get() :: list(Place.t())
   def get do
+    Cache.all(nil, return: :value)
+    |> update_in([Access.all(), Access.key(:screens)], fn screens ->
+      Enum.reject(screens, fn screen ->
+        match?(%{hidden?: true}, screen) or match?(%OutfrontTakeoverScreen{}, screen)
+      end)
+    end)
+  end
+
+  @spec get_all() :: list(Place.t())
+  def get_all do
     Cache.all(nil, return: :value)
     |> update_in([Access.all(), Access.key(:screens)], fn screens ->
       Enum.reject(screens, &match?(%{hidden?: true}, &1))

--- a/lib/screenplay/places/builder.ex
+++ b/lib/screenplay/places/builder.ex
@@ -9,7 +9,7 @@ defmodule Screenplay.Places.Builder do
 
   alias Screenplay.Places
   alias Screenplay.Places.Place
-  alias Screenplay.Places.Place.{PaEssScreen, ShowtimeScreen}
+  alias Screenplay.Places.Place.{OutfrontTakeoverScreen, PaEssScreen, ShowtimeScreen}
   alias Screenplay.ScreensConfig, as: ScreensConfigStore
   alias ScreensConfig.{Alerts, Departures, Footer, Header, MultiStopAlerts, Screen}
   alias ScreensConfig.Departures.{Query, Section}
@@ -57,6 +57,7 @@ defmodule Screenplay.Places.Builder do
   defp build do
     live_showtime_screens = get_showtime_screens()
     paess_places = get_paess_places()
+    outfront_ett_places = get_outfront_ett_places()
     {:ok, parent_stations} = @stops_mod.fetch_all_parent_stations()
 
     # All parent stations should be displayed in Screenplay,
@@ -81,6 +82,10 @@ defmodule Screenplay.Places.Builder do
     # Add on PA/ESS signs
     |> Enum.map(fn %{id: id, screens: screens} = place ->
       Map.put(place, :screens, screens ++ (paess_places[id] || []))
+    end)
+    # Add on Outfront ETT screens
+    |> Enum.map(fn %{id: id, screens: screens} = place ->
+      Map.put(place, :screens, screens ++ (outfront_ett_places[id] || []))
     end)
     # Get rid of CR and Bus stops with no screens
     |> Enum.reject(fn %{routes: routes, screens: screens} ->
@@ -421,5 +426,26 @@ defmodule Screenplay.Places.Builder do
       _ ->
         []
     end
+  end
+
+  defp get_outfront_ett_places do
+    outfront_config = Application.get_env(:screenplay, :outfront_takeover_screens, %{})
+
+    outfront_config
+    |> Enum.flat_map(fn {_line, stations} ->
+      Enum.map(stations, fn station ->
+        %{
+          place_id: station.place_id,
+          screen: %OutfrontTakeoverScreen{
+            id: "#{station.place_id}-outfront",
+            type: "outfront_takeover",
+            portrait: station.portrait,
+            landscape: station.landscape,
+            sftp_dir_name: station.sftp_dir_name
+          }
+        }
+      end)
+    end)
+    |> Enum.group_by(& &1.place_id, & &1.screen)
   end
 end

--- a/lib/screenplay/places/place.ex
+++ b/lib/screenplay/places/place.ex
@@ -1,7 +1,7 @@
 defmodule Screenplay.Places.Place do
   @moduledoc """
   Module used to define struct for screen configs stored in `Screenplay.Places.Cache`.
-  A screen config can either be a `PaEssScreen.t()` or a `ShowtimeScreen.t()`.
+  A screen config can either be a `PaEssScreen.t()`, a `ShowtimeScreen.t()`, or an `OutfrontTakeoverScreen.t()`.
   """
 
   defmodule PaEssScreen do
@@ -59,9 +59,34 @@ defmodule Screenplay.Places.Place do
     end
   end
 
+  defmodule OutfrontTakeoverScreen do
+    @moduledoc """
+    Module used to define struct for Outfront Takeover screen configs stored in `Screenplay.Places.Cache`.
+    """
+
+    @derive Jason.Encoder
+
+    @type t :: %__MODULE__{
+            id: String.t(),
+            type: String.t(),
+            portrait: boolean(),
+            landscape: boolean(),
+            sftp_dir_name: String.t()
+          }
+
+    @enforce_keys [:id, :type, :portrait, :landscape, :sftp_dir_name]
+    defstruct @enforce_keys
+
+    def new(map) do
+      map
+      |> Map.new(fn {k, v} -> {String.to_existing_atom(k), v} end)
+      |> then(&struct!(__MODULE__, &1))
+    end
+  end
+
   @type route :: String.t()
 
-  @type screen :: PaEssScreen.t() | ShowtimeScreen.t()
+  @type screen :: PaEssScreen.t() | ShowtimeScreen.t() | OutfrontTakeoverScreen.t()
 
   @type t :: %__MODULE__{
           id: String.t(),
@@ -79,8 +104,14 @@ defmodule Screenplay.Places.Place do
 
     screens =
       Enum.map(screens, fn
-        pa_ess_screen = %{"type" => "pa_ess"} -> PaEssScreen.new(pa_ess_screen)
-        showtime_screen -> ShowtimeScreen.new(showtime_screen)
+        pa_ess_screen = %{"type" => "pa_ess"} ->
+          PaEssScreen.new(pa_ess_screen)
+
+        outfront_screen = %{"type" => "outfront_takeover"} ->
+          OutfrontTakeoverScreen.new(outfront_screen)
+
+        showtime_screen ->
+          ShowtimeScreen.new(showtime_screen)
       end)
 
     %__MODULE__{

--- a/lib/screenplay_web/controllers/emergency_takeover_tool/alert_controller.ex
+++ b/lib/screenplay_web/controllers/emergency_takeover_tool/alert_controller.ex
@@ -33,7 +33,6 @@ defmodule ScreenplayWeb.EmergencyTakeoverTool.AlertController do
 
     portrait_image_data = decode_png(portrait_png)
     landscape_image_data = decode_png(landscape_png)
-
     _ = SFTP.set_takeover_images(stations, portrait_image_data, landscape_image_data)
 
     json(conn, %{success: true})

--- a/lib/screenplay_web/controllers/emergency_takeover_tool/page_controller.ex
+++ b/lib/screenplay_web/controllers/emergency_takeover_tool/page_controller.ex
@@ -1,12 +1,15 @@
 defmodule ScreenplayWeb.EmergencyTakeoverTool.PageController do
   use ScreenplayWeb, :controller
 
+  alias Screenplay.Places
+  alias Screenplay.Places.Place.OutfrontTakeoverScreen
+
   plug(:sentry_dsn)
 
-  @stations_and_screen_orientations Application.compile_env!(
-                                      :screenplay,
-                                      :outfront_takeover_tool_screens
-                                    )
+  @outfront_station_and_screens Application.compile_env!(
+                                  :screenplay,
+                                  :outfront_takeover_screens
+                                )
 
   defp sentry_dsn(conn, _) do
     dsn =
@@ -24,6 +27,30 @@ defmodule ScreenplayWeb.EmergencyTakeoverTool.PageController do
   end
 
   def stations_and_screen_orientations(conn, _params) do
-    json(conn, @stations_and_screen_orientations)
+    json(conn, @outfront_station_and_screens)
+  end
+
+  def stations_and_screens(conn, _params) do
+    places = Places.get_all()
+
+    # Extract all OutfrontTakeoverScreen screens as a simple map
+    # This will be expanded to include showtime screens as well
+    outfront_screens =
+      places
+      |> Enum.flat_map(fn place ->
+        place.screens
+        |> Enum.filter(&match?(%OutfrontTakeoverScreen{}, &1))
+        |> Enum.map(fn screen ->
+          {place.name,
+           %{
+             name: place.name,
+             portrait: screen.portrait,
+             landscape: screen.landscape
+           }}
+        end)
+      end)
+      |> Map.new()
+
+    json(conn, outfront_screens)
   end
 end

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -168,7 +168,7 @@ defmodule ScreenplayWeb.Router do
     get("/active_alerts", AlertController, :active_alerts)
     get("/past_alerts", AlertController, :past_alerts)
 
-    get("/stations_and_screen_orientations", PageController, :stations_and_screen_orientations)
+    get("/stations_and_screens", PageController, :stations_and_screens)
   end
 
   # Enables LiveDashboard only for development


### PR DESCRIPTION
**Asana task**: [ETT: integrate Outfront screens with Places framework](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1213370222596876?focus=true)

- No user-visible changes (aside from ASHMONT and BRAINTREE no longer being capitalized on the Station Selection list
- Adds parent station ID to the hardcoded JSON of emergency-takeover-compatible Outfront screens
- Adds a new screen type in the Places framework that represents these Outfront ETT screens. These are filtered out in all cases except when finding the ETT compatible screens.

