### PR TITLE
fix: hide archived PSA templates

### DIFF
--- a/assets/js/components/Dashboard/PaMessageForm/AssociateAlert.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/AssociateAlert.tsx
@@ -104,11 +104,9 @@ const AssociateAlert = ({ onApply, onCancel }: AssociateAlertPageProps) => {
         </div>
         <div style={{ flex: 1 }}>
           <MessageTable
-            isLoading={false}
             isReadOnly={false}
             headers={["Alert message", "ID", "Start-End", "Last modified"]}
             addSelectColumn
-            addMoreActions={false}
             rows={filteredAlerts.map((alert: Alert) => {
               return (
                 <AssociateAlertsRow

--- a/assets/js/components/Dashboard/PaMessageForm/StaticTemplatePage.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/StaticTemplatePage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Button } from "react-bootstrap";
 import type { StaticTemplate, TemplateType } from "Models/static_template";
 import MessageTable, { SortDirection } from "../../Tables/MessageTable";
-import _staticTemplates from "../../../../static/static_templates.json";
+import staticTemplatesJSON from "../../../../static/static_templates.json";
 import StaticTemplateRow from "../../Tables/Rows/StaticTemplateRow";
 import { RadioList } from "Components/RadioList";
 import * as styles from "Styles/pa-messages.module.scss";
@@ -14,7 +14,9 @@ interface Props {
   onSelect: (template: StaticTemplate) => void;
 }
 
-export const STATIC_TEMPLATES = _staticTemplates as StaticTemplate[];
+export const STATIC_TEMPLATES = staticTemplatesJSON as StaticTemplate[];
+
+const SELECTABLE_TEMPLATES = STATIC_TEMPLATES.filter((t) => !t.archived);
 
 const StaticTemplatePage = ({ onCancel, onSelect }: Props) => {
   const [selectedTemplateType, setSelectedTemplateType] =
@@ -33,27 +35,25 @@ const StaticTemplatePage = ({ onCancel, onSelect }: Props) => {
     }
   };
 
-  const sortedTemplates = sortColumn
-    ? STATIC_TEMPLATES.filter(
-        (template) => template.type === selectedTemplateType,
-      ).sort((first: StaticTemplate, second: StaticTemplate) => {
-        let firstValue;
-        let secondValue;
+  const templates = SELECTABLE_TEMPLATES.filter(
+    (template) => template.type === selectedTemplateType,
+  ).sort((first: StaticTemplate, second: StaticTemplate) => {
+    let firstValue: string;
+    let secondValue: string;
 
-        if (sortColumn === "Message") {
-          firstValue = first.title;
-          secondValue = second.title;
-        } else {
-          firstValue = templateTypeLabel(first);
-          secondValue = templateTypeLabel(second);
-        }
+    if (sortColumn === "Message") {
+      firstValue = first.title;
+      secondValue = second.title;
+    } else {
+      firstValue = templateTypeLabel(first);
+      secondValue = templateTypeLabel(second);
+    }
 
-        return (
-          firstValue.localeCompare(secondValue) *
-          (sortDirection === SortDirection.Asc ? 1 : -1)
-        );
-      })
-    : STATIC_TEMPLATES;
+    return (
+      firstValue.localeCompare(secondValue) *
+      (sortDirection === SortDirection.Asc ? 1 : -1)
+    );
+  });
 
   useHideSidebar();
 
@@ -88,10 +88,8 @@ const StaticTemplatePage = ({ onCancel, onSelect }: Props) => {
           <MessageTable
             headers={["Message", "Type"]}
             isReadOnly={false}
-            isLoading={false}
             addSelectColumn
-            addMoreActions={false}
-            rows={sortedTemplates.map((template) => {
+            rows={templates.map((template) => {
               return (
                 <StaticTemplateRow
                   key={template.title}
@@ -100,7 +98,6 @@ const StaticTemplatePage = ({ onCancel, onSelect }: Props) => {
                 />
               );
             })}
-            emptyStateText=""
             handleHeaderClick={setColumnSorting}
             sortColumn={sortColumn}
             sortDirection={sortDirection}

--- a/assets/js/components/Dashboard/PaMessagesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessagesPage.tsx
@@ -160,7 +160,6 @@ const PaMessagesPage: ComponentType = () => {
           <MessageTable
             isLoading={shouldShowLoadingState}
             headers={["Message", "Interval", "Start-End"]}
-            addSelectColumn={false}
             addMoreActions={showMoreActions}
             isReadOnly={isReadOnly}
             rows={

--- a/assets/js/components/Tables/MessageTable.tsx
+++ b/assets/js/components/Tables/MessageTable.tsx
@@ -50,9 +50,9 @@ const MessageTable = ({
                   {header === sortColumn && (
                     <>
                       {sortDirection === SortDirection.Asc ? (
-                        <ChevronDown style={{ marginLeft: 4 }} />
-                      ) : (
                         <ChevronUp style={{ marginLeft: 4 }} />
+                      ) : (
+                        <ChevronDown style={{ marginLeft: 4 }} />
                       )}
                     </>
                   )}


### PR DESCRIPTION
The `archived` flag was intended as a way to keep the template selection page clean while not outright deleting templates (since this would break looking at past PSAs which used them), but nothing in the code actually used this flag.

* Make template selection respect this flag.

* Remove an odd ternary that could never be false, but seemingly caused a bug where each time the table sorting was changed, it would permanently create a duplicate of the first row (in ascending message order).

* Remove extra props from uses of `MessageTable` that had the same behavior as not specifying the prop.

* Fix an unrelated bug where the table sorting chevrons were the opposite of what they should have been; "ascending" sort displayed a downward-pointing chevron. (Sorting logic was not affected, and the Static Templates selector is the only sortable table in the app.)

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1215144952558462?focus=true