### PR TITLE
chore: group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 5
+    groups:
+      all-updates:
+        patterns:
+          - "*"
   - package-ecosystem: mix
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,10 @@ updates:
       default-days: 7
     open-pull-requests-limit: 5
     groups:
-      all-updates:
-        patterns:
-          - "*"
+      github-actions-minor:
+        update-types:
+          - "patch"
+          - "minor"
   - package-ecosystem: mix
     directory: "/"
     schedule:


### PR DESCRIPTION


**Asana task**: N/A

Description

In 8c6bfdac, Dependabot was configured to update GitHub Actions. In the 2026.07.07 retro, we commented that the number of individual PRs was getting high. This commit attempts to cut down on the noise by grouping updates of all actions across all semver version types.

- [ ] For features with a design/UX component, deployed branch to dev-green and let product know it's ready for review.
