### PR TITLE
chore: Add dev-blue to Screenplay deployable environments

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -9,6 +9,7 @@ on:
         default: dev
         options:
         - dev
+        - dev-blue
         - dev-green
   push:
     branches: [main]


### PR DESCRIPTION
Screenplay dev-blue infrastructure is now fully configured, so this adds it as an environment that we can deploy to. 