### PR TITLE
 fix: hide stale alerts when associating with pa messages 

### DIFF
--- a/lib/screenplay/alerts/alert.ex
+++ b/lib/screenplay/alerts/alert.ex
@@ -169,4 +169,14 @@ defmodule Screenplay.Alerts.Alert do
   def access_alert?(alert) do
     Enum.any?(alert.informed_entities, &(not is_nil(&1.facility)))
   end
+
+  @spec will_fall_off?(t(), DateTime.t()) :: boolean()
+  def will_fall_off?(alert, now \\ DateTime.utc_now())
+
+  def will_fall_off?(%__MODULE__{active_period: [{_, period_end}]}, now)
+      when period_end != nil do
+    DateTime.compare(period_end, now) in [:lt, :eq]
+  end
+
+  def will_fall_off?(_, _), do: false
 end

--- a/lib/screenplay/pa_messages/pa_message/queries.ex
+++ b/lib/screenplay/pa_messages/pa_message/queries.ex
@@ -46,21 +46,13 @@ defmodule Screenplay.PaMessages.PaMessage.Queries do
   @spec current(queryable :: Ecto.Queryable.t(), alerts :: [Alert.t()], now :: DateTime.t()) ::
           Ecto.Query.t()
   def current(q \\ PaMessage, alerts, now) do
-    alert_ids = alerts |> Enum.reject(&alert_will_fall_off?(&1, now)) |> Enum.map(& &1.id)
+    alert_ids = alerts |> Enum.reject(&Alert.will_fall_off?(&1, now)) |> Enum.map(& &1.id)
 
     from m in q,
       where:
         m.start_datetime <= ^now and
           ((is_nil(m.end_datetime) and m.alert_id in ^alert_ids) or m.end_datetime >= ^now)
   end
-
-  @spec alert_will_fall_off?(Alert.t(), DateTime.t()) :: boolean()
-  defp alert_will_fall_off?(%Alert{active_period: [{_, period_end}]}, now)
-       when period_end != nil do
-    DateTime.compare(period_end, now) in [:lt, :eq]
-  end
-
-  defp alert_will_fall_off?(_, _), do: false
 
   @doc """
   Limit the query to only PaMessages that have an end_datetime in the past or

--- a/lib/screenplay_web/controllers/alerts_api_controller.ex
+++ b/lib/screenplay_web/controllers/alerts_api_controller.ex
@@ -36,7 +36,9 @@ defmodule ScreenplayWeb.AlertsApiController do
   def non_access_alerts(conn, _params) do
     non_access_alerts =
       AlertsCache.alerts()
-      |> Enum.reject(&Alert.access_alert?/1)
+      |> Enum.reject(fn alert ->
+        Alert.access_alert?(alert) || Alert.will_fall_off?(alert)
+      end)
       |> Enum.map(&Alert.to_full_map/1)
 
     json(conn, %{alerts: non_access_alerts})

--- a/test/screenplay_web/controllers/alerts_api_controller_test.exs
+++ b/test/screenplay_web/controllers/alerts_api_controller_test.exs
@@ -1,0 +1,25 @@
+defmodule ScreenplayWeb.AlertsApiControllerTest do
+  use ScreenplayWeb.ConnCase
+
+  alias Screenplay.AlertsCacheHelpers
+
+  setup do
+    AlertsCacheHelpers.seed_alerts_cache(
+      2,
+      ~U[2024-05-01T04:00:00Z],
+      ~U[2024-05-01T06:00:00Z]
+    )
+
+    :ok
+  end
+
+  describe "GET /api/alerts/non_access_alerts" do
+    @tag :authenticated
+    test "filters out alerts that ended", %{conn: conn} do
+      assert %{"alerts" => []} =
+               conn
+               |> get("/api/alerts/non_access_alerts")
+               |> json_response(200)
+    end
+  end
+end


### PR DESCRIPTION
**Asana task**: [Bug - Delay in closing Alert-associated PA Messages](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1215504297867591)

Prior to this commit, when associating a new PA message with an alert,
closed alerts were displayed. This commit updates the logic as to not
retrieve said alerts.

Depends On: https://github.com/mbta/screenplay/pull/765

Description

- [ ] For features with a design/UX component, deployed branch to dev-green and let product know it's ready for review.
