### PR TITLE
fix: filter pa messages with an ended alert

### DIFF
--- a/lib/screenplay/pa_messages.ex
+++ b/lib/screenplay/pa_messages.ex
@@ -57,14 +57,14 @@ defmodule Screenplay.PaMessages do
       |> Map.put_new_lazy(:now, &DateTime.utc_now/0)
       |> Map.put_new(:state, :all)
 
-    alert_ids = AlertsCache.alert_ids()
+    alerts = AlertsCache.alerts()
 
     signs_for_routes = RoutesToSigns.signs_for_routes(opts[:routes])
 
     now = opts[:now] || DateTime.utc_now()
 
     PaMessage
-    |> PaMessage.Queries.state(opts[:state], alert_ids, now)
+    |> PaMessage.Queries.state(opts[:state], alerts, now)
     |> PaMessage.Queries.signs(opts[:signs])
     |> PaMessage.Queries.signs(signs_for_routes)
     |> order_by(desc: :inserted_at)
@@ -88,7 +88,7 @@ defmodule Screenplay.PaMessages do
   @spec get_active_messages() :: [PaMessage.t()]
   @spec get_active_messages(now :: DateTime.t()) :: [PaMessage.t()]
   def get_active_messages(now \\ DateTime.utc_now()) do
-    AlertsCache.alert_ids()
+    AlertsCache.alerts()
     |> PaMessage.Queries.active(now)
     |> Repo.all()
   end

--- a/lib/screenplay/pa_messages/pa_message/queries.ex
+++ b/lib/screenplay/pa_messages/pa_message/queries.ex
@@ -7,13 +7,14 @@ defmodule Screenplay.PaMessages.PaMessage.Queries do
   """
   import Ecto.Query
 
+  alias Screenplay.Alerts.Alert
   alias Screenplay.PaMessages.PaMessage
   alias Screenplay.Util
 
-  def state(q \\ PaMessage, state, alert_ids, now)
-  def state(q, :current, alert_ids, now), do: current(q, alert_ids, now)
+  def state(q \\ PaMessage, state, alerts, now)
+  def state(q, :current, alerts, now), do: current(q, alerts, now)
   def state(q, :future, _alert_ids, now), do: future(q, now)
-  def state(q, :past, alert_ids, now), do: past(q, alert_ids, now)
+  def state(q, :past, alerts, now), do: past(q, alerts, now)
   def state(q, :all, _, _), do: q
 
   @doc """
@@ -24,14 +25,14 @@ defmodule Screenplay.PaMessages.PaMessage.Queries do
   """
   @spec active(
           queryable :: Ecto.Queryable.t(),
-          alert_ids :: [String.t()],
+          alerts :: [Alert.t()],
           now :: DateTime.t()
         ) ::
           Ecto.Query.t()
-  def active(q \\ PaMessage, alert_ids, now) do
+  def active(q \\ PaMessage, alerts, now) do
     service_day_of_week = now |> Util.service_date() |> Date.day_of_week()
 
-    current(q, alert_ids, now)
+    current(q, alerts, now)
     |> where([m], (is_nil(m.paused) or not m.paused) and ^service_day_of_week in m.days_of_week)
   end
 
@@ -42,20 +43,32 @@ defmodule Screenplay.PaMessages.PaMessage.Queries do
   either its end time is in the future or it has no end time and its associated
   alert is in passed list of alert IDs.
   """
-  @spec active(queryable :: Ecto.Queryable.t(), alert_ids :: [String.t()], now :: DateTime.t()) ::
+  @spec current(queryable :: Ecto.Queryable.t(), alerts :: [Alert.t()], now :: DateTime.t()) ::
           Ecto.Query.t()
-  def current(q \\ PaMessage, alert_ids, now) do
+  def current(q \\ PaMessage, alerts, now) do
+    alert_ids = alerts |> Enum.reject(&alert_will_fall_off?(&1, now)) |> Enum.map(& &1.id)
+
     from m in q,
       where:
         m.start_datetime <= ^now and
           ((is_nil(m.end_datetime) and m.alert_id in ^alert_ids) or m.end_datetime >= ^now)
   end
 
+  @spec alert_will_fall_off?(Alert.t(), DateTime.t()) :: boolean()
+  defp alert_will_fall_off?(%Alert{active_period: [{_, period_end}]}, now)
+       when period_end != nil do
+    DateTime.compare(period_end, now) in [:lt, :eq]
+  end
+
+  defp alert_will_fall_off?(_, _), do: false
+
   @doc """
   Limit the query to only PaMessages that have an end_datetime in the past or
   are associated with a past alert.
   """
-  def past(q \\ PaMessage, alert_ids, now) do
+  def past(q \\ PaMessage, alerts, now) do
+    alert_ids = Enum.map(alerts, & &1.id)
+
     from m in q,
       where: m.end_datetime < ^now or (is_nil(m.end_datetime) and m.alert_id not in ^alert_ids)
   end

--- a/test/screenplay_web/controllers/pa_messages_api_controller_test.exs
+++ b/test/screenplay_web/controllers/pa_messages_api_controller_test.exs
@@ -6,8 +6,14 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
 
   import Screenplay.Factory
 
+  @seeded_alert_end_datetime_utc ~U[2024-05-01T06:00:00Z]
+
   setup_all do
-    AlertsCacheHelpers.seed_alerts_cache(2, ~U[2024-05-01T04:00:00Z], ~U[2024-05-01T06:00:00Z])
+    AlertsCacheHelpers.seed_alerts_cache(
+      2,
+      ~U[2024-05-01T04:00:00Z],
+      @seeded_alert_end_datetime_utc
+    )
 
     start_supervised!(Screenplay.Places.Cache)
 
@@ -94,6 +100,40 @@ defmodule ScreenplayWeb.PaMessagesApiControllerTest do
       })
 
       assert [%{"id" => 2}] =
+               conn
+               |> get("/api/pa-messages?state=current&now=#{now}")
+               |> json_response(200)
+    end
+
+    @tag :authenticated
+    test "filters out PA messages associated with an ended alert", %{conn: conn} do
+      insert(:pa_message, %{
+        id: 1,
+        alert_id: "1",
+        days_of_week: [1, 2, 3, 4, 5, 6, 7],
+        start_datetime: ~U[2024-05-01 00:00:00Z],
+        end_datetime: nil
+      })
+
+      assert [] =
+               conn
+               |> get("/api/pa-messages?state=current&now=#{@seeded_alert_end_datetime_utc}")
+               |> json_response(200)
+    end
+
+    @tag :authenticated
+    test "does not filter PA messages associated with an ongoing alert", %{conn: conn} do
+      now = DateTime.add(@seeded_alert_end_datetime_utc, -10, :minute)
+
+      insert(:pa_message, %{
+        id: 1,
+        alert_id: "1",
+        days_of_week: [1, 2, 3, 4, 5, 6, 7],
+        start_datetime: ~U[2024-05-01 00:00:00Z],
+        end_datetime: nil
+      })
+
+      assert [%{"id" => 1}] =
                conn
                |> get("/api/pa-messages?state=current&now=#{now}")
                |> json_response(200)


### PR DESCRIPTION


**Asana task**: [Bug - Delay in closing Alert-associated PA Messages](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1215504297867591)

Description

Filter PA messages that are associated with an ended alert. Prior to this commit, a PA message associated with an ended alert would continue to be shown in the PA messages section of the application until the alert fell off the data feed. With this commit, the end date of the associated alert is picked up faster than the alert dropping off, allowing the PA message to be removed from the PA messages list before the ~five minute period has elapsed.

Note: When working on this fix, I found a related bug where ended alerts are not being removed from the "associate this new pa message with an alert" list. Fixed in https://github.com/mbta/screenplay/pull/766

- [ ] For features with a design/UX component, deployed branch to dev-green and let product know it's ready for review.
