### PR TITLE
add basic tool for uploading FIFA messages

### DIFF
--- a/assets/js/components/App.tsx
+++ b/assets/js/components/App.tsx
@@ -23,6 +23,9 @@ const SelectScreenTypeComponent = React.lazy(
 const PaMessagesPage = React.lazy(() => import("Components/PaMessagesPage"));
 const NewPaMessage = React.lazy(() => import("Components/NewPaMessage"));
 const EditPaMessage = React.lazy(() => import("Components/EditPaMessage"));
+const UploadPaMessages = React.lazy(
+  () => import("Components/UploadPaMessages"),
+);
 const PredictionSuppressionPage = React.lazy(
   () => import("Components/PredictionSuppressionPage"),
 );
@@ -54,6 +57,7 @@ class AppRoutes extends React.Component {
             </Route>
             <Route path="pa-messages" element={<PaMessagesPage />} />
             <Route path="pa-messages/new" element={<NewPaMessage />} />
+            <Route path="pa-messages/upload" element={<UploadPaMessages />} />
             <Route path="pa-messages/:id/edit" element={<EditPaMessage />} />
             <Route
               path="prediction-suppression"

--- a/assets/js/components/Dashboard/PaMessagesPage.tsx
+++ b/assets/js/components/Dashboard/PaMessagesPage.tsx
@@ -113,6 +113,12 @@ const PaMessagesPage: ComponentType = () => {
               </Link>
             )}
             <Link
+              to="/pa-messages/upload"
+              className={cx(styles.dashboardLink, "d-block mt-3")}
+            >
+              <span className={styles.text}>Upload FIFA messages</span>
+            </Link>
+            <Link
               to="https://mbta.splunkcloud.com/en-US/app/search/paess__pa_message_announcement_log"
               target="_blank"
               className={cx(styles.dashboardLink, "d-inline-block mt-3")}

--- a/assets/js/components/Dashboard/UploadPaMessages.tsx
+++ b/assets/js/components/Dashboard/UploadPaMessages.tsx
@@ -1,0 +1,166 @@
+import React, { useState } from "react";
+import fp from "lodash/fp";
+import { Button } from "react-bootstrap";
+import { parse } from "csv-parse/browser/esm/sync";
+import { createNewPaMessage } from "Utils/api";
+import { useScreenplayState } from "Hooks/useScreenplayContext";
+import { signDirection } from "../../util";
+import Toast from "Components/Toast";
+
+const gameDates = [
+  {
+    id: "6/13",
+    start: new Date("2026-06-13T04:00:00"),
+    end: new Date("2026-06-13T18:00:00"),
+  },
+  {
+    id: "6/16",
+    start: new Date("2026-06-16T04:00:00"),
+    end: new Date("2026-06-16T15:00:00"),
+  },
+  {
+    id: "6/19",
+    start: new Date("2026-06-19T04:00:00"),
+    end: new Date("2026-06-19T15:00:00"),
+  },
+  {
+    id: "6/23",
+    start: new Date("2026-06-23T04:00:00"),
+    end: new Date("2026-06-23T13:00:00"),
+  },
+  {
+    id: "6/26",
+    start: new Date("2026-06-26T04:00:00"),
+    end: new Date("2026-06-26T12:00:00"),
+  },
+  {
+    id: "6/29",
+    start: new Date("2026-06-29T04:00:00"),
+    end: new Date("2026-06-29T13:30:00"),
+  },
+  {
+    id: "7/09",
+    start: new Date("2026-07-09T04:00:00"),
+    end: new Date("2026-07-09T13:00:00"),
+  },
+];
+
+const UploadPaMessages = () => {
+  const [file, setFile] = useState<File>();
+  const [dateId, setDateId] = useState(gameDates[0].id);
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+  const { places } = useScreenplayState();
+
+  const submit = async () => {
+    try {
+      setLoading(true);
+      const { start, end } = gameDates.find((item) => item.id === dateId)!;
+      const contents = await new Promise<string>((resolve) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.readAsText(file!);
+      });
+
+      const placesLookup = fp.indexBy("name", places);
+      const lookupSigns = (line: string, station: string, where: string) => {
+        const place = placesLookup[station];
+        if (!place) {
+          throw new Error(`Couldn't find place named ${station}`);
+        }
+        return place.screens
+          .filter(
+            (screen) =>
+              screen.type === "pa_ess" &&
+              signDirection(screen) === where &&
+              screen.routes![0].id.startsWith(line),
+          )
+          .map((screen) => screen.id);
+      };
+      const items = parse(contents).flatMap(
+        ([line, station, left, middle, right]) => [
+          { message: left, signIds: lookupSigns(line, station, "left") },
+          { message: middle, signIds: lookupSigns(line, station, "middle") },
+          { message: right, signIds: lookupSigns(line, station, "right") },
+        ],
+      );
+      const groupedItems = Object.entries(
+        fp.groupBy((item) => item.message, items),
+      )
+        .map(([message, items]) => ({
+          message,
+          signIds: items.flatMap((item) => item.signIds),
+        }))
+        .filter(({ message, signIds }) => message && signIds.length);
+
+      await Promise.all(
+        groupedItems.map(async ({ message, signIds }) => {
+          const res = await createNewPaMessage({
+            alert_id: null,
+            start_datetime: start.toISOString(),
+            end_datetime: end.toISOString(),
+            days_of_week: [1, 2, 3, 4, 5, 6, 7],
+            sign_ids: signIds,
+            priority: 5,
+            interval_in_minutes: 4,
+            visual_text: message,
+            audio_text: message,
+            audio_url: "",
+            message_type: null,
+            template_id: null,
+          });
+          if (res.status !== 200) {
+            throw JSON.stringify(res.errors);
+          }
+        }),
+      );
+      setResult("success");
+      setFile(undefined);
+    } catch (e) {
+      setResult(e ? e.toString() : null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="px-5 py-4">
+      <h1 className="mb-5">Upload FIFA Messages</h1>
+      <label htmlFor="csv-file" className="d-block">
+        CSV file
+      </label>
+      <input
+        id="csv-file"
+        type="file"
+        onChange={(e) => setFile(e.target.files?.[0])}
+      />
+      <label htmlFor="game-date" className="mt-4 d-block">
+        Game date
+      </label>
+      <select
+        id="game-date"
+        value={dateId}
+        onChange={(e) => setDateId(e.target.value)}
+      >
+        {gameDates.map(({ id }) => (
+          <option key={id} value={id}>
+            {id}
+          </option>
+        ))}
+      </select>
+      <div className="mt-4">
+        <Button
+          disabled={!file || loading}
+          type="submit"
+          className="button-primary"
+          onClick={submit}
+        >
+          {loading ? "Loading..." : "Upload"}
+        </Button>
+      </div>
+      <Toast message={result} variant="info" onClose={() => setResult(null)} />
+    </div>
+  );
+};
+
+export default UploadPaMessages;

--- a/assets/js/util.ts
+++ b/assets/js/util.ts
@@ -170,17 +170,19 @@ export const placesWithSelectedAlert = (
     : [];
 };
 
+export const signDirection = (sign: Screen) => {
+  const directionIds = sign.routes?.map((r) => r.direction_id);
+  if (fp.intersection(directionIds, [0, 1]).length === 2) {
+    return "middle";
+  } else if (directionIds?.includes(0)) {
+    return "left";
+  } else {
+    return "right";
+  }
+};
+
 export const signsByDirection = (signs: Screen[]) => {
-  const groupedSigns = fp.groupBy((sign) => {
-    const directionIds = sign.routes?.map((r) => r.direction_id);
-    if (fp.intersection(directionIds, [0, 1]).length === 2) {
-      return "middle";
-    } else if (directionIds?.includes(0)) {
-      return "left";
-    } else {
-      return "right";
-    }
-  }, signs);
+  const groupedSigns = fp.groupBy(signDirection, signs);
 
   return {
     left: groupedSigns["left"] ?? [],

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -13,6 +13,7 @@
         "@types/pluralize": "^0.0.33",
         "bootstrap": "^5.3.8",
         "classnames": "^2.5.1",
+        "csv-parse": "^6.2.1",
         "date-fns": "^4.1.0",
         "lodash": "^4.17.23",
         "moment": "^2.29.4",
@@ -4280,6 +4281,12 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
+      "license": "MIT"
+    },
+    "node_modules/csv-parse": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
+      "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -20,6 +20,7 @@
     "@types/pluralize": "^0.0.33",
     "bootstrap": "^5.3.8",
     "classnames": "^2.5.1",
+    "csv-parse": "^6.2.1",
     "date-fns": "^4.1.0",
     "lodash": "^4.17.23",
     "moment": "^2.29.4",

--- a/lib/screenplay_web/router.ex
+++ b/lib/screenplay_web/router.ex
@@ -83,6 +83,7 @@ defmodule ScreenplayWeb.Router do
 
     get("/", PaMessagesController, :index)
     get("/new", PaMessagesController, :index)
+    get("/upload", PaMessagesController, :index)
     get("/:id/edit", PaMessagesController, :index)
   end
 


### PR DESCRIPTION
**Asana task**: [Match Day PA Message Configuration](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1214901474689447?focus=true)

This adds a page to allow bulk uploading of FIFA messages via a defined CSV file. The feature is intentionally minimal, since it will only be used a handful of times during the next few weeks. Tested with some handcrafted dummy data (see ticket for data format).