### PR TITLE
fix: restore bootstrap overrides

### DIFF
--- a/assets/css/dashboard/bottom-action-bar.scss
+++ b/assets/css/dashboard/bottom-action-bar.scss
@@ -1,4 +1,4 @@
-@use "../variables-screenplay-forms";
+@use "../variables";
 
 .bottom-action-bar {
   position: absolute;
@@ -18,7 +18,7 @@
   }
 
   .forward {
-    background-color: variables-screenplay-forms.$form-check-input-checked-bg-color;
+    background-color: variables.$button-primary;
     color: black;
     &:hover {
       background-color: #72a4cd;

--- a/assets/css/dashboard/new-pa-message/associate-alert-page.scss
+++ b/assets/css/dashboard/new-pa-message/associate-alert-page.scss
@@ -1,4 +1,3 @@
-@use "../../variables-screenplay-forms";
 @use "../../variables";
 
 .alert-description {
@@ -49,7 +48,7 @@
     }
 
     .apply-button {
-      background-color: variables-screenplay-forms.$form-check-input-checked-bg-color;
+      background-color: variables.$button-primary;
       color: black;
 
       &:hover {

--- a/assets/css/dashboard/pa-messages-page.scss
+++ b/assets/css/dashboard/pa-messages-page.scss
@@ -1,5 +1,4 @@
 @use "../variables";
-@use "../variables-screenplay-forms";
 
 .pause-active-switch-container {
   position: relative;
@@ -9,8 +8,6 @@
       width: 86px;
       height: 24px;
       margin-top: 0;
-      background-color: variables-screenplay-forms.$form-check-input-checked-bg-color;
-      border-color: variables-screenplay-forms.$form-check-input-checked-bg-color;
     }
 
     .form-check-input:not(:checked) {

--- a/assets/css/dashboard/pa-messages-page.scss
+++ b/assets/css/dashboard/pa-messages-page.scss
@@ -1,4 +1,5 @@
 @use "../variables";
+@use "../variables-screenplay-forms";
 
 .pause-active-switch-container {
   position: relative;
@@ -8,6 +9,8 @@
       width: 86px;
       height: 24px;
       margin-top: 0;
+      background-color: variables-screenplay-forms.$form-check-input-checked-bg-color;
+      border-color: variables-screenplay-forms.$form-check-input-checked-bg-color;
     }
 
     .form-check-input:not(:checked) {

--- a/assets/css/screenplay.scss
+++ b/assets/css/screenplay.scss
@@ -1,7 +1,13 @@
 @use "variables";
 
 @use "bootstrap/scss/bootstrap" with (
-  $primary: variables.$theme-primary
+  $primary: variables.$theme-primary,
+  // Overrides for Bootstrap's `$form-*` variables
+  $form-check-input-checked-color: variables.$dark-bg,
+  $form-check-input-checked-bg-color: variables.$button-primary,
+  $form-check-input-bg: variables.$dark-bg,
+  $form-check-input-border: 1px solid variables.$border-primary,
+  $form-feedback-invalid-color: variables.$text-error
 );
 @use "dashboard";
 @use "dashboard/places-page";

--- a/assets/css/screenplay.scss
+++ b/assets/css/screenplay.scss
@@ -1,10 +1,8 @@
 @use "variables";
 
-$theme-colors: (
-  "primary": variables.$theme-primary,
+@use "bootstrap/scss/bootstrap" with (
+  $primary: variables.$theme-primary
 );
-
-@use "bootstrap/scss/bootstrap";
 @use "dashboard";
 @use "dashboard/places-page";
 @use "dashboard/alerts-page";

--- a/assets/css/variables-screenplay-forms.scss
+++ b/assets/css/variables-screenplay-forms.scss
@@ -1,8 +1,0 @@
-@use "variables";
-
-// Overrides for Bootstrap `$form-*` variables
-$form-check-input-checked-color: #0f1417;
-$form-check-input-checked-bg-color: #8ecdff;
-$form-check-input-bg: #0f1417;
-$form-check-input-border: 1px solid #8b9198;
-$form-feedback-invalid-color: variables.$text-error;


### PR DESCRIPTION


**Asana task**: N/A

Description
In https://github.com/mbta/screenplay/commit/ad3b11bafdb35026bff08dccfb20f3aee29dc9ca, we moved from `@import` to `@use` statements for most
stylesheets. That change introduced a regression which led to certain
default bootstrap styles to be used instead of the custom primary theme
for screenplay. Migrating a single `@import` of Bootstrap to a `@use`
caused the theme map we define in `Screenplay.scss` to not be taken into
account when `bs-btn-*` styles are applied. As a result, the default
Bootstrap Blue was used in a handful of UI components.

This commit also includes a where the custom color of PA message
"active" toggle was not being properly applied. This was caused by the
previously global style not being applied to the toggle as a part of the
migration.

---
**Before - Action Buttons**
<img width="1477" height="318" alt="Screenshot 2026-06-05 at 10 14 02" src="https://github.com/user-attachments/assets/e1dff984-fa48-4483-899b-b850fe045fe2" />



**After - Action Buttons**

<img width="1549" height="318" alt="Screenshot 2026-06-04 at 14 51 23" src="https://github.com/user-attachments/assets/536fdbb4-e552-4b5b-828d-2ead3402a366" />

---

**Before - Active Toggle**
<img width="1477" height="260" alt="Screenshot 2026-06-05 at 10 14 31" src="https://github.com/user-attachments/assets/0cb215b4-bf06-420f-a53e-fb23038d7867" />



**After - Active Toggle**
<img width="1477" height="260" alt="Screenshot 2026-06-05 at 10 14 48" src="https://github.com/user-attachments/assets/f3d8e66a-52a1-477a-b64a-fc1f8e3a4c96" />
