### PR TITLE
fix alert link

### DIFF
--- a/assets/js/components/Dashboard/AlertDetails.tsx
+++ b/assets/js/components/Dashboard/AlertDetails.tsx
@@ -54,11 +54,14 @@ const AlertDetails: ComponentType = () => {
               {formatEffect(selectedAlert.effect)} #{selectedAlert.id}
             </span>
             <Button
-              href={alertsUiUrl + `/edit/${selectedAlert.id}`}
+              href={
+                alertsUiUrl +
+                `/alerts?${new URLSearchParams({ "filter[multi_column_search]": selectedAlert.id, "filter[timeline]": "all" }).toString()}`
+              }
               target="_blank"
               className="alert-details__external-link"
             >
-              Edit Alert <ArrowUpRight className="bootstrap-line-icon" />
+              View Alert <ArrowUpRight className="bootstrap-line-icon" />
             </Button>
           </div>
         </div>


### PR DESCRIPTION
**Asana task**: [Screenplay Bug: wrong URL on Edit Alert button ](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1214354571963285?focus=true)

This, along with the associated infra change, changes the alert link so it works regardless of permission.