### PR TITLE
fix: hide stale alerts, close pa messages with assoc alerts

### DIFF
--- a/lib/screenplay/alerts/alert.ex
+++ b/lib/screenplay/alerts/alert.ex
@@ -165,6 +165,15 @@ defmodule Screenplay.Alerts.Alert do
     DateTime.compare(t, start_t) in [:gt, :eq] && DateTime.compare(t, end_t) in [:lt, :eq]
   end
 
+  @spec closed?(t(), DateTime.t()) :: boolean()
+  def closed?(alert, now \\ DateTime.utc_now())
+
+  def closed?(%__MODULE__{active_period: [{_, period_end}]}, now) when period_end != nil do
+    DateTime.compare(period_end, now) in [:lt, :eq]
+  end
+
+  def closed?(_, _), do: false
+
   @spec access_alert?(t()) :: boolean()
   def access_alert?(alert) do
     Enum.any?(alert.informed_entities, &(not is_nil(&1.facility)))

--- a/lib/screenplay/alerts/cache.ex
+++ b/lib/screenplay/alerts/cache.ex
@@ -12,6 +12,7 @@ defmodule Screenplay.Alerts.Cache do
 
   @default_opts [
     get_json_fn: &V3Api.get_json/2,
+    now_fn: &DateTime.utc_now/0,
     update_interval_ms: 4_000
   ]
 
@@ -54,18 +55,22 @@ defmodule Screenplay.Alerts.Cache do
     :ets.new(:alerts, [:protected, :named_table, read_concurrency: true])
 
     get_json_fn = Keyword.get(opts, :get_json_fn)
+    now_fn = Keyword.get(opts, :now_fn)
     update_interval_ms = Keyword.get(opts, :update_interval_ms)
 
     schedule_fetch(update_interval_ms)
 
-    {:ok, {get_json_fn, update_interval_ms}}
+    {:ok, {get_json_fn, now_fn, update_interval_ms}}
   end
 
   @impl true
-  def handle_info(:fetch, state = {get_json_fn, update_interval_ms}) do
+  def handle_info(:fetch, state = {get_json_fn, now_fn, update_interval_ms}) do
     case Alert.fetch(get_json_fn) do
       {:ok, alerts} ->
-        alerts_to_insert = Enum.map(alerts, fn alert -> {alert.id, alert} end)
+        alerts_to_insert =
+          alerts
+          |> Enum.reject(&Alert.closed?(&1, now_fn.()))
+          |> Enum.map(fn alert -> {alert.id, alert} end)
 
         :ets.delete_all_objects(:alerts)
         :ets.insert(:alerts, alerts_to_insert)

--- a/test/screenplay/alerts/alert_test.exs
+++ b/test/screenplay/alerts/alert_test.exs
@@ -220,4 +220,62 @@ defmodule Screenplay.Alerts.AlertTest do
       end
     end
   end
+
+  describe "closed?/2" do
+    test "returns false when there are no active periods" do
+      refute Alert.closed?(%Alert{active_period: []})
+    end
+
+    test "returns false when end of active period is nil" do
+      refute Alert.closed?(%Alert{active_period: [{~U[2026-06-01T01:00:00Z], nil}]})
+    end
+
+    test "returns false when there are multiple active periods" do
+      refute Alert.closed?(%Alert{
+               active_period: [
+                 {~U[2026-06-01T01:00:00Z], ~U[2026-06-01T02:00:00Z]},
+                 {~U[2026-06-02T01:00:00Z], ~U[2026-06-02T02:00:00Z]}
+               ]
+             })
+    end
+
+    test "returns false when the end time is later than the current time" do
+      now = ~U[2026-06-01T02:00:00Z]
+
+      refute Alert.closed?(
+               %Alert{
+                 active_period: [
+                   {~U[2026-06-01T01:00:00Z], DateTime.add(now, 1, :minute)}
+                 ]
+               },
+               now
+             )
+    end
+
+    test "returns true when the end time is equal to the current time" do
+      now = ~U[2026-06-01T02:00:00Z]
+
+      assert Alert.closed?(
+               %Alert{
+                 active_period: [
+                   {~U[2026-06-01T01:00:00Z], now}
+                 ]
+               },
+               now
+             )
+    end
+
+    test "returns true when the end time is before than the current time" do
+      now = ~U[2026-06-01T02:00:00Z]
+
+      assert Alert.closed?(
+               %Alert{
+                 active_period: [
+                   {~U[2026-06-01T01:00:00Z], DateTime.add(now, -1, :minute)}
+                 ]
+               },
+               now
+             )
+    end
+  end
 end

--- a/test/screenplay/alerts/cache_test.exs
+++ b/test/screenplay/alerts/cache_test.exs
@@ -13,6 +13,36 @@ defmodule Screenplay.Alerts.CacheTest do
     assert %Alert{id: "1"} = Cache.alert("1")
   end
 
+  test "alerts that have ended are not added to the store" do
+    now = ~U[2026-06-01T01:00:00Z]
+
+    AlertsCacheHelpers.seed_alerts_cache(
+      1,
+      DateTime.add(now, -10, :minute),
+      DateTime.add(now, -5, :minute),
+      fn -> now end
+    )
+
+    _ = await_updated()
+
+    assert [] = Cache.alerts()
+  end
+
+  test "alerts that have just ended are not added to the store" do
+    now = ~U[2026-06-01T01:00:00Z]
+
+    AlertsCacheHelpers.seed_alerts_cache(
+      1,
+      DateTime.add(now, -10, :minute),
+      now,
+      fn -> now end
+    )
+
+    _ = await_updated()
+
+    assert [] = Cache.alerts()
+  end
+
   test "It handles a failed API response and does not update the store" do
     get_json_fn = fn "/alerts", %{"include" => "routes"} ->
       :error

--- a/test/support/alerts_cache_helpers.ex
+++ b/test/support/alerts_cache_helpers.ex
@@ -7,7 +7,12 @@ defmodule Screenplay.AlertsCacheHelpers do
 
   alias Screenplay.Alerts.Cache, as: AlertsCache
 
-  def seed_alerts_cache(num_alerts, start_dt, end_dt) do
+  def seed_alerts_cache(num_alerts, start_dt, end_dt, now_fn \\ nil) do
+    # Alerts whose end time occurs before "now" will be filtered out by
+    # the `AlertsCache`. Have `now_fn` default to just before the end
+    # time of the new Alert to prevent filtering by default in tests
+    now_fn = now_fn || fn -> DateTime.add(end_dt, -5, :minute) end
+
     get_json_fn = fn "/alerts", %{"include" => "routes"} ->
       {:ok,
        %{
@@ -24,7 +29,7 @@ defmodule Screenplay.AlertsCacheHelpers do
        }}
     end
 
-    {:ok, fetcher} = start_supervised({AlertsCache, get_json_fn: get_json_fn})
+    {:ok, fetcher} = start_supervised({AlertsCache, get_json_fn: get_json_fn, now_fn: now_fn})
     send(fetcher, :fetch)
   end
 

--- a/test/support/alerts_cache_helpers.ex
+++ b/test/support/alerts_cache_helpers.ex
@@ -11,7 +11,7 @@ defmodule Screenplay.AlertsCacheHelpers do
     # Alerts whose end time occurs before "now" will be filtered out by
     # the `AlertsCache`. Have `now_fn` default to just before the end
     # time of the new Alert to prevent filtering by default in tests
-    now_fn = now_fn || fn -> DateTime.add(end_dt, -5, :minute) end
+    now_fn = now_fn || fn -> DateTime.add(end_dt, -1, :minute) end
 
     get_json_fn = fn "/alerts", %{"include" => "routes"} ->
       {:ok,


### PR DESCRIPTION


**Asana task**: [Bug - Delay in closing Alert-associated PA Messages](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1215504297867591)

Description

Prior to this commit, when associating a new PA message with an alert, closed alerts were displayed. Filtering alerts at retrieval time based on whether they are closed or not keeps closed alerts out of the cache. By preventing said alerts from entering the cache:

1. Alerts that are closed will not be shown when associating a new PA message with an alert
2. Exising PA messages associated with an alert whose alert has been closed will be removed from the PA Messages list without having to wait for the alert to "fall off" the data feed.

This change does not alter the Alert fetching logic. A consequence of that is changes to Alerts will not instantly be refelcted in Screenplay. Rather, we are (still) reliant on fetching Alerts from the V3 API to get the latest alert information.

Replaces: #765, #766 

- [ ] For features with a design/UX component, deployed branch to dev-green and let product know it's ready for review.
