### PR TITLE
fix: add text validation to pa/ess text messages

### DIFF
--- a/assets/js/components/Dashboard/PaMessageForm/MainForm.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/MainForm.tsx
@@ -25,6 +25,7 @@ import * as paMessageStyles from "Styles/pa-messages.module.scss";
 import type { StaticTemplate, TemplateType } from "Models/static_template";
 
 const MAX_TEXT_LENGTH = 2000;
+const INVALID_VISUAL_TEXT_CHARACTERS = /[^a-zA-Z0-9,\/!@':\s\-.]/g;
 
 interface Props {
   title: string;
@@ -157,6 +158,12 @@ const MainForm = ({
   const popoverText = "The service day starts and ends at 4:00 AM";
 
   const isEndTimeInvalid = validated && !moment(endTime, "HH:mm").isValid();
+
+  const invalidVisualTextInputs = new Set(
+    [...visualText.matchAll(INVALID_VISUAL_TEXT_CHARACTERS)].map(
+      (match) => match[0],
+    ),
+  );
 
   return (
     <div className={paMessageStyles.editPage}>
@@ -403,6 +410,15 @@ const MainForm = ({
                   validationText={"Text cannot be blank"}
                   validated={validated}
                 />
+                {validated && invalidVisualTextInputs.size > 0 && (
+                  <div className="validation-error">
+                    The following characters are not permitted and must be
+                    replaced:{" "}
+                    {Array.from(invalidVisualTextInputs)
+                      .map((char) => `'${char}'`)
+                      .join(", ")}
+                  </div>
+                )}
               </div>
               <div className={paMessageStyles.copyButtonCol}>
                 <Button

--- a/assets/js/components/Dashboard/PaMessageForm/MainForm.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/MainForm.tsx
@@ -26,7 +26,7 @@ import type { StaticTemplate, TemplateType } from "Models/static_template";
 
 const MAX_TEXT_LENGTH = 2000;
 // A negated set regex used to limit the visual text sent to signs.
-const INVALID_VISUAL_TEXT_CHARACTERS = /[^a-zA-Z0-9,\/!@':\s\-.]/g;
+const INVALID_VISUAL_TEXT_CHARACTERS = /[^a-zA-Z0-9,/!@':\s\-.]/g;
 
 interface Props {
   title: string;

--- a/assets/js/components/Dashboard/PaMessageForm/MainForm.tsx
+++ b/assets/js/components/Dashboard/PaMessageForm/MainForm.tsx
@@ -25,6 +25,7 @@ import * as paMessageStyles from "Styles/pa-messages.module.scss";
 import type { StaticTemplate, TemplateType } from "Models/static_template";
 
 const MAX_TEXT_LENGTH = 2000;
+// A negated set regex used to limit the visual text sent to signs.
 const INVALID_VISUAL_TEXT_CHARACTERS = /[^a-zA-Z0-9,\/!@':\s\-.]/g;
 
 interface Props {
@@ -67,6 +68,14 @@ interface Props {
   onClearSelectedTemplate: () => void;
   isReadOnly?: boolean;
 }
+
+export const getInvalidVisualText = (visualText: string): Set<string> => {
+  return new Set(
+    [...visualText.matchAll(INVALID_VISUAL_TEXT_CHARACTERS)].map(
+      (match) => match[0],
+    ),
+  );
+};
 
 const MainForm = ({
   title,
@@ -158,12 +167,7 @@ const MainForm = ({
   const popoverText = "The service day starts and ends at 4:00 AM";
 
   const isEndTimeInvalid = validated && !moment(endTime, "HH:mm").isValid();
-
-  const invalidVisualTextInputs = new Set(
-    [...visualText.matchAll(INVALID_VISUAL_TEXT_CHARACTERS)].map(
-      (match) => match[0],
-    ),
-  );
+  const invalidVisualTextInputs = getInvalidVisualText(visualText);
 
   return (
     <div className={paMessageStyles.editPage}>

--- a/assets/tests/components/Dashboard/PaMessageForm/MainForm.test.tsx
+++ b/assets/tests/components/Dashboard/PaMessageForm/MainForm.test.tsx
@@ -1,0 +1,14 @@
+import { getInvalidVisualText } from "Components/PaMessageForm/MainForm";
+
+describe("MainForm", () => {
+  describe("getInvalidVisualText()", () => {
+    test.each([
+      { input: "hyphen - endash – emdash —", expected: new Set("–—") },
+      { input: "See the train coming?", expected: new Set("?") },
+      { input: "Green Line[D] service suspended", expected: new Set("[]") },
+      { input: "Service will result in ~15 minutes", expected: new Set("~") },
+    ])("detects invalid text", ({ input, expected }) => {
+      expect(getInvalidVisualText(input)).toEqual(expected);
+    });
+  });
+});

--- a/assets/tests/components/Dashboard/PaMessageForm/MainForm.test.tsx
+++ b/assets/tests/components/Dashboard/PaMessageForm/MainForm.test.tsx
@@ -10,5 +10,12 @@ describe("MainForm", () => {
     ])("detects invalid text", ({ input, expected }) => {
       expect(getInvalidVisualText(input)).toEqual(expected);
     });
+
+    test.each([{ input: "Green Line B/C/D/E service suspended" }])(
+      "allows valid messages",
+      ({ input }) => {
+        expect(getInvalidVisualText(input)).toEqual(new Set());
+      },
+    );
   });
 });


### PR DESCRIPTION
**Asana task**: [Screenplay: invalid characters in PA messages](https://app.asana.com/1/15492006741476/project/1185117109217422/task/1216523723126553?focus=true)

Description

Add text validation to visual messages sent to signs. The set of allowed
characters is largely borrowed from [Realtime Signs](https://github.com/mbta/realtime_signs/blob/831f805027295590bd5f21c77a9720a8e160e203/lib/pa_ess/utilities.ex#L609)
with the following additions:
* hyphens ('-'), as these were the basis of the original issue where an
endash was added to a message and not processed properly by the hardware
* periods ('.'), to write whole sentences that are visually complete

No validation was added to the text area for predefined templates, as we
assume that the text provided there are correct.

<img width="806" height="426" alt="Screenshot 2026-07-15 at 15 17 21" src="https://github.com/user-attachments/assets/64b98286-da78-491d-ac5a-f9c61d9858fc" />
<img width="806" height="426" alt="Screenshot 2026-07-15 at 15 24 17" src="https://github.com/user-attachments/assets/cd54017f-7ef5-42b1-bbfc-f5e5138b84ca" />

\* For posterity `@ol` is meant to be a dial-up joke, not Orange Line commentary 😆 

- [ ] For features with a design/UX component, deployed branch to dev-green and let product know it's ready for review.
