### PR TITLE
add line filtering for alert places

### DIFF
--- a/assets/js/components/Dashboard/AlertDetails.tsx
+++ b/assets/js/components/Dashboard/AlertDetails.tsx
@@ -28,7 +28,7 @@ const AlertDetails: ComponentType = () => {
 
   const navigate = useNavigate();
 
-  const foundAlert = alerts.find((alert) => alert.id === id);
+  const foundAlert = (alerts ?? []).find((alert) => alert.id === id);
   useEffect(() => {
     if (foundAlert) {
       setSelectedAlert(foundAlert);
@@ -37,9 +37,17 @@ const AlertDetails: ComponentType = () => {
 
   const validAlertId = id && allAPIAlertIds.includes(id) ? id : undefined;
 
+  if (!alerts || !places) {
+    return null;
+  }
+  const alertPlaces = placesWithSelectedAlert(
+    selectedAlert,
+    places,
+    screensByAlertMap,
+  );
   return selectedAlert ? (
     // Define a new ContextProvider so state is not saved to Context used on the PlacesPage.
-    <PlacesListStateContainer>
+    <PlacesListStateContainer places={alertPlaces}>
       <div className="alert-details">
         <div className="page-content__header">
           <div>
@@ -69,14 +77,10 @@ const AlertDetails: ComponentType = () => {
           <div className="page-content__body">
             <AlertCard alert={selectedAlert} classNames="selected-alert" />
             <PlacesList
-              places={placesWithSelectedAlert(
-                selectedAlert,
-                places,
-                screensByAlertMap,
-              )}
-              noModeFilter
+              places={alertPlaces}
               isAlertPlacesList
               showAnimationForNewPlaces
+              showLineMap={false}
             />
           </div>
         )}

--- a/assets/js/components/Dashboard/AlertsPage.tsx
+++ b/assets/js/components/Dashboard/AlertsPage.tsx
@@ -26,6 +26,10 @@ import moment from "moment-timezone";
 const AlertsPage: ComponentType = () => {
   const { places, alerts, screensByAlertMap } = useScreenplayState();
 
+  if (!places || !alerts) {
+    return null;
+  }
+
   const alertsWithPlaces = alerts.filter(
     (alert) => screensByAlertMap[alert.id],
   );

--- a/assets/js/components/Dashboard/Dashboard.tsx
+++ b/assets/js/components/Dashboard/Dashboard.tsx
@@ -114,7 +114,7 @@ const Dashboard: ComponentType = () => {
         alerts: newAlerts,
         screens_by_alert: screensByAlertMap,
       } = alertsData;
-      findAndSetBannerAlert(alerts, newAlerts);
+      findAndSetBannerAlert(alerts ?? [], newAlerts);
       setAlerts(newAlerts, allAPIalertIds, screensByAlertMap);
     }
   };

--- a/assets/js/components/Dashboard/PlacesPage.tsx
+++ b/assets/js/components/Dashboard/PlacesPage.tsx
@@ -18,6 +18,7 @@ import {
 import { DirectionID } from "Models/direction_id";
 import { usePrevious } from "Hooks/usePrevious";
 import { sortByStationOrder } from "../../util";
+import fp from "lodash/fp";
 
 const getSortLabel = (
   modeLineFilterValue: { label: string },
@@ -36,6 +37,9 @@ const getSortLabel = (
 const PlacesPage: ComponentType = () => {
   const { places } = useScreenplayState();
 
+  if (!places) {
+    return null;
+  }
   return (
     <div className="places-page">
       <div className="page-content__header">Places</div>
@@ -48,16 +52,16 @@ const PlacesPage: ComponentType = () => {
 
 interface PlacesListProps {
   places: Place[];
-  noModeFilter?: boolean;
   isAlertPlacesList?: boolean;
   showAnimationForNewPlaces?: boolean;
+  showLineMap?: boolean;
 }
 
 const PlacesList: ComponentType<PlacesListProps> = ({
   places,
-  noModeFilter,
   isAlertPlacesList,
   showAnimationForNewPlaces,
+  showLineMap = true,
 }: PlacesListProps) => {
   // ascending/southbound/westbound = 0, descending/northbound/eastbound = 1
   const {
@@ -175,6 +179,11 @@ const PlacesList: ComponentType<PlacesListProps> = ({
     statusFilterValue !== STATUSES[0] ||
     screenTypeFilterValue !== SCREEN_TYPES[0];
 
+  const allPlaceRoutes = fp.uniq(places.flatMap(({ routes }) => routes));
+  const modeOptions = MODES_AND_LINES.filter(({ ids }) => {
+    return ids[0] === "All" || fp.intersection(ids, allPlaceRoutes).length > 0;
+  });
+
   return (
     <>
       <Container fluid>
@@ -187,14 +196,12 @@ const PlacesList: ComponentType<PlacesListProps> = ({
             />
           </Col>
           <Col lg={3} className="d-flex justify-content-end pe-3">
-            {!noModeFilter && (
-              <FilterDropdown
-                list={MODES_AND_LINES}
-                onSelect={(value: any) => handleSelectModeOrLine(value)}
-                selectedValue={modeLineFilterValue}
-                className="modes-and-lines"
-              />
-            )}
+            <FilterDropdown
+              list={modeOptions}
+              onSelect={(value: any) => handleSelectModeOrLine(value)}
+              selectedValue={modeLineFilterValue}
+              className="modes-and-lines"
+            />
           </Col>
           <Col lg={3} className="place-screen-types pe-3">
             <FilterDropdown
@@ -245,7 +252,9 @@ const PlacesList: ComponentType<PlacesListProps> = ({
               }
               activeEventKeys={activeEventKeys}
               sortDirection={sortDirection}
-              filteredLine={isOnlyFilteredByRoute ? getFilteredLine() : null}
+              filteredLine={
+                showLineMap && isOnlyFilteredByRoute ? getFilteredLine() : null
+              }
               className={isFiltered || isAlertPlacesList ? "filtered" : ""}
             />
           );

--- a/assets/js/hooks/usePlacesWithPaEss.ts
+++ b/assets/js/hooks/usePlacesWithPaEss.ts
@@ -6,7 +6,7 @@ export const usePlacesWithPaEss = () => {
   const { places } = useScreenplayState();
   return useMemo(
     () =>
-      places
+      (places ?? [])
         .map((place) => ({
           ...place,
           screens: place.screens.filter((screen) => screen.type === "pa_ess"),

--- a/assets/js/hooks/useScreenplayContext.tsx
+++ b/assets/js/hooks/useScreenplayContext.tsx
@@ -16,6 +16,7 @@ import { BannerAlert } from "../components/Dashboard/AlertBanner";
 import { ActionOutcomeToastProps } from "../components/Dashboard/ActionOutcomeToast";
 import useSWR, { KeyedMutator } from "swr";
 import { getSuppressedPredictions } from "Utils/api";
+import fp from "lodash/fp";
 
 interface Props {
   children: React.ReactNode;
@@ -28,9 +29,9 @@ interface FilterValue {
 }
 
 interface ScreenplayState {
-  places: Place[];
+  places?: Place[];
   lineStops: LineStop[];
-  alerts: Alert[];
+  alerts?: Alert[];
   allAPIAlertIds: string[];
   screensByAlertMap: ScreensByAlert;
   bannerAlert?: BannerAlert;
@@ -55,9 +56,9 @@ const [useScreenplayState, ScreenplayStateProvider] =
   createGenericContext<ScreenplayState>();
 
 const ScreenplayStateContainer = ({ children }: Props) => {
-  const [places, setPlaces] = useState<Place[]>([]);
+  const [places, setPlaces] = useState<Place[]>();
   const [lineStops, setLineStops] = useState<LineStop[]>([]);
-  const [alerts, setAlerts] = useState<Alert[]>([]);
+  const [alerts, setAlerts] = useState<Alert[]>();
   const [allAPIAlertIds, setAllAPIAlertIds] = useState<string[]>([]);
   const [screensByAlertMap, setScreensByAlertMap] = useState<ScreensByAlert>(
     {},
@@ -156,10 +157,30 @@ interface PlacesListState {
 const [usePlacesListState, PlacesListStateProvider] =
   createGenericContext<PlacesListState>();
 
-const PlacesListStateContainer = ({ children }: Props) => {
+interface PlacesListStateContainerProps {
+  children: React.ReactNode;
+  places?: Place[];
+}
+
+const PlacesListStateContainer = ({
+  children,
+  places,
+}: PlacesListStateContainerProps) => {
   const [sortDirection, setSortDirection] = useState<DirectionID>(0);
   const [modeLineFilterValue, setModeLineFilterValue] = useState<FilterValue>(
-    PLACES_PAGE_MODES_AND_LINES[0],
+    () => {
+      return places
+        ? fp
+            .reverse(PLACES_PAGE_MODES_AND_LINES)
+            .find(
+              ({ ids }) =>
+                ids[0] === "All" ||
+                places.every(
+                  (place) => fp.intersection(ids, place.routes).length > 0,
+                ),
+            )!
+        : PLACES_PAGE_MODES_AND_LINES[0];
+    },
   );
   const [screenTypeFilterValue, setScreenTypeFilterValue] =
     useState<FilterValue>(SCREEN_TYPES[0]);

--- a/assets/js/hooks/useScreenplayContext.tsx
+++ b/assets/js/hooks/useScreenplayContext.tsx
@@ -169,7 +169,7 @@ const PlacesListStateContainer = ({
   const [sortDirection, setSortDirection] = useState<DirectionID>(0);
   const [modeLineFilterValue, setModeLineFilterValue] = useState<FilterValue>(
     () => {
-      return places
+      return places && places.length > 0
         ? fp
             .reverse(PLACES_PAGE_MODES_AND_LINES)
             .find(

--- a/assets/js/util.ts
+++ b/assets/js/util.ts
@@ -122,7 +122,7 @@ export const formatEffect = (effect: string) => {
 // Filters out screens that don't have the alert, then filters out places with empty
 // screens array
 export const placesWithSelectedAlert = (
-  alert: Alert | null,
+  alert: Alert | undefined,
   places: Place[],
   screensByAlertMap: ScreensByAlert,
 ) => {

--- a/assets/tests/components/alertsPage.test.tsx
+++ b/assets/tests/components/alertsPage.test.tsx
@@ -5,9 +5,12 @@ import { renderWithScreenplayProvider } from "../utils/renderWithScreenplayProvi
 
 describe("Alerts Page", () => {
   describe("filtering", () => {
-    test("filters places by mode and route", async () => {
+    beforeEach(async () => {
       renderWithScreenplayProvider(<AlertsPage />);
+      await screen.findAllByRole("button", { name: "All MODES" });
+    });
 
+    test("filters places by mode and route", async () => {
       expect(await screen.findByTestId("1")).toBeInTheDocument();
       // Verify alerts not present on a screen are not visible
       expect(screen.queryByTestId("5")).toBeNull();
@@ -33,8 +36,6 @@ describe("Alerts Page", () => {
     });
 
     test("filters places by screen type", async () => {
-      renderWithScreenplayProvider(<AlertsPage />);
-
       fireEvent.click(screen.getByRole("button", { name: "All SCREEN TYPES" }));
       fireEvent.click(
         await screen.findByRole("button", { name: "Bus Shelter" }),

--- a/assets/tests/components/placesPage.test.tsx
+++ b/assets/tests/components/placesPage.test.tsx
@@ -5,9 +5,12 @@ import { renderWithScreenplayProvider } from "../utils/renderWithScreenplayProvi
 
 describe("PlacesPage", () => {
   describe("filtering", () => {
-    test("filters places by screen type", async () => {
+    beforeEach(async () => {
       renderWithScreenplayProvider(<PlacesPage />);
+      await screen.findAllByRole("button", { name: "All MODES" });
+    });
 
+    test("filters places by screen type", async () => {
       fireEvent.click(screen.getByRole("button", { name: "All SCREEN TYPES" }));
       fireEvent.click(await screen.findByRole("button", { name: "DUP" }));
       expect(await screen.findByText("Davis")).toBeInTheDocument();
@@ -36,8 +39,6 @@ describe("PlacesPage", () => {
     });
 
     test("filters places by mode and route", async () => {
-      renderWithScreenplayProvider(<PlacesPage />);
-
       fireEvent.click(screen.getByRole("button", { name: "All MODES" }));
       fireEvent.click(await screen.findByRole("button", { name: "Blue Line" }));
       expect(await screen.findByText("WONDERLAND")).toBeInTheDocument();
@@ -64,8 +65,6 @@ describe("PlacesPage", () => {
     });
 
     test("adds `filtered` class to PlaceRow when filtered", async () => {
-      renderWithScreenplayProvider(<PlacesPage />);
-
       fireEvent.click(screen.getByRole("button", { name: "All MODES" }));
       fireEvent.click(await screen.findByRole("button", { name: "Blue Line" }));
       expect(
@@ -74,8 +73,6 @@ describe("PlacesPage", () => {
     });
 
     test("reset button clears filters", async () => {
-      renderWithScreenplayProvider(<PlacesPage />);
-
       fireEvent.click(screen.getByRole("button", { name: "All MODES" }));
       fireEvent.click(await screen.findByRole("button", { name: "Blue Line" }));
       fireEvent.click(
@@ -86,9 +83,12 @@ describe("PlacesPage", () => {
   });
 
   describe("sorting", () => {
-    test("sort label changes depending on filter selected", async () => {
+    beforeEach(async () => {
       renderWithScreenplayProvider(<PlacesPage />);
+      await screen.findAllByRole("button", { name: "All MODES" });
+    });
 
+    test("sort label changes depending on filter selected", async () => {
       expect(screen.getByTestId("sort-label").textContent?.trim()).toBe("ABC");
       fireEvent.click(screen.getByRole("button", { name: "All MODES" }));
       fireEvent.click(await screen.findByRole("button", { name: "Blue Line" }));
@@ -110,8 +110,6 @@ describe("PlacesPage", () => {
     });
 
     test("sort label changes when clicked", async () => {
-      renderWithScreenplayProvider(<PlacesPage />);
-
       expect(screen.getByTestId("sort-label").textContent?.trim()).toBe("ABC");
       fireEvent.click(screen.getByTestId("sort-label"));
       expect(
@@ -140,8 +138,6 @@ describe("PlacesPage", () => {
     });
 
     test("sort order changes for RL", async () => {
-      renderWithScreenplayProvider(<PlacesPage />);
-
       fireEvent.click(screen.getByRole("button", { name: "All MODES" }));
       fireEvent.click(await screen.findByRole("button", { name: "Red Line" }));
       expect(
@@ -159,8 +155,6 @@ describe("PlacesPage", () => {
     });
 
     test("sort order changes for OL", async () => {
-      renderWithScreenplayProvider(<PlacesPage />);
-
       fireEvent.click(screen.getByRole("button", { name: "All MODES" }));
       fireEvent.click(screen.getByRole("button", { name: "Orange Line" }));
       expect(
@@ -190,8 +184,6 @@ describe("PlacesPage", () => {
     });
 
     test("sort order changes for GL", async () => {
-      renderWithScreenplayProvider(<PlacesPage />);
-
       fireEvent.click(screen.getByRole("button", { name: "All MODES" }));
       fireEvent.click(screen.getByRole("button", { name: "Green Line" }));
 
@@ -240,8 +232,6 @@ describe("PlacesPage", () => {
     });
 
     test("sort order changes for BL", async () => {
-      renderWithScreenplayProvider(<PlacesPage />);
-
       fireEvent.click(screen.getByRole("button", { name: "All MODES" }));
       fireEvent.click(screen.getByRole("button", { name: "Blue Line" }));
 


### PR DESCRIPTION
**Asana task**: [Screenplay: Sort/filter stations in Posted Alerts](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1215387822203482?focus=true)

This adds the line/mode filter to the places list on the alert detail page. The filter defaults to a certain line if all places are on the same line, and uses the corresponding station sort order. Otherwise, it defaults to All, and uses alphabetical sorting. In either case, the filter can be changed to see a subset of the impacted places.

Note that several pages now wait until the places and alerts are loaded before displaying their content, which is necessary to properly initialize the defaults, and has the side effect of removing some flashes of empty content, e.g. the erroneous "not found" message on the alert details page.