### PR TITLE
fix: ensure only pa-message-admin role can upload csv

### DIFF
--- a/assets/js/components/Dashboard/UploadPaMessages.tsx
+++ b/assets/js/components/Dashboard/UploadPaMessages.tsx
@@ -6,6 +6,7 @@ import { createNewPaMessage } from "Utils/api";
 import { useScreenplayState } from "Hooks/useScreenplayContext";
 import { signDirection } from "../../util";
 import Toast from "Components/Toast";
+import { isPaMessageAdmin } from "Utils/auth";
 
 const gameDates = [
   {
@@ -149,14 +150,18 @@ const UploadPaMessages = () => {
         ))}
       </select>
       <div className="mt-4">
-        <Button
-          disabled={!file || loading}
-          type="submit"
-          className="button-primary"
-          onClick={submit}
-        >
-          {loading ? "Loading..." : "Upload"}
-        </Button>
+        {!isPaMessageAdmin() ? (
+          <div>You do not have sufficient privileges to upload a file.</div>
+        ) : (
+          <Button
+            disabled={!file || loading}
+            type="submit"
+            className="button-primary"
+            onClick={submit}
+          >
+            {loading ? "Loading..." : "Upload"}
+          </Button>
+        )}
       </div>
       <Toast message={result} variant="info" onClose={() => setResult(null)} />
     </div>


### PR DESCRIPTION


**Asana task**: [Slack](https://mbta.slack.com/archives/C039ARUM48H/p1781105097538789)

Description

Update upload component to only show the button to upload a CSV when users have the pa-message-admin role. This should (correctly) fail on the backend already, this is a presentational change only

- [ ] For features with a design/UX component, deployed branch to dev-green and let product know it's ready for review.
