### PR TITLE
start endpoint process last

### DIFF
--- a/lib/screenplay/application.ex
+++ b/lib/screenplay/application.ex
@@ -16,15 +16,14 @@ defmodule Screenplay.Application do
         ScreenplayWeb.Telemetry,
         # Start the PubSub system
         {Phoenix.PubSub, name: Screenplay.PubSub},
-        # Start the Endpoint (http/https)
-        ScreenplayWeb.Endpoint,
         Screenplay.ScreensConfig
       ] ++
         if Application.get_env(:screenplay, :start_cache_processes) do
           [Screenplay.Alerts.Cache, Screenplay.Places, Screenplay.PredictionSuppression]
         else
           []
-        end
+        end ++
+        [ScreenplayWeb.Endpoint]
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options


### PR DESCRIPTION
**Asana task**: [Screenplay: Fix process ordering to reduce errors on shutdown](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1211731814923660?focus=true)

This makes the endpoint process the last one to launch, and the first one to shut down. This should avoid ETS or GenServer errors on shutdown due to the controllers trying to call various supporting processes after they've been terminated.