### PR TITLE
Fix test warnings

### DIFF
--- a/test/screenplay_web/controllers/auth_controller_test.exs
+++ b/test/screenplay_web/controllers/auth_controller_test.exs
@@ -5,8 +5,6 @@ defmodule ScreenplayWeb.Controllers.AuthControllerTest do
 
   describe "callback" do
     test "redirects on success and saves refresh token", %{conn: conn} do
-      current_time = System.system_time(:second)
-
       conn =
         conn
         |> init_test_session(%{})

--- a/test/screenplay_web/controllers/auth_controller_test.exs
+++ b/test/screenplay_web/controllers/auth_controller_test.exs
@@ -14,6 +14,7 @@ defmodule ScreenplayWeb.Controllers.AuthControllerTest do
       assert redirected_to(conn) == "/test"
     end
 
+    @tag :capture_log
     test "handles generic failure", %{conn: conn} do
       conn =
         conn

--- a/test/screenplay_web/controllers/pa_messages_api_controller_test.exs
+++ b/test/screenplay_web/controllers/pa_messages_api_controller_test.exs
@@ -15,12 +15,14 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
   end
 
   describe "active/2" do
+    @tag :capture_log
     test "responds 403 if x-api-key is missing", %{conn: conn} do
       conn = get(conn, "/api/pa-messages/active")
 
       assert %{status: 403, halted: true, resp_body: "Invalid API key"} = conn
     end
 
+    @tag :capture_log
     test "responds 403 if x-api-key does not match app API key", %{conn: conn} do
       conn =
         conn |> Plug.Conn.put_req_header("x-api-key", "1234") |> get("/api/pa-messages/active")
@@ -285,6 +287,7 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
     end
 
     @tag :authenticated_pa_message_admin
+    @tag :capture_log
     test "returns an error object when passed invalid params", %{conn: conn} do
       assert %{"errors" => _} =
                conn
@@ -293,6 +296,7 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
     end
 
     @tag :authenticated
+    @tag :capture_log
     test "requires the PA message admin role", %{conn: conn} do
       conn = post(conn, "/api/pa-messages", @valid_params)
       assert response(conn, :unauthorized)
@@ -323,6 +327,7 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
     end
 
     @tag :authenticated_pa_message_admin
+    @tag :capture_log
     test "returns a 404 when the pa message does not exist", %{conn: conn} do
       assert %{"error" => "not_found"} ==
                conn
@@ -331,6 +336,7 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
     end
 
     @tag :authenticated
+    @tag :capture_log
     test "requires the PA message admin role", %{conn: conn} do
       conn = put(conn, "/api/pa-messages/1", %{visual_text: "Updated Visual Text"})
       assert response(conn, :unauthorized)
@@ -370,6 +376,7 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
     end
 
     @tag :authenticated
+    @tag :capture_log
     test "returns a 404 if the PA message doesn't exist", %{conn: conn} do
       assert %{"error" => "not_found"} =
                conn

--- a/test/screenplay_web/controllers/suppressed_predictions_api_controller_test.exs
+++ b/test/screenplay_web/controllers/suppressed_predictions_api_controller_test.exs
@@ -11,6 +11,7 @@ defmodule ScreenplayWeb.SuppressedPredictionsApiControllerTest do
   end
 
   describe "GET /api/suppressed-predictions with index/2" do
+    @tag :capture_log
     test "responds 403 if not authenticated", %{conn: conn} do
       conn =
         conn
@@ -60,6 +61,7 @@ defmodule ScreenplayWeb.SuppressedPredictionsApiControllerTest do
     }
 
     @tag :authenticated
+    @tag :capture_log
     test "returns error when user is not a suppression admin", %{conn: conn} do
       conn = post(conn, "/api/suppressed-predictions", @valid_params)
       assert response(conn, 401)
@@ -79,6 +81,7 @@ defmodule ScreenplayWeb.SuppressedPredictionsApiControllerTest do
     end
 
     @tag :authenticated_suppression_admin
+    @tag :capture_log
     test "returns an error when passing in a Green Line branch route instead of Green", %{
       conn: conn
     } do
@@ -99,6 +102,7 @@ defmodule ScreenplayWeb.SuppressedPredictionsApiControllerTest do
     end
 
     @tag :authenticated_suppression_admin
+    @tag :capture_log
     test "returns an error when passing in a Silver Line route that is not 741, 742, 743 or 746",
          %{
            conn: conn
@@ -120,6 +124,7 @@ defmodule ScreenplayWeb.SuppressedPredictionsApiControllerTest do
     end
 
     @tag :authenticated_suppression_admin
+    @tag :capture_log
     test "returns an error when passed invalid location id", %{conn: conn} do
       assert %{"errors" => _} =
                conn
@@ -131,6 +136,7 @@ defmodule ScreenplayWeb.SuppressedPredictionsApiControllerTest do
     end
 
     @tag :authenticated_suppression_admin
+    @tag :capture_log
     test "returns an error when passed invalid direction id", %{conn: conn} do
       assert %{"errors" => _} =
                conn
@@ -181,6 +187,7 @@ defmodule ScreenplayWeb.SuppressedPredictionsApiControllerTest do
     end
 
     @tag :authenticated_suppression_admin
+    @tag :capture_log
     test "returns 404 when SuppressedPrediction with id is not found", %{conn: conn} do
       assert %{"error" => "not_found"} =
                conn
@@ -230,6 +237,7 @@ defmodule ScreenplayWeb.SuppressedPredictionsApiControllerTest do
     end
 
     @tag :authenticated_suppression_admin
+    @tag :capture_log
     test "returns 404 when SuppressedPrediction with id is not found", %{conn: conn} do
       assert %{"error" => "not_found"} =
                conn

--- a/test/screenplay_web/controllers/unauthorized_controller_test.exs
+++ b/test/screenplay_web/controllers/unauthorized_controller_test.exs
@@ -5,6 +5,7 @@ defmodule ScreenplayWeb.Controllers.UnauthorizedControllerTest do
 
   describe "index/2" do
     @tag :authenticated
+    @tag :capture_log
     test "renders response", %{conn: conn} do
       conn = get(conn, unauthorized_path(conn, :index))
 


### PR DESCRIPTION
* Fix an unused variable warning.
* Capture warnings for tests we expect to emit them. There are a lot of these since the introduction of the Logster plug in 782ad5a, which has a default behavior of logging `4xx` responses as `warn`.

We might alternatively use `ExUnit.start(capture_log: true)`, which effectively applies this tag to every test case. But it might be nice to know when code under test is emitting a warning we *didn't* expect, even if it passes.