### PR TITLE
fix: Modal text colors incorrect following Bootstrap upgrade

### DIFF
--- a/assets/css/dashboard/new-pa-message/associate-alert-page.scss
+++ b/assets/css/dashboard/new-pa-message/associate-alert-page.scss
@@ -20,7 +20,7 @@
 }
 
 .alert-items-modal {
-  color: white;
+  --bs-modal-color: #{$text-primary};
 
   .modal-dialog {
     min-width: 800px;

--- a/assets/css/error-modal.scss
+++ b/assets/css/error-modal.scss
@@ -1,5 +1,6 @@
 .modal.error-modal {
-  color: $text-primary;
+  --bs-modal-color: #{$text-primary};
+
   .modal-dialog {
     margin-top: 362px;
   }


### PR DESCRIPTION
**Asana task**: [Screenplay: Modal text colors hard to read](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1215002948592216?focus=true)

After the Bootstrap update in [this Dependabot commit](https://github.com/mbta/screenplay/commit/afc8df59e013f147e9a3260770b58855aee0a416), the color within `modal-content` started to be overridden by `bs-modal-color`. Resolved this by explicitly setting this variable instead of the color within both the alert association modal and the error modal.

### PA Message Workflow
<img width="878" height="561" alt="image" src="https://github.com/user-attachments/assets/0e16344d-b291-465d-9438-a1a66805b020" />

### Error Modal
<img width="629" height="320" alt="image" src="https://github.com/user-attachments/assets/94fdd121-29dd-409d-b2ef-ad658e5d6239" />
