### PR TITLE
chore: add github actions to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,14 @@
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: "monday"
+      time: "10:00"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
   - package-ecosystem: mix
     directory: "/"
     schedule:


### PR DESCRIPTION


**Asana task**: N/A

Description
Update dependabot configuration to update github actions, using cooldown and open PR limits to keep the configuration consistent with the rest of the repo's dependanbot settings

- [ ] For features with a design/UX component, deployed branch to dev-green and let product know it's ready for review.
