### PR TITLE
refactor: simplify client PA Message types

### DIFF
--- a/assets/js/components/Dashboard/PaMessageForm/MainForm.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/MainForm.tsx
@@ -22,8 +22,7 @@ import { AudioPreview, Page } from "./types";
 import SelectedSignsByRouteTags from "./SelectedSignsByRouteTags";
 import { Place } from "Models/place";
 import * as paMessageStyles from "Styles/pa-messages.module.scss";
-import { StaticTemplate } from "Models/static_template";
-import { MessageType } from "Models/pa_message";
+import type { StaticTemplate, TemplateType } from "Models/static_template";
 
 const MAX_TEXT_LENGTH = 2000;
 
@@ -604,14 +603,12 @@ const NewPaMessageHeader = ({
     );
   };
 
-  const formatMessageType = (messageType: MessageType) => {
-    switch (messageType) {
+  const formatTemplateType = (templateType: TemplateType) => {
+    switch (templateType) {
       case "psa":
         return "PSA";
       case "emergency":
         return "Emergency";
-      default:
-        return "";
     }
   };
 
@@ -652,7 +649,7 @@ const NewPaMessageHeader = ({
         className={cx("d-flex align-items-center", paMessageStyles.alertHeader)}
       >
         <span className={paMessageStyles.larger}>
-          Template: {formatMessageType(selectedTemplate.type)} -{" "}
+          Template: {formatTemplateType(selectedTemplate.type)} -{" "}
           {selectedTemplate.title}
         </span>
         {!isReadOnly && (

--- a/assets/js/components/Dashboard/PaMessageForm/PaMessageForm.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/PaMessageForm.tsx
@@ -10,32 +10,17 @@ import { usePlacesWithPaEss } from "Hooks/usePlacesWithPaEss";
 import Toast from "Components/Toast";
 import { busRouteIdsAtPlaces, getRouteIdsForSign } from "../../../util";
 import fp from "lodash/fp";
-import { StaticTemplate } from "Models/static_template";
-import { MessageType } from "Models/pa_message";
-
-interface PaMessageFormData {
-  alert_id: string | null;
-  start_datetime: string;
-  end_datetime: string | null;
-  days_of_week: number[];
-  sign_ids: string[];
-  priority: number;
-  interval_in_minutes: number;
-  visual_text: string;
-  audio_text: string;
-  audio_url: string;
-  message_type: MessageType;
-  template_id: number | null;
-}
+import type { PaMessageChange } from "Models/pa_message";
+import type { StaticTemplate } from "Models/static_template";
 
 interface Props {
   title: string;
-  onSubmit: (data: PaMessageFormData) => any;
+  onSubmit: (data: PaMessageChange) => any;
   onError: (message: string | null) => void;
   onErrorsChange: (errors: string[]) => void;
   errorMessage: string | null;
   errors: string[];
-  defaultValues?: Partial<PaMessageFormData>;
+  defaultValues?: PaMessageChange;
   defaultAlert?: Alert | string | null;
   defaultTemplate?: StaticTemplate | null;
   defaultAudioState?: AudioPreview;
@@ -200,7 +185,7 @@ const PaMessageForm = ({
       <MainForm
         hide={page !== Page.MAIN}
         onSubmit={() => {
-          const formData: PaMessageFormData = {
+          const formData: PaMessageChange = {
             alert_id:
               typeof associatedAlert === "string"
                 ? associatedAlert

--- a/assets/js/components/Dashboard/PaMessageForm/StaticTemplatePage.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/StaticTemplatePage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Button } from "react-bootstrap";
-import { StaticTemplate } from "Models/static_template";
+import type { StaticTemplate, TemplateType } from "Models/static_template";
 import MessageTable, { SortDirection } from "../../Tables/MessageTable";
 import _staticTemplates from "../../../../static/static_templates.json";
 import StaticTemplateRow from "../../Tables/Rows/StaticTemplateRow";
@@ -13,8 +13,6 @@ interface Props {
   onCancel: () => void;
   onSelect: (template: StaticTemplate) => void;
 }
-
-type TemplateType = "psa" | "emergency";
 
 export const STATIC_TEMPLATES = _staticTemplates as StaticTemplate[];
 

--- a/assets/js/components/Tables/Rows/PaMessageRow.tsx
+++ b/assets/js/components/Tables/Rows/PaMessageRow.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentType } from "react";
 import KebabMenu from "Components/KebabMenu";
 import { updateExistingPaMessage } from "Utils/api";
-import { PaMessage, UpdatePaMessageBody } from "Models/pa_message";
+import type { PaMessage, PaMessageChange } from "Models/pa_message";
 import moment from "moment";
 import cx from "classnames";
 import { useNavigate } from "react-router-dom";
@@ -48,9 +48,8 @@ const PaMessageRow: ComponentType<PaMessageRowProps> = ({
   const togglePaused = async (event: React.MouseEvent<HTMLDivElement>) => {
     event.stopPropagation();
     try {
-      await updateExistingPaMessage(paMessage.id, {
-        paused: !paMessage.paused,
-      } as UpdatePaMessageBody);
+      const change: PaMessageChange = { paused: !paMessage.paused };
+      await updateExistingPaMessage(paMessage.id, change);
       onUpdate();
     } catch (error) {
       setErrorMessage((error as Error).message);

--- a/assets/js/models/pa_message.ts
+++ b/assets/js/models/pa_message.ts
@@ -1,3 +1,5 @@
+import { type TemplateType } from "./static_template";
+
 export interface PaMessage {
   id: number;
   alert_id: string | null;
@@ -14,14 +16,10 @@ export interface PaMessage {
   saved: boolean;
   inserted_at: string;
   updated_at: string;
-  message_type: MessageType;
+  message_type: TemplateType | null;
   template_id: number | null;
 }
 
-export type MessageType = null | "psa" | "emergency";
-
-export type NewPaMessageBody = Omit<
-  PaMessage,
-  "id" | "paused" | "saved" | "inserted_at" | "updated_at"
+export type PaMessageChange = Partial<
+  Omit<PaMessage, "id" | "inserted_at" | "updated_at">
 >;
-export type UpdatePaMessageBody = Partial<PaMessage>;

--- a/assets/js/models/static_template.ts
+++ b/assets/js/models/static_template.ts
@@ -1,4 +1,4 @@
-import { type MessageType } from "./pa_message";
+export type TemplateType = "psa" | "emergency";
 
 export interface StaticTemplate {
   id: number;
@@ -6,5 +6,6 @@ export interface StaticTemplate {
   visual_text: string;
   audio_text?: string;
   audio_url?: string;
-  type: MessageType;
+  type: TemplateType;
+  archived: boolean;
 }

--- a/assets/js/utils/api.ts
+++ b/assets/js/utils/api.ts
@@ -5,7 +5,7 @@ import { ScreenConfiguration } from "../models/screen_configuration";
 import { ScreensByAlert } from "../models/screensByAlert";
 import { PlaceIdsAndNewScreens } from "../components/Dashboard/PermanentConfiguration/Workflows/GlEink/ConfigureScreensPage";
 import getCsrfToken from "../csrf";
-import { NewPaMessageBody, UpdatePaMessageBody } from "Models/pa_message";
+import type { PaMessageChange } from "Models/pa_message";
 import { SuppressedPrediction } from "Models/suppressed_prediction";
 import { withErrorHandling } from "./errorHandler";
 import { REFRESH_PAGE_ERROR_MESSAGE } from "Constants/constants";
@@ -193,7 +193,7 @@ export const publishScreensForPlace = async (
 };
 
 export const createNewPaMessage = async (
-  message: NewPaMessageBody,
+  message: PaMessageChange,
 ): Promise<{ status: number; errors: any }> => {
   const response = await fetch(API_ENDPOINT_PA_MESSAGES, {
     ...getPostBodyAndHeaders(message),
@@ -208,7 +208,7 @@ export const createNewPaMessage = async (
 
 export const updateExistingPaMessage = async (
   id: string | number,
-  updates: UpdatePaMessageBody,
+  change: PaMessageChange,
 ): Promise<{ status: number; body: any }> => {
   const response = await fetch(`${API_ENDPOINT_PA_MESSAGES}/${id}`, {
     method: "PUT",
@@ -217,7 +217,7 @@ export const updateExistingPaMessage = async (
       "content-type": "application/json",
       "x-csrf-token": getCsrfToken(),
     },
-    body: JSON.stringify(updates),
+    body: JSON.stringify(change),
   });
 
   if (response.status === 422) {


### PR DESCRIPTION
* Remove redundant `PaMessageFormData` type which was almost exactly `NewPaMessageBody`.

* Consolidate `NewPaMessageBody` and `UpdatePaMessageBody` into just `PaMessageChange`, which is the partial version. The server does not really have this dichotomy; it has validations on specific fields that apply to the final state of the message, regardless of whether it's a create or an update. This allows an `as` cast to be removed in `PaMessageRow`.

* Define the `message_type` of a `PaMessage` in terms of the `type` of a `StaticTemplate`, rather than the other way around. This allows an unreachable-in-practice branch to be removed in `MainForm`, and a duplicate type to be removed in `StaticTemplatePage`.