### PR TITLE
chore: Remove unused alerts_s3_path variable

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -36,7 +36,6 @@ if config_env() != :test do
   sentry_dsn = System.get_env("SENTRY_DSN")
 
   config :screenplay,
-    alerts_s3_path: "screenplay/" <> System.get_env("ALERTS_S3_FILENAME", ""),
     sftp_client_module: sftp_client_module,
     outfront_ssh_key: System.get_env("OUTFRONT_SSH_KEY"),
     outfront_sftp_user: System.get_env("OUTFRONT_SFTP_USER"),


### PR DESCRIPTION
Some cleanup that was missed when we moved to store Emergency Takeover Alerts in Postgres. `alerts_s3_path` is no longer used and has been cleaned up everywhere else.