### PR TITLE
chore(ci): replace mbta/actions/reshim-asdf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   asdf:
     name: ASDF
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v7.0.0
       # cache the ASDF directory, using the values from .tool-versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
   asdf:
     name: ASDF
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v7.0.0
       # cache the ASDF directory, using the values from .tool-versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,7 @@ jobs:
   asdf:
     name: ASDF
     runs-on: ubuntu-latest
-    outputs:
-      asdf_dir: ${{ steps.asdf_env_setup.outputs.ASDF_DIR }}
-      asdf_data_dir: ${{ steps.asdf_env_setup.outputs.ASDF_DATA_DIR }}
+
     steps:
       - uses: actions/checkout@v7.0.0
       # cache the ASDF directory, using the values from .tool-versions
@@ -25,12 +23,6 @@ jobs:
       # only run `asdf install` if we didn't hit the cache
       - uses: asdf-vm/actions/install@v4
         if: steps.asdf-cache.outputs.cache-hit != 'true'
-      # if we did hit the cache, set up the environment
-      - name: Setup ASDF environment
-        uses: asdf-vm/actions/setup@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
-        with:
-          skip_install: true
-        if: steps.asdf-cache.outputs.cache-hit == 'true'
 
   build:
     name: Build and test
@@ -59,16 +51,15 @@ jobs:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
         id: asdf-cache
-      - name: Reshim ASDF
-        run: |
-          echo "$ASDF_DIR/bin" >> $GITHUB_PATH
-          echo "$ASDF_DIR/shims" >> $GITHUB_PATH
-          $ASDF_DIR/bin/asdf reshim
-        env:
-          ASDF_DIR: ${{ needs.asdf.outputs.asdf_dir }}
-          ASDF_DATA_DIR: ${{ needs.asdf.outputs.asdf_data_dir }}
-      - run: exit 1
+      - name: Exit if ASDF cache isn't setup
+        run: exit 1
         if: steps.asdf-cache.outputs.cache-hit != 'true'
+      - name: Setup ASDF environment
+        uses: asdf-vm/actions/setup@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
+        with:
+          skip_install: true
+      - name: Reshim ASDF
+        run: asdf reshim
       - name: Restore dependencies cache
         id: deps-cache
         uses: actions/cache@v6.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,9 @@ jobs:
   asdf:
     name: ASDF
     runs-on: ubuntu-latest
-
+    outputs:
+      asdf_dir: ${{ steps.asdf_env_setup.outputs.ASDF_DIR }}
+      asdf_data_dir: ${{ steps.asdf_env_setup.outputs.ASDF_DATA_DIR }}
     steps:
       - uses: actions/checkout@v7.0.0
       # cache the ASDF directory, using the values from .tool-versions
@@ -23,6 +25,13 @@ jobs:
       # only run `asdf install` if we didn't hit the cache
       - uses: asdf-vm/actions/install@v4
         if: steps.asdf-cache.outputs.cache-hit != 'true'
+      # if we did hit the cache, set up the environment
+      - name: Setup ASDF environment
+        id: asdf_env_setup
+        run: |
+          echo "ASDF_DIR=$HOME/.asdf" >> "$GITHUB_OUTPUT"
+          echo "ASDF_DATA_DIR=$HOME/.asdf" >> "$GITHUB_OUTPUT"
+        if: steps.asdf-cache.outputs.cache-hit == 'true'
 
   build:
     name: Build and test
@@ -51,8 +60,14 @@ jobs:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
         id: asdf-cache
-      - uses: mbta/actions/reshim-asdf@v2
-      # The asdf job should have prepared the cache. exit if it didn't for some reason
+      - name: Reshim ASDF
+        run: |
+          echo "$ASDF_DIR/bin" >> $GITHUB_PATH
+          echo "$ASDF_DIR/shims" >> $GITHUB_PATH
+          $ASDF_DIR/bin/asdf reshim
+        env:
+          ASDF_DIR: ${{ needs.asdf.outputs.asdf_dir }}
+          ASDF_DATA_DIR: ${{ needs.asdf.outputs.asdf_data_dir }}
       - run: exit 1
         if: steps.asdf-cache.outputs.cache-hit != 'true'
       - name: Restore dependencies cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,9 @@ jobs:
         if: steps.asdf-cache.outputs.cache-hit != 'true'
       # if we did hit the cache, set up the environment
       - name: Setup ASDF environment
-        id: asdf_env_setup
-        run: |
-          echo "ASDF_DIR=$HOME/.asdf" >> "$GITHUB_OUTPUT"
-          echo "ASDF_DATA_DIR=$HOME/.asdf" >> "$GITHUB_OUTPUT"
+        uses: asdf-vm/actions/setup@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
+        with:
+          skip_install: true
         if: steps.asdf-cache.outputs.cache-hit == 'true'
 
   build:


### PR DESCRIPTION


**Asana task**: N/A

Description
Replace `mbta/actions/reshim-asdf` with bash equivalent commands. In
the v2.20 release, commit https://github.com/mbta/actions/commit/3579cb7ca08e2f13da2b49aee882d0d219d553f6
marked the reshim-asdf action as deprecated. A recent Dependabot update
attempted to bump this action's version to v2.21 - while the update
would succeed otherwise, replace the action now while it's on top of
mind.

(Note: Since we're using tags instead of SHAs for this action, we're technically already using v2.**20** (v2 still points at one minor behind as of this writing) in its deprecated state)


The existing job structure of the CI workflow has been maintained as-is.
In the future, there is room to refactor this to either a composite
action or series of parallel steps, which would eliminate the need to
pass the `ASDF_DIR` and `ASDF_DATA_DIR` values between jobs. However,
since this is an unplanned task created to avoid a deprecated Action,
leave that for another day.

`asdf-vm/actions/setup` was not used here. While the action can achieve
the same effect as the new `asdf_env_setup` step, it did not seem worth
it to have to manage an additional dependency for setting up something
on our `PATH`. In the future, when Dependabot PRs are grouped and/or the
CI workflow is refactored, this can certainly be re-explored (i.e. this
is a judgment call more than anything).



- [ ] For features with a design/UX component, deployed branch to dev-green and let product know it's ready for review.
