### PR TITLE
fix: Do not overwrite screen configs without emergency_messaging_location

### DIFF
--- a/lib/screenplay/permanent_config.ex
+++ b/lib/screenplay/permanent_config.ex
@@ -4,6 +4,8 @@ defmodule Screenplay.PermanentConfig do
   # Suppress dialyzer warning until more app_ids are implemented.
   @dialyzer [{:nowarn_function, get_route_id: 3}, {:nowarn_function, json_to_struct: 4}]
 
+  require Logger
+
   alias Screenplay.EmergencyTakeoverTool.Alerts.Alert
   alias Screenplay.PendingScreensConfig.Fetch, as: PendingScreensFetch
   alias Screenplay.Places
@@ -483,22 +485,28 @@ defmodule Screenplay.PermanentConfig do
     for {id, screen} <- screens,
         into: %{} do
       if id in screen_ids do
-        %Screen{app_params: %{emergency_messaging_location: eml}} = screen
+        case screen do
+          %Screen{app_params: %{emergency_messaging_location: eml}} when not is_nil(eml) ->
+            emergency_takeover =
+              Alert.build_emergency_takeover(
+                message,
+                alert_id,
+                screen.app_id,
+                eml
+              )
 
-        emergency_takeover =
-          Alert.build_emergency_takeover(
-            message,
-            alert_id,
-            screen.app_id,
-            eml
-          )
+            {id,
+             put_in(
+               screen,
+               [Access.key!(:app_params), Access.key!(:emergency_takeover)],
+               emergency_takeover
+             )}
 
-        {id,
-         put_in(
-           screen,
-           [Access.key!(:app_params), Access.key!(:emergency_takeover)],
-           emergency_takeover
-         )}
+          _ ->
+            Logger.error("Tried to takeover #{id} without an emergency_messaging_location")
+
+            {id, screen}
+        end
       else
         {id, screen}
       end

--- a/lib/screenplay/permanent_config.ex
+++ b/lib/screenplay/permanent_config.ex
@@ -480,9 +480,11 @@ defmodule Screenplay.PermanentConfig do
   end
 
   defp update_screens_with_emergency_takeover(screens, screen_ids, alert_id, message) do
-    for {id, %Screen{app_params: %{emergency_messaging_location: eml}} = screen} <- screens,
+    for {id, screen} <- screens,
         into: %{} do
       if id in screen_ids do
+        %Screen{app_params: %{emergency_messaging_location: eml}} = screen
+
         emergency_takeover =
           Alert.build_emergency_takeover(
             message,

--- a/test/screenplay/permanent_config_test.exs
+++ b/test/screenplay/permanent_config_test.exs
@@ -25,6 +25,65 @@ defmodule Screenplay.PermanentConfigTest do
 
   alias ScreensConfig.Screen.GlEink
 
+  @screen_without_takeover %Screen{
+    vendor: :mercury,
+    device_id: nil,
+    name: nil,
+    app_id: :pre_fare_v2,
+    refresh_if_loaded_before: nil,
+    disabled: false,
+    hidden_from_screenplay: false,
+    app_params: %PreFare{
+      emergency_messaging_location: :inside,
+      emergency_takeover: nil,
+      content_summary: %ContentSummary{parent_station_id: "place-test"},
+      elevator_status: %ElevatorStatus{parent_station_id: "place-test"},
+      full_line_map: [],
+      header: %Header.StopId{stop_id: "place-test"},
+      reconstructed_alert_widget: %ScreensConfig.Alerts{stop_id: "place-test"}
+    },
+    tags: []
+  }
+  @gl_eink_screen %Screen{
+    vendor: :mercury,
+    device_id: nil,
+    name: nil,
+    app_id: :gl_eink_v2,
+    refresh_if_loaded_before: nil,
+    disabled: false,
+    hidden_from_screenplay: false,
+    app_params: %GlEink{
+      departures: %Departures{
+        sections: [
+          %Departures.Section{
+            query: %Departures.Query{
+              params: %Departures.Query.Params{
+                stop_ids: ["place-test"],
+                route_ids: ["Green-B"],
+                direction_id: 1
+              }
+            }
+          }
+        ]
+      },
+      footer: %Footer{stop_id: "place-test"},
+      header: %Header.Destination{
+        route_id: "Green-B",
+        direction_id: 1
+      },
+      alerts: %Alerts{stop_id: "456"},
+      line_map: %LineMap{
+        stop_id: "456",
+        station_id: "place-test",
+        direction_id: 1,
+        route_id: "Green-B"
+      },
+      evergreen_content: [],
+      platform_location: :back
+    },
+    tags: []
+  }
+
   def fetch_current_config_version do
     {:ok, _config, metadata} = Local.fetch_config()
     metadata.version_id
@@ -440,65 +499,6 @@ defmodule Screenplay.PermanentConfigTest do
   end
 
   describe "add_emergency_takeover_configs/3" do
-    @screen_without_takeover %Screen{
-      vendor: :mercury,
-      device_id: nil,
-      name: nil,
-      app_id: :pre_fare_v2,
-      refresh_if_loaded_before: nil,
-      disabled: false,
-      hidden_from_screenplay: false,
-      app_params: %PreFare{
-        emergency_messaging_location: :inside,
-        emergency_takeover: nil,
-        content_summary: %ContentSummary{parent_station_id: "place-test"},
-        elevator_status: %ElevatorStatus{parent_station_id: "place-test"},
-        full_line_map: [],
-        header: %Header.StopId{stop_id: "place-test"},
-        reconstructed_alert_widget: %ScreensConfig.Alerts{stop_id: "place-test"}
-      },
-      tags: []
-    }
-    @gl_eink_screen %Screen{
-      vendor: :mercury,
-      device_id: nil,
-      name: nil,
-      app_id: :gl_eink_v2,
-      refresh_if_loaded_before: nil,
-      disabled: false,
-      hidden_from_screenplay: false,
-      app_params: %GlEink{
-        departures: %Departures{
-          sections: [
-            %Departures.Section{
-              query: %Departures.Query{
-                params: %Departures.Query.Params{
-                  stop_ids: ["place-test"],
-                  route_ids: ["Green-B"],
-                  direction_id: 1
-                }
-              }
-            }
-          ]
-        },
-        footer: %Footer{stop_id: "place-test"},
-        header: %Header.Destination{
-          route_id: "Green-B",
-          direction_id: 1
-        },
-        alerts: %Alerts{stop_id: "456"},
-        line_map: %LineMap{
-          stop_id: "456",
-          station_id: "place-test",
-          direction_id: 1,
-          route_id: "Green-B"
-        },
-        evergreen_content: [],
-        platform_location: :back
-      },
-      tags: []
-    }
-
     setup do
       published_screens_path = get_fixture_path("screens_config.json")
 
@@ -579,26 +579,6 @@ defmodule Screenplay.PermanentConfigTest do
   end
 
   describe "clear_emergency_takeover_configs/1" do
-    @screen_without_takeover %Screen{
-      vendor: :mercury,
-      device_id: nil,
-      name: nil,
-      app_id: :pre_fare_v2,
-      refresh_if_loaded_before: nil,
-      disabled: false,
-      hidden_from_screenplay: false,
-      app_params: %PreFare{
-        emergency_messaging_location: :inside,
-        emergency_takeover: nil,
-        content_summary: %ContentSummary{parent_station_id: "place-test"},
-        elevator_status: %ElevatorStatus{parent_station_id: "place-test"},
-        full_line_map: [],
-        header: %Header.StopId{stop_id: "place-test"},
-        reconstructed_alert_widget: %ScreensConfig.Alerts{stop_id: "place-test"}
-      },
-      tags: []
-    }
-
     setup do
       published_screens_path = get_fixture_path("screens_config.json")
 
@@ -617,7 +597,8 @@ defmodule Screenplay.PermanentConfigTest do
         %Config{
           screens: %{
             "PRE-1" => screen_with_takeover,
-            "PRE-2" => @screen_without_takeover
+            "PRE-2" => @screen_without_takeover,
+            "GL-1" => @gl_eink_screen
           }
         }
         |> Config.to_json()
@@ -636,6 +617,7 @@ defmodule Screenplay.PermanentConfigTest do
 
       assert screens[takeover_screen_id] == @screen_without_takeover
       assert screens["PRE-2"] == @screen_without_takeover
+      assert screens["GL-1"] == @gl_eink_screen
     end
   end
 end

--- a/test/screenplay/permanent_config_test.exs
+++ b/test/screenplay/permanent_config_test.exs
@@ -459,6 +459,45 @@ defmodule Screenplay.PermanentConfigTest do
       },
       tags: []
     }
+    @gl_eink_screen %Screen{
+      vendor: :mercury,
+      device_id: nil,
+      name: nil,
+      app_id: :gl_eink_v2,
+      refresh_if_loaded_before: nil,
+      disabled: false,
+      hidden_from_screenplay: false,
+      app_params: %GlEink{
+        departures: %Departures{
+          sections: [
+            %Departures.Section{
+              query: %Departures.Query{
+                params: %Departures.Query.Params{
+                  stop_ids: ["place-test"],
+                  route_ids: ["Green-B"],
+                  direction_id: 1
+                }
+              }
+            }
+          ]
+        },
+        footer: %Footer{stop_id: "place-test"},
+        header: %Header.Destination{
+          route_id: "Green-B",
+          direction_id: 1
+        },
+        alerts: %Alerts{stop_id: "456"},
+        line_map: %LineMap{
+          stop_id: "456",
+          station_id: "place-test",
+          direction_id: 1,
+          route_id: "Green-B"
+        },
+        evergreen_content: [],
+        platform_location: :back
+      },
+      tags: []
+    }
 
     setup do
       published_screens_path = get_fixture_path("screens_config.json")
@@ -467,7 +506,8 @@ defmodule Screenplay.PermanentConfigTest do
         %Config{
           screens: %{
             "PRE-1" => @screen_without_takeover,
-            "PRE-2" => @screen_without_takeover
+            "PRE-2" => @screen_without_takeover,
+            "GL-1" => @gl_eink_screen
           }
         }
         |> Config.to_json()
@@ -503,6 +543,7 @@ defmodule Screenplay.PermanentConfigTest do
                )
 
       assert screens["PRE-2"] == @screen_without_takeover
+      assert screens["GL-1"] == @gl_eink_screen
     end
 
     test "adds a canned emergency takeover config to a screen" do


### PR DESCRIPTION
The existing pattern matching when setting an emergency takeover assumed that all screens had an `emergency_messaging_location`, and thus accidentally set the config for all screens without one (einks and bus shelters) to nil. 