### PR TITLE
deps(dev): remove unused types package

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -32,7 +32,6 @@
         "@eslint/js": "^9.39.2",
         "@testing-library/jest-dom": "^6.4.8",
         "@testing-library/react": "^16.0.1",
-        "@types/date-fns": "^2.6.3",
         "@types/jest": "^29.5.14",
         "@types/lodash": "^4.17.23",
         "@types/phoenix": "^1.6.7",
@@ -2831,17 +2830,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.20.7"
-      }
-    },
-    "node_modules/@types/date-fns": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/@types/date-fns/-/date-fns-2.6.3.tgz",
-      "integrity": "sha512-Ke1lw2Ni1t/wMUoLtKFmSNCLozcTBd6vmMqFP4hRzXn6qzkNt97bPAX0x5Y/c15DP43kKvwW1ycStD5+43jVQA==",
-      "deprecated": "This is a stub types definition. date-fns provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "date-fns": "*"
       }
     },
     "node_modules/@types/estree": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -39,7 +39,6 @@
     "@eslint/js": "^9.39.2",
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "^16.0.1",
-    "@types/date-fns": "^2.6.3",
     "@types/jest": "^29.5.14",
     "@types/lodash": "^4.17.23",
     "@types/phoenix": "^1.6.7",


### PR DESCRIPTION
On install this package gives a message that it is deprecated and now does nothing, because `date-fns` now has first-party type definitions.