### PR TITLE
chore: add zizmor to the repo

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -3,12 +3,16 @@ on:
   pull_request:
     types: [opened, reopened]
 
+permissions: {}
+
 jobs:
   asana:
-    uses: mbta/workflows/.github/workflows/asana.yml@v5
+    uses: mbta/workflows/.github/workflows/asana.yml@c76e5ccd9556fbea52bc41548f7ceed5985ad775 # v5.1.0
     with:
       attach-pr: true
       trigger-phrase: "\\*\\*Asana task\\*\\*:"
+    permissions:
+      pull-requests: read # Needed to read Asana ticket info from PR description
     secrets:
       asana-token: ${{ secrets.ASANA_SECRET_FOR_INSURIFY_ACTION }}
       github-secret: ${{ secrets.ASANA_GITHUB_INTEGRATION_SECRET }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on: push
 
+permissions: {}
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
@@ -12,16 +14,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       # cache the ASDF directory, using the values from .tool-versions
       - name: ASDF cache
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
         id: asdf-cache
       # only run `asdf install` if we didn't hit the cache
-      - uses: asdf-vm/actions/install@v4
+      - uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
         if: steps.asdf-cache.outputs.cache-hit != 'true'
 
   build:
@@ -34,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     services:
       postgres:
-        image: postgres
+        image: postgres@sha256:d0f363f8366fbc3f52d172c6e76bc27151c3d643b870e1062b4e8bfe65baf609 # v16.3-bookworm
         ports:
           - 5432:5432
         env:
@@ -44,9 +48,11 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     needs: asdf
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: ASDF cache
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
@@ -62,7 +68,7 @@ jobs:
         run: asdf reshim
       - name: Restore dependencies cache
         id: deps-cache
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
@@ -85,7 +91,7 @@ jobs:
 
       # NPM Build + Test
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.x
           cache: "npm"
@@ -95,4 +101,4 @@ jobs:
       - run: npm --prefix assets run check
       - run: npm --prefix assets test
 
-      - uses: mbta/actions/dialyzer@v2.24
+      - uses: mbta/actions/dialyzer@788f8e264e9ebb1b76b927c89e6466d5a162be80 # v2.24

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     services:
       postgres:
-        image: postgres@sha256:d0f363f8366fbc3f52d172c6e76bc27151c3d643b870e1062b4e8bfe65baf609 # v16.3-bookworm
+        image: postgres:v16.3-bookworm@sha256:d0f363f8366fbc3f52d172c6e76bc27151c3d643b870e1062b4e8bfe65baf609
         ports:
           - 5432:5432
         env:

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -13,12 +13,17 @@ on:
   push:
     branches: [main]
 
+permissions: {}
+
 jobs:
   call-workflow:
-    uses: mbta/workflows/.github/workflows/deploy-ecs.yml@v5
+    uses: mbta/workflows/.github/workflows/deploy-ecs.yml@ead2d40fcc0c546bd6f099a6d8fcd9f9950eab03 # v5.0.0
     with:
       app-name: screenplay
       environment: ${{ github.event.inputs.environment || 'dev' }}
+    permissions:
+      contents: read # Needed to check out the repository
+      id-token: write # Needed to authenticate against AWS
     secrets:
       aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
       docker-repo: ${{ secrets.DOCKER_REPO }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,30 @@
+name: GitHub Actions Security Check
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    paths:
+      - '.github/**'
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+        with:
+          advanced-security: false
+          persona: auditor


### PR DESCRIPTION


**Asana task**: [Add Zizmor to screenplay](https://app.asana.com/1/15492006741476/project/1185117109217422/task/1216719907405007)

Description

This commit adds zizmor to the repo. Doing so entails to components:
1. Adding a new workflow to run zizmor when workflow files are edited
2. Updating existing workflows to be compliant with the pedantic persona provided by zizmor

For this repository, the latter consisted of:
1. Pinning actions used. Most actions were up to date already, making this action largely a no-op. Version comment strings have been updated
 to ensure they do not use major version only tags (e.g. `v5`), as these
 can cause issues should the tag move to a new version.
2. Updating permissions so actions use have the least amount of permission when running
3. Justifying permissions via comments
4. Pinning the Postgres image used. The version was selected to match what is deployed to AWS at the time of this writing. 


- [ ] For features with a design/UX component, deployed branch to dev-green and let product know it's ready for review.
